### PR TITLE
chore(deps): bump GHA versions to current majors

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -34,8 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -54,8 +54,8 @@ jobs:
     # pytest) IS required at import time. Install full requirements.txt for
     # parity with the integration test environment.
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Free disk space
         # nlp-service pulls in PyTorch (~800 MB) + ffmpeg/flite. GHA runners
@@ -87,7 +87,7 @@ jobs:
           df -h
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Run integration test
         run: bash scripts/integration-test.sh


### PR DESCRIPTION
## Summary
- Consolidates Dependabot PRs #10, #11, #13, #14 into one PR so the integration-test workflow runs once instead of four times
- Bumps: `actions/checkout` 4→6, `actions/setup-node` 4→6, `actions/setup-python` 5→6, `docker/setup-buildx-action` 3→4

## Audit notes
- All four call sites pin `node-version: '20'` / `python-version: '3.11'` explicitly — v6 default-version shifts don't apply
- `cache-dependency-path` is explicit at both setup-node call sites (lines 27, 42), so v6's auto-detection change doesn't apply
- No v4-only inputs in use (no `ssh-key`, custom `token`, non-default `fetch-depth`, `persist-credentials: false`)

## Test plan
- [ ] unit-tests-app passes on new actions
- [ ] unit-tests-cli passes on new actions
- [ ] unit-tests-nlp passes on new actions
- [ ] integration-test completes end-to-end with new buildx

Supersedes #10, #11, #13, #14 — those will be closed once this lands.