### PR TITLE
chore(cli): bump engines.node to >=20 (prereq for #22)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -17,7 +17,7 @@
     "prepublishOnly": "npm run build"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "dependencies": {
     "commander": "^12.1.0",


### PR DESCRIPTION
## Summary
- Bumps `cli/package.json` `engines.node` from `>=18` to `>=20`
- Prerequisite for Dependabot PR #22 (commander 12->14) — commander v14 requires Node >=20

## Why separate from #22
- Editing `cli/package.json` directly on Dependabot's branch would conflict with its rebase
- One-line engines-field change isolated here so Dependabot can auto-rebase #22 cleanly

## Test plan
- [ ] unit-tests-cli passes (lockfile untouched, just engines metadata)
- [ ] #22 becomes MERGEABLE after this lands