### PR TITLE
chore(deps): remove unused uuid, override postcss to ^8.5.10

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -16,15 +16,13 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-force-graph-2d": "^1.23.15",
-        "undici": "^7.25.0",
-        "uuid": "^10.0.0"
+        "undici": "^7.25.0"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.0",
         "@types/node": "^24.9.2",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
-        "@types/uuid": "^10.0.0",
         "@vitest/ui": "^4.1.4",
         "typescript": "^5.0.0",
         "vitest": "^4.1.4"
@@ -1067,13 +1065,6 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.4",
@@ -2440,9 +2431,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -2459,9 +2450,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -3015,19 +3006,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/vite": {
       "version": "8.0.8",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
@@ -3104,35 +3082,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/vitest": {

--- a/app/package.json
+++ b/app/package.json
@@ -18,17 +18,18 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-force-graph-2d": "^1.23.15",
-    "undici": "^7.25.0",
-    "uuid": "^10.0.0"
+    "undici": "^7.25.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",
     "@types/node": "^24.9.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "@types/uuid": "^10.0.0",
     "@vitest/ui": "^4.1.4",
     "typescript": "^5.0.0",
     "vitest": "^4.1.4"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
## Summary

Clears Dependabot alerts [#9](https://github.com/tuirk/Kompl/security/dependabot/9) (`uuid` GHSA-w5hq-g745-h8pq) and [#10](https://github.com/tuirk/Kompl/security/dependabot/10) (`postcss<8.5.10` stringify XSS). Reachability was zero on both: the `uuid` npm package had no JS/TS imports anywhere (all UUIDs come from `crypto.randomUUID`); `postcss` only runs at build time on our own `globals.css` with no user-CSS surface. Fix is hygiene, not response.

## Edits

- **`app/package.json`** — remove `uuid` (dead dep), remove `@types/uuid` (orphaned), add `overrides` block forcing `postcss ^8.5.10`. Override pattern matches existing precedent at [mcp-server/package.json:18](https://github.com/tuirk/Kompl/blob/main/mcp-server/package.json#L18).
- **`app/package-lock.json`** — refreshed via plain `npm install` (no `--package-lock-only` this time, lets `node_modules` reconcile).

## Lockfile delta — two layers

**Intended (this PR's actual security fix):**
- `postcss` 8.4.31 → 8.5.10 everywhere (override forces all nested copies)
- `uuid` entry removed
- `@types/uuid` entry removed

**Drift carryover (leftover from 727428f's `--package-lock-only` install, would happen on any `npm install` regardless of this PR):**
- `@types/node` 20 → 24 (types only — `app/package.json` already declared `^24.9.2`)
- `undici-types` 6 → 7 (transitive of @types/node, types only)
- `better-sqlite3` 12.8 → 12.9 (minor — native rebuild required, API stable)
- `next` 16.2.3 → 16.2.4 (patch)
- 59 platform binaries added (cross-platform install enablers)

## Reachability evidence (zero on both)

- `rg -tjs -tts -tmjs "(['\"]uuid(/v[0-9])?['\"]|require\(\s*['\"]uuid|import\(\s*['\"]uuid)" app/ cli/ mcp-server/ scripts/` → zero matches (covers static, dynamic, subpath, type-only).
- `n8n/workflows/**/*.json` Code-node strings → zero `uuid` references.
- `nlp-service/` is Python-only (Python `import uuid` is stdlib, unrelated).
- No `postcss.config.*`, no `tailwind.config.*`, no user-CSS API endpoints.
- `vitest`'s `vite` already shipped `postcss@8.5.10` in this exact dep tree — proves 8.5.10 works fine here transitively.

## Local verification

- `npm install` → `added 59 packages, removed 3, changed 7. found 0 vulnerabilities`
- `npm ls postcss` → every entry `8.5.10`, no `8.4.31` lines
- `npm ls uuid @types/uuid` → both empty
- `npm run build` → green, full route table generated
- `npm run test` → 286/286 passing

## Test plan
- [x] Local `npm install` clean
- [x] Local `npm run build` passes
- [x] Local `npm run test` 286/286
- [ ] CI `unit-tests-app` green
- [ ] CI `unit-tests-cli` green
- [ ] CI `unit-tests-nlp` green
- [ ] CI `integration-test` green (Docker Next.js standalone bundle — surfaces any postcss-bump regression)
- [ ] Post-merge: `gh api /repos/tuirk/Kompl/dependabot/alerts/9 --jq .state` → `fixed`
- [ ] Post-merge: `gh api /repos/tuirk/Kompl/dependabot/alerts/10 --jq .state` → `fixed`

If Dependabot auto-close stalls past 1 hour, manual fallback procedure is documented in [the plan](https://github.com/tuirk/Kompl/blob/main/.claude/plans) (V7.1 — `gh api PATCH ... dismissed_reason='tolerable_risk'`).

Co-authored-by: tuirk <65666288+tuirk@users.noreply.github.com>
Co-authored-by: ahjinsolo <270563675+ahjinsolo@users.noreply.github.com>