### PR TITLE
fix(resolve): drop substring from cross-session anchor

### DIFF
--- a/nlp-service/routers/resolution.py
+++ b/nlp-service/routers/resolution.py
@@ -165,7 +165,13 @@ def _is_acronym(short: str, long: str) -> bool:
 
 
 def _fuzzy_method(a: str, b: str) -> str | None:
-    """Return the best matching method name if a and b should be merged, else None."""
+    """Return the best matching method name if a and b should be merged, else None.
+
+    Used for SAME-SESSION pairwise grouping where the inputs are sibling
+    extractions from the same source pool — substring/acronym signals are
+    soft-priors there ("Karpathy" + "A. Karpathy" in one article pool are
+    almost certainly the same person).
+    """
     al, bl = a.lower(), b.lower()
 
     # Exact
@@ -189,6 +195,42 @@ def _fuzzy_method(a: str, b: str) -> str | None:
             return "substring"
 
     # Acronym
+    if _is_acronym(a, b) or _is_acronym(b, a):
+        return "acronym"
+
+    return None
+
+
+def _cross_session_method(a: str, b: str) -> str | None:
+    """Stricter variant of _fuzzy_method for cross-session anchoring against
+    existing wiki page titles.
+
+    Drops the substring branch. Substring matching is a fine soft-prior for
+    same-session pairs but over-merges when one side is an authoritative,
+    permanent wiki page title — e.g. extracting "Vilnius" from a new source
+    must NOT bind to an existing "Vilnius Cathedral" page just because one
+    is a character-level substring of the other. The same shape hits cities
+    vs landmarks (London ↔ London Eye), parents vs subsidiaries, brands vs
+    product lines.
+
+    Layer 2 embedding similarity handles the legitimate cross-session cases
+    (e.g. "Andrej Karpathy" ↔ existing "Karpathy" page) semantically,
+    sending borderline pairs to Layer 3 LLM disambiguation.
+    """
+    al, bl = a.lower(), b.lower()
+
+    if al == bl:
+        return "exact"
+
+    if len(a) >= 4 and len(b) >= 4:
+        from rapidfuzz.distance import Levenshtein
+        if Levenshtein.distance(al, bl) <= 2:
+            return "levenshtein"
+
+    from rapidfuzz.distance import JaroWinkler
+    if JaroWinkler.similarity(al, bl) >= 0.92:
+        return "jaro_winkler"
+
     if _is_acronym(a, b) or _is_acronym(b, a):
         return "acronym"
 
@@ -269,11 +311,15 @@ def resolve_fuzzy(req: FuzzyResolveRequest) -> FuzzyResolveResponse:
             alias_canonical[i] = pt_exact.title
             alias_method[i] = "existing_page_title"
             continue
-        # Fuzzy match against any page title
+        # Fuzzy match against any page title — uses the strict cross-session
+        # matcher (no substring) to avoid binding short-name entities to
+        # longer-name pages they happen to be a character-level prefix of
+        # (e.g. "Vilnius" ↔ existing "Vilnius Cathedral"). Layer 2 embedding
+        # handles those semantically.
         for pt in req.existing_page_titles:
             if not _entity_matches_page_type(e.type, pt.page_type):
                 continue
-            if _fuzzy_method(e.name, pt.title):
+            if _cross_session_method(e.name, pt.title):
                 alias_canonical[i] = pt.title
                 alias_method[i] = "existing_page_title"
                 break

--- a/nlp-service/tests/test_resolution.py
+++ b/nlp-service/tests/test_resolution.py
@@ -156,6 +156,56 @@ class TestFuzzyExistingPageTitles:
         resp = resolution_client.post("/resolve/fuzzy", json=body)
         assert resp.status_code == 200
 
+    def test_substring_does_not_bind_short_entity_to_long_page_title(self, resolution_client):
+        """Regression: a short-name entity must NOT bind to a longer page title
+        just because one is a character-level substring of the other.
+
+        Cities and landmarks within them ("Vilnius" ↔ "Vilnius Cathedral"),
+        parents and subsidiaries, brands and product lines all share this
+        shape. Same-session substring matching is fine, but cross-session
+        anchoring against authoritative wiki page titles must be stricter.
+
+        Expected: entity falls through to unresolved so Layer 2 embedding can
+        evaluate semantic similarity.
+        """
+        body = {
+            "entities": [
+                {"name": "Vilnius", "type": "LOCATION", "source_id": "src1", "context": ""}
+            ],
+            "existing_aliases": [],
+            "existing_page_titles": [
+                {"title": "Vilnius Cathedral", "page_type": "entity"}
+            ],
+        }
+        resp = resolution_client.post("/resolve/fuzzy", json=body)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["resolved"] == []
+        assert len(data["unresolved"]) == 1
+        assert data["unresolved"][0]["name"] == "Vilnius"
+
+    def test_substring_does_not_bind_long_entity_to_short_page_title(self, resolution_client):
+        """Symmetric to above: extracting 'Catan Junior' must not bind to an
+        existing 'Catan' page via reverse substring. The substring branch
+        triggers on either direction (al in bl OR bl in al), so the strict
+        cross-session matcher must reject both.
+        """
+        body = {
+            "entities": [
+                {"name": "Catan Junior", "type": "PRODUCT", "source_id": "src1", "context": ""}
+            ],
+            "existing_aliases": [],
+            "existing_page_titles": [
+                {"title": "Catan", "page_type": "entity"}
+            ],
+        }
+        resp = resolution_client.post("/resolve/fuzzy", json=body)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["resolved"] == []
+        assert len(data["unresolved"]) == 1
+        assert data["unresolved"][0]["name"] == "Catan Junior"
+
 
 # ---------------------------------------------------------------------------
 # /resolve/embedding — anchor + ambiguous cross-session pairs


### PR DESCRIPTION
## Summary
- Adds `_cross_session_method` — strict variant of `_fuzzy_method` for the Layer-1 cross-session anchor that drops the substring branch (keeps exact, levenshtein, jaro-winkler, acronym).
- Fixes a regression introduced in `af83675` (corpus-wide canonicalisation): "Vilnius" deterministically aliased to existing "Vilnius Cathedral" page because one is a character-level substring of the other. Same shape would hit any city ↔ landmark, parent ↔ subsidiary, brand ↔ product line.
- Adds 2 regression tests (forward + reverse substring direction).

## Why substring is wrong cross-session
Same-session: substring-matching two raw strings extracted from the same source pool is a fine soft-prior (e.g. "Karpathy" + "A. Karpathy" almost certainly the same person). Cross-session: the page-title side is authoritative and permanent — a wrong merge writes a permanent alias row and reroutes every future mention. Substring is too dumb for that job.

The legitimate cross-session merges this would have caught (e.g. "Andrej Karpathy" ↔ existing "Karpathy") are handled by Layer 2 embedding, with Layer 3 LLM in the 0.7–0.9 ambiguous band.

## Test plan
- [x] `pytest tests/test_resolution.py` — 16/16 pass (2 new regression tests + 14 pre-existing)
- [x] `pytest tests/` (full nlp-service suite) — 66/66 pass
- [x] No TS-side changes required (the substring decision is pure-Python; TS tests cover plan-rule + alias-backfill consumption only)
- [x] `_fuzzy_method` (same-session pairwise grouping) untouched

## Out of scope (deferred)
The Jaro-Winkler branch can also produce borderline merges in the same shape ("London Eye" vs existing "London" computes JW ≈ 0.92, right at the threshold). Not addressed here — kept the diff scoped to the actual reported regression. Documented in `docs/Tui-read.me` (gitignored notes) for follow-up if real ingest data ever surfaces it.