### PR TITLE
chore: bump Node runtime 20 -> 24 LTS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      - dependency-name: "@types/node"
+        versions: [">=25"]
 
   - package-ecosystem: npm
     directory: /mcp-server
@@ -27,6 +30,9 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      - dependency-name: "@types/node"
+        versions: [">=25"]
 
   - package-ecosystem: npm
     directory: /cli
@@ -41,6 +47,9 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      - dependency-name: "@types/node"
+        versions: [">=25"]
 
   - package-ecosystem: pip
     directory: /nlp-service

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: app/package-lock.json
       - run: npm ci
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: cli/package-lock.json
       - run: npm ci

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -19,7 +19,7 @@
 # named 'sqlite3'" when using python3-minimal. Still no pip/venv/setuptools.
 
 # ---- Build stage ----
-FROM node:20-slim AS builder
+FROM node:24-slim AS builder
 
 # python3 + build tools needed by node-gyp to compile better-sqlite3 from
 # source when the prebuild-install binary download fails (e.g. --no-cache builds).
@@ -38,7 +38,7 @@ COPY app/ ./
 RUN npm run build
 
 # ---- Runtime stage ----
-FROM node:20-slim AS runtime
+FROM node:24-slim AS runtime
 
 # Install python3 (full stdlib, includes sqlite3) for migrate.py.
 # --no-install-recommends keeps pip/setuptools/venv out. migrate.py uses

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -21,7 +21,7 @@
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^24.9.2",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@types/uuid": "^10.0.0",
@@ -1039,13 +1039,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/react": {
@@ -3003,9 +3003,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/app/package.json
+++ b/app/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^24.9.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@types/uuid": "^10.0.0",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
-        "@types/node": "^20.0.0",
+        "@types/node": "^24.9.2",
         "@types/prompts": "^2.4.9",
         "jest": "^29.7.0",
         "ts-jest": "^29.4.9",
@@ -27,7 +27,7 @@
         "typescript": "^5.7.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=24"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1815,13 +1815,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/prompts": {
@@ -5466,9 +5466,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/cli/package.json
+++ b/cli/package.json
@@ -17,7 +17,7 @@
     "prepublishOnly": "npm run build"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "dependencies": {
     "commander": "^14.0.3",
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
-    "@types/node": "^20.0.0",
+    "@types/node": "^24.9.2",
     "@types/prompts": "^2.4.9",
     "jest": "^29.7.0",
     "ts-jest": "^29.4.9",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       nlp-service:
         condition: service_healthy
     healthcheck:
-      # node is always present in node:20-slim; wget/curl are not.
+      # node is always present in node:24-slim; wget/curl are not.
       # Checks HTTP status only (not JSON body): exits 0 on HTTP 200, exits 1
       # on non-200, socket error, or 3s timeout. Both status:'ok' and
       # status:'degraded' return HTTP 200 — the container stays healthy while

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -12,7 +12,7 @@
         "zod": "^3.23.0"
       },
       "devDependencies": {
-        "@types/node": "^20.0.0",
+        "@types/node": "^24.9.2",
         "typescript": "^5.5.0"
       }
     },
@@ -69,13 +69,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/accepts": {
@@ -1107,9 +1107,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "typescript": "^5.5.0",
-    "@types/node": "^20.0.0"
+    "@types/node": "^24.9.2"
   },
   "overrides": {
     "hono": "^4.12.14"


### PR DESCRIPTION
## Summary
- Bumps `app/Dockerfile` builder + runtime stages from `node:20-slim` to `node:24-slim`
- Bumps CI matrix (`unit-tests-app`, `unit-tests-cli`) from `node-version: '20'` to `'24'`
- Lifts `@types/node` to `^24.9.2` across `app/`, `cli/`, `mcp-server/` (resolves to 24.12.2)
- Tightens `cli/package.json` engines from `>=20` to `>=24`
- Adds Dependabot ignore rule for `@types/node >=25` in all 3 npm groups so weekly PRs stay on the LTS line (v25 is Current, EOL 2026-06-01)
- Updates docker-compose healthcheck comment

## Why
Node 20 hits EOL **2026-04-30**. Node 24 entered Active LTS on 2025-10-28 and is supported through 2028-04-30.

## Compatibility
- `better-sqlite3@12.9.0` ships Node 24 prebuilds for Debian glibc (verified on npm registry)
- Next.js 16.2.4 minimum is `>=20.9`, no upper bound
- `node:24-slim` aliases `24-bookworm-slim` (same Debian 12 / glibc 2.36 family as `20-slim`) — no native-module rebuild risk
- Source audit: zero usage of `url.parse`, `punycode`, `createCipher`, `process.binding`, or undici stream patterns affected by the v7 bump (the only `fetch` call sites use `await res.json()` once, no streaming)
- GitNexus impact analysis: `openDb` (242 dependents) and `getDb` (18 dependents) are CRITICAL paths but their backing dep is verified Node 24-compatible

## Test plan
- [ ] CI green (unit-tests-app + unit-tests-cli on Node 24)
- [ ] Followup: docker compose build app on Node 24 image, verify better-sqlite3 prebuild loads (no node-gyp fallback)