### PR TITLE
feat(llm): multi-provider abstraction + DeepSeek backend (Phases 1-5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,16 @@ GEMINI_RPM=800
 GEMINI_INPUT_TOKEN_CAP=128000
 GEMINI_DAILY_USD_CAP=5.00
 
+# DeepSeek V4 Pro as a second selectable backend (Phase 4 multi-provider).
+# Get key at: https://api-docs.deepseek.com
+# Default DEEPSEEK_RPM=60 matches DeepSeek's documented per-minute cap.
+# Discount window: 75% off through 2026-05-31T15:59:00Z UTC; the provider
+# auto-flips to list pricing after the deadline. Override via
+# DEEPSEEK_INPUT_USD_PER_M / OUTPUT / CACHE if you need to pin pricing
+# manually (e.g. after the discount window or for non-UTC deployments).
+DEEPSEEK_API_KEY=
+DEEPSEEK_RPM=60
+
 # ---- Ingestion (live in commit 3) ----
 
 # Firecrawl v2 API key — https://docs.firecrawl.dev/

--- a/app/src/app/api/health/route.ts
+++ b/app/src/app/api/health/route.ts
@@ -76,6 +76,12 @@ export async function GET() {
         vector_backlog: vectorBacklog,
         stale_sessions_fixed: staleSessionsFixed,
         stuck_queued_fixed: stuckQueuedFixed,
+        // Phase 5 multi-provider: presence-only flags consumed by the
+        // Settings UI to gate the model dropdown. No outbound key probe.
+        provider_keys: {
+          gemini_present: !!process.env.GEMINI_API_KEY,
+          deepseek_present: !!process.env.DEEPSEEK_API_KEY,
+        },
       },
       // Return 200 for both 'ok' and 'degraded' so Docker healthcheck only
       // fails on hard errors. The app is usable in degraded state.

--- a/app/src/app/api/settings/route.ts
+++ b/app/src/app/api/settings/route.ts
@@ -225,7 +225,7 @@ export async function POST(request: Request) {
   if (body.chat_model !== undefined) {
     if (!isChatModel(body.chat_model)) {
       return NextResponse.json(
-        { error: 'chat_model must be one of: gemini-2.5-flash-lite, gemini-2.5-flash, gemini-2.5-pro' },
+        { error: 'chat_model must be one of: gemini-2.5-flash-lite, gemini-2.5-flash, gemini-2.5-pro, deepseek-v4-pro' },
         { status: 422 },
       );
     }
@@ -235,7 +235,7 @@ export async function POST(request: Request) {
   if (body.compile_model !== undefined) {
     if (!isChatModel(body.compile_model)) {
       return NextResponse.json(
-        { error: 'compile_model must be one of: gemini-2.5-flash-lite, gemini-2.5-flash, gemini-2.5-pro' },
+        { error: 'compile_model must be one of: gemini-2.5-flash-lite, gemini-2.5-flash, gemini-2.5-pro, deepseek-v4-pro' },
         { status: 422 },
       );
     }

--- a/app/src/app/settings/page.tsx
+++ b/app/src/app/settings/page.tsx
@@ -84,6 +84,14 @@ export default function SettingsPage() {
   const [compileModelSaving, setCompileModelSaving] = useState(false);
   const [compileModelSaved, setCompileModelSaved] = useState(false);
 
+  // Phase 5/6 multi-provider: presence-only flags from /api/health gate the
+  // dropdown options. null = still loading; never throw on a fetch failure
+  // (operator on a broken health endpoint should still see Gemini default).
+  const [providerKeys, setProviderKeys] = useState<{
+    gemini_present: boolean;
+    deepseek_present: boolean;
+  } | null>(null);
+
   // Thinking budgets — per-LLM-call-site reasoning token allowance.
   // Source of truth lives in /data/llm-config.json (mirrored from settings
   // table); nlp-service reads the JSON on each Gemini call. -1 = unlimited,
@@ -210,6 +218,24 @@ export default function SettingsPage() {
         setCompileModelState(data.compile_model);
         setThinkingBudgets(data.thinking_budgets);
         setThinkingBudgetsDraft(data.thinking_budgets);
+      });
+  }, []);
+
+  // Phase 5/6 multi-provider: fetch the provider-key presence flags so the
+  // model dropdowns can disable options whose backend isn't configured.
+  // /api/health returns lots of fields; we only read provider_keys here.
+  useEffect(() => {
+    void fetch('/api/health')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: { provider_keys?: { gemini_present: boolean; deepseek_present: boolean } } | null) => {
+        if (data?.provider_keys) {
+          setProviderKeys(data.provider_keys);
+        }
+      })
+      .catch(() => {
+        // Non-fatal: dropdowns fall back to "all enabled" while
+        // providerKeys stays null. The POST validator at /api/settings
+        // is the back-stop on actually-invalid selections.
       });
   }, []);
 
@@ -991,7 +1017,7 @@ export default function SettingsPage() {
           >
             <div style={{ flex: 1 }}>
               <div style={{ fontWeight: 600, fontSize: '0.95rem', marginBottom: '0.35rem', display: 'flex', alignItems: 'center', gap: 8 }}>
-                Daily Gemini spend cap
+                Daily LLM spend cap
                 <span
                   style={{
                     padding: '1px 6px',
@@ -1009,13 +1035,16 @@ export default function SettingsPage() {
                 </span>
               </div>
               <div style={{ fontSize: '0.85rem', color: 'var(--fg-muted)', lineHeight: 1.5 }}>
-                Hard USD ceiling on Gemini API spend per UTC day. When exceeded, LLM calls raise a cost-ceiling error and the pipeline marks affected work as retryable. Resets at midnight UTC.
+                Hard USD ceiling on combined LLM API spend per UTC day (Gemini + DeepSeek share
+                this cap). When exceeded, LLM calls raise a cost-ceiling error and the pipeline
+                marks affected work as retryable. Resets at midnight UTC.
                 Set to <strong>0</strong> for unlimited (no cap).
-                {' '}The tracked number comes from each Gemini call&apos;s <code>usage_metadata</code>
-                (input + cached + output + thinking tokens, multiplied by the model&apos;s published
-                per-million-token price). It&apos;s an <strong>estimate</strong> — real invoice
-                totals may differ by a few percent due to token-count rounding, cached-content
-                discounts, and any price drift between Gemini&apos;s schedule and our constants.
+                {' '}The tracked number comes from each provider&apos;s usage metadata
+                (input + cached + output + thinking tokens, multiplied by the model&apos;s
+                published per-million-token price). It&apos;s an <strong>estimate</strong> —
+                real invoice totals may differ by a few percent due to token-count rounding,
+                cached-content discounts, and any price drift between the provider&apos;s
+                schedule and our constants.
               </div>
             </div>
             <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexShrink: 0 }}>
@@ -1081,7 +1110,7 @@ export default function SettingsPage() {
                 Compile model
               </div>
               <div style={{ fontSize: '0.85rem', color: 'var(--fg-muted)', lineHeight: 1.5 }}>
-                Which Gemini model the <strong>compile pipeline</strong> uses for every LLM step
+                Which model the <strong>compile pipeline</strong> uses for every LLM step
                 (extract, resolve, draft, crossref, schema). Flash (default) balances cost and
                 quality; Flash Lite is cheapest; Pro is most capable but most expensive.
                 Compile spend is typically <strong>10-100× higher than chat</strong> because the
@@ -1106,9 +1135,38 @@ export default function SettingsPage() {
                   opacity: compileModel === null ? 0.5 : 1,
                 }}
               >
-                <option value="gemini-2.5-flash-lite">Flash Lite</option>
-                <option value="gemini-2.5-flash">Flash (default)</option>
-                <option value="gemini-2.5-pro">Pro</option>
+                <optgroup label="Gemini">
+                  <option
+                    value="gemini-2.5-flash-lite"
+                    disabled={providerKeys ? !providerKeys.gemini_present : false}
+                    title={providerKeys && !providerKeys.gemini_present
+                      ? 'Set GEMINI_API_KEY in your environment to enable'
+                      : undefined}
+                  >Flash Lite</option>
+                  <option
+                    value="gemini-2.5-flash"
+                    disabled={providerKeys ? !providerKeys.gemini_present : false}
+                    title={providerKeys && !providerKeys.gemini_present
+                      ? 'Set GEMINI_API_KEY in your environment to enable'
+                      : undefined}
+                  >Flash (default)</option>
+                  <option
+                    value="gemini-2.5-pro"
+                    disabled={providerKeys ? !providerKeys.gemini_present : false}
+                    title={providerKeys && !providerKeys.gemini_present
+                      ? 'Set GEMINI_API_KEY in your environment to enable'
+                      : undefined}
+                  >Pro</option>
+                </optgroup>
+                <optgroup label="DeepSeek">
+                  <option
+                    value="deepseek-v4-pro"
+                    disabled={providerKeys ? !providerKeys.deepseek_present : false}
+                    title={providerKeys && !providerKeys.deepseek_present
+                      ? 'Set DEEPSEEK_API_KEY in your environment to enable'
+                      : undefined}
+                  >V4 Pro</option>
+                </optgroup>
               </select>
             </div>
           </div>
@@ -1150,7 +1208,7 @@ export default function SettingsPage() {
                 Chat model
               </div>
               <div style={{ fontSize: '0.85rem', color: 'var(--fg-muted)', lineHeight: 1.5 }}>
-                Which Gemini model the <strong>Chat</strong> page uses to synthesise answers.
+                Which model the <strong>Chat</strong> page uses to synthesise answers.
                 Flash Lite is cheapest and a good default; Pro is the most capable but the most
                 expensive. Changes apply to <strong>new chats only</strong> — conversations
                 already in progress keep the model they started with.
@@ -1171,9 +1229,38 @@ export default function SettingsPage() {
                   opacity: chatModel === null ? 0.5 : 1,
                 }}
               >
-                <option value="gemini-2.5-flash-lite">Flash Lite (default)</option>
-                <option value="gemini-2.5-flash">Flash</option>
-                <option value="gemini-2.5-pro">Pro</option>
+                <optgroup label="Gemini">
+                  <option
+                    value="gemini-2.5-flash-lite"
+                    disabled={providerKeys ? !providerKeys.gemini_present : false}
+                    title={providerKeys && !providerKeys.gemini_present
+                      ? 'Set GEMINI_API_KEY in your environment to enable'
+                      : undefined}
+                  >Flash Lite (default)</option>
+                  <option
+                    value="gemini-2.5-flash"
+                    disabled={providerKeys ? !providerKeys.gemini_present : false}
+                    title={providerKeys && !providerKeys.gemini_present
+                      ? 'Set GEMINI_API_KEY in your environment to enable'
+                      : undefined}
+                  >Flash</option>
+                  <option
+                    value="gemini-2.5-pro"
+                    disabled={providerKeys ? !providerKeys.gemini_present : false}
+                    title={providerKeys && !providerKeys.gemini_present
+                      ? 'Set GEMINI_API_KEY in your environment to enable'
+                      : undefined}
+                  >Pro</option>
+                </optgroup>
+                <optgroup label="DeepSeek">
+                  <option
+                    value="deepseek-v4-pro"
+                    disabled={providerKeys ? !providerKeys.deepseek_present : false}
+                    title={providerKeys && !providerKeys.deepseek_present
+                      ? 'Set DEEPSEEK_API_KEY in your environment to enable'
+                      : undefined}
+                  >V4 Pro</option>
+                </optgroup>
               </select>
             </div>
           </div>

--- a/app/src/lib/db.ts
+++ b/app/src/lib/db.ts
@@ -2531,12 +2531,21 @@ export const CHAT_MODELS = [
   'gemini-2.5-flash-lite',
   'gemini-2.5-flash',
   'gemini-2.5-pro',
+  'deepseek-v4-pro',
 ] as const;
 export type ChatModel = typeof CHAT_MODELS[number];
 export const DEFAULT_CHAT_MODEL: ChatModel = 'gemini-2.5-flash-lite';
 
 export function isChatModel(v: unknown): v is ChatModel {
   return typeof v === 'string' && (CHAT_MODELS as readonly string[]).includes(v);
+}
+
+// Phase 4 multi-provider: prefix dispatch matches the nlp-service factory at
+// nlp-service/services/providers/__init__.py. Settings UI uses this to drive
+// per-provider <optgroup> placement in the dropdowns.
+export function getProviderForModel(m: string): 'gemini' | 'deepseek' {
+  if (m.startsWith('deepseek-')) return 'deepseek';
+  return 'gemini';
 }
 
 export function getChatModel(): ChatModel {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       # calls — the downstream work runs inside nlp-service, which has its
       # own copies above. Presence-only check, no SDK import.
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
       FIRECRAWL_API_KEY: ${FIRECRAWL_API_KEY:-}
     volumes:
       - kompl-data:/data
@@ -78,6 +79,12 @@ services:
       PYTHONUNBUFFERED: "1"
       # Commit 4: LLM compile. google-genai SDK reads GEMINI_API_KEY.
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      # Phase 4 multi-provider: DeepSeek V4 Pro as a second selectable backend
+      # behind the LLMProvider abstraction. Operators set this to opt in;
+      # absence is fine — the factory only wires DeepSeek when the model
+      # prefix selects it (gemini-* sessions never read this var).
+      DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
+      DEEPSEEK_RPM: ${DEEPSEEK_RPM:-60}
       # Rate limiter: 800 RPM = 80% of tier-1 cap (1000 RPM). Set lower if on free tier.
       GEMINI_RPM: ${GEMINI_RPM:-800}
       # Input truncation: 128,000 chars ≈ 32,000 tokens (1 token/4 chars).

--- a/docs/plans/2026-05-05-deepseek-second-llm-provider.md
+++ b/docs/plans/2026-05-05-deepseek-second-llm-provider.md
@@ -1,0 +1,1457 @@
+# Kompl v2 Multi-Provider LLM (Phase 1) — DeepSeek V4 Pro as second backend behind Settings dropdown
+
+**Date:** 2026-05-05
+**Status:** Active. Supersedes the streaming-detector mitigation plan (`~/.claude/plans/plan-the-streaming-detector-ancient-candle.md`, **never executed**, dropped after Stage C live-precision validation failed — issue #7). No prior commits to reference. Old draft lives outside the repo's `docs/plans/` and does not need deletion.
+**Branch:** `feat/multi-provider-llm`
+
+---
+
+## North Star
+
+Add DeepSeek V4 Pro as a second, operator-selectable LLM provider behind a Settings dropdown — Gemini stays the default, every existing extraction/lint/disambiguate/draft/synthesize/digest call site routes through a `LLMProvider` abstraction whose model→provider dispatch is locked in for an Anthropic Phase 2.
+
+**Scope (in):** `nlp-service/services/providers/` (new package); refactor of `nlp-service/services/llm_client.py` from monolithic Gemini client to dispatcher; 7 system-prompt `"json"` trailers; conversion of 8 schema-bound call sites to `messages=[system, user]` shape; Settings UI dropdown expansion gated by `/api/health` provider-key flags; `docker-compose.yml` env wiring; `nlp-service/test_corpus/` end-to-end re-validation.
+
+**Scope (out, hard):**
+- Anthropic backend (Phase 2 — separate plan after this ships clean for ≥1 week)
+- Streaming on either provider (Stage C precision validation failed — does not return without a different approach; the deleted repetition-detector code stays deleted)
+- Halved-input fallback for DeepSeek (Gemini-bug-specific rationale doesn't apply)
+- Provider-specific prompt overlays beyond the minimum (`"json"` trailer + inlined JSON-format hint only; one shared core prompt)
+- Migrating non-LLM call sites
+- Onboarding-flow strictness changes (key probing limited to `/api/health`)
+- Schema migration (`compile_model`/`chat_model` columns already accept any string)
+- Renaming the `GEMINI_*` env vars to `LLM_*` — operator-facing breaking change, deferred
+
+**Operating constraints:**
+- Single-writer SQLite rule (CLAUDE.md #1) — no DB access in providers, only HTTP through Next.js
+- Strict service boundaries (CLAUDE.md #2) — Pydantic `extra='forbid'` on FastAPI surfaces, no bare `dict`, no `||` fallbacks
+- LLM-per-item expansion loops keep their hard iteration cap + feature flag (CLAUDE.md #7) — not relaxed for DeepSeek
+- Single-key constraint per operator: dropdown is "operator picks one provider per session," not a fallback chain
+- Per-session model lock (CLAUDE.md gotcha) — mid-session Settings changes never hot-swap; cancel + restart to switch
+- Daily LLM spend cap is dollar-denominated and shared across providers (the existing `/data/llm-cap.json`)
+- DeepSeek RPM defaults conservatively to 60 (their documented per-minute cap); each provider owns its own pyrate-limiter bucket
+- DeepSeek discount window: prices are 75% off through 2026-05-31T15:59:00Z; after that the code path takes list pricing automatically — no manual edit at deadline
+
+---
+
+## Execution drill for every phase
+
+1. **Spec first:** write `docs/plans/phase_X_spec.md` before implementation (`phase_X_Y_spec.md` for sub-phases). Spec covers scope, data contracts, public API/tool/config changes, success criteria, out-of-scope items, safety constraints, test strategy.
+2. **Tests first:** write failing tests, fixtures, or harness assertions against the spec before implementation. No implementation without a red test. For eval-only work, the red test is the fixture/harness expectation that proves the missing behavior.
+3. **Implement:** smallest code/docs/config changes that make the tests pass. No scope creep. Helper work ships inside the phase that needs it, not as a detached cleanup track.
+4. **Spec alignment review:** diff implementation against the phase spec, this plan, ROADMAP, eval docs, test-site docs, tool schemas, config docs, and touched skill/prompt contracts. Update docs or record explicit drift.
+5. **Code quality review:** naming, dead code, abstractions, error boundaries, type coverage, lint/format, logging/observability, can-it-fail-safely.
+6. **Final code review:** integration/eval checks green, no TODOs remain, docs updated, `gitnexus_detect_changes` reviewed, ready-to-merge recorded.
+
+---
+
+## What's already done — do not redo
+
+| Capability | Source / Commit |
+|---|---|
+| Streaming code paths cleanup (no live streamer remains) | confirmed by inspection on `feat/multi-provider-llm` HEAD |
+| Preserved validation corpus for side-by-side runs | `nlp-service/test_corpus/` — 7 sources + manifest |
+| Per-session model lock infrastructure | `app/src/lib/db.ts:1447` `getEffectiveCompileModel()`; `compile_progress.compile_model` column already accepts arbitrary string (migration v20) |
+| `_salvage_extraction` is provider-agnostic and stays at the dispatch layer | `nlp-service/services/llm_client.py:446` |
+| `httpx` already pinned in nlp-service (no new pip dependency for DeepSeek HTTP client) | `nlp-service/requirements.txt:6` `httpx==0.28.1` |
+| Empirical 28-call spike validates DeepSeek V4 Pro on our exact prompt shape | 28/28 ok, 0 parse failures, 0 salvage attempts, including 95K-char Open Standards source — see plan Context |
+
+---
+
+## Context — multi-provider LLM
+
+### Decision rationale — why DeepSeek V4 Pro and not the alternatives
+
+| Option | Verdict | Reason |
+|---|---|---|
+| **DeepSeek V4 Pro (`deepseek-v4-pro`)** | **Default pick for second provider** | Empirical 28-call spike at `max_tokens=16000` on our exact prompt shape: 28/28 ok, 0 parse failures, 0 salvage attempts. Cleanly extracts the 95K-char Open Standards source that Gemini cannot. OpenAI-compatible HTTP API → `httpx` already pinned, no new dep. Discount window 75% off through 2026-05-31T15:59:00Z, list still cheaper than Gemini Flash on equivalent calls. |
+| Gemini 3.x family | Stay on 2.5 default; do not promote 3.x as alternative | Same upstream sampler-bug pathology that breaks 2.5 Flash on `temperature=0.0` + `response_schema=PydanticClass` now also reproduces on 3.x in our internal repro. New provider, not new Gemini SKU, is the answer. |
+| Streaming-detector mitigation (prior plan) | Rejected | Stage C live precision validation failed: legitimate JSON enumerations (`mentions: ["Vilnius", ...]`, `entities: [{"name":"…"}, ...]`) are indistinguishable from sampler loops at the detector's level — two intrinsic FP modes that re-tuning cannot eliminate. Gemini's streaming endpoint has its own truncation bug too (Vilnius source: 3K tokens non-streamed → 1.5K streamed, same prompt). Two stacking upstream bugs. |
+| Anthropic (Claude family) | Deferred to Phase 2 | Out of scope for this plan. The `gemini-*` / `deepseek-*` model-prefix dispatch in `providers/__init__.py` is pre-committed to `anthropic-*`, so Phase 2 adds one provider class + one `__init__.py` factory entry + one `CHAT_MODELS` row + one optgroup. No structural rework. |
+| `openai` Python SDK as DeepSeek client | Avoid | Adds a new pip dependency for a small call surface we can hit directly via the already-pinned `httpx`. The conversion service already proves `httpx` is sufficient. |
+| Floating DeepSeek model aliases (`deepseek-chat`, `deepseek-reasoner`) | Avoid in dropdown | The thinking-on/off split is already driven by per-call-site `thinking_budgets` in `/data/llm-config.json` (default values at `app/src/lib/db.ts:2589-2600`); exposing two pseudo-models would split cost/quality reasoning across two knobs that mean the same thing. Single explicit pin `deepseek-v4-pro` only. |
+
+### Quirks that bite when adding DeepSeek as a second provider
+
+| # | Trap | File:line where it bites | Fix in phase |
+|---|---|---|---|
+| 1 | DeepSeek `response_format={"type":"json_object"}` requires the literal word `"json"` somewhere in the prompt — silently degrades to free-form text otherwise | 7 system prompts in `nlp-service/services/llm_client.py` (`:490, :634, :864, :882, :1269, :1519, :1616`) | Phase 1 |
+| 2 | DeepSeek's `reasoning_effort` field is an enum `{disabled, low, medium, high, max}`, not the integer `thinking_budget` Gemini expects. Same ask, different shape. | new `nlp-service/services/providers/__init__.py` `translate_thinking_budget()` | Phase 4 |
+| 3 | Gemini's `usage_metadata` field names (`prompt_token_count`, `candidates_token_count`, `cached_content_token_count`, `thoughts_token_count`) are NOT what DeepSeek returns (`prompt_tokens`, `completion_tokens`, `prompt_cache_hit_tokens`). Wrong field names silently zero out cost. | `_record_usage` at `nlp-service/services/llm_client.py:297` (Gemini-specific) and new equivalent in `providers/deepseek.py` | Phase 2 + Phase 4 |
+| 4 | Many call sites today concatenate system+user into one prompt string instead of using `messages=[system, user]`, e.g. `nlp-service/services/llm_client.py:537, :702, :1559`. Both providers cache better with `messages` shape; DeepSeek handles JSON-mode reliably only with explicit roles. | All 8 schema-bound call sites in `nlp-service/services/llm_client.py` | Phase 3 |
+| 5 | `docker-compose.yml` only substitutes `.env` into `environment:` blocks that explicitly name the var — adding `process.env.DEEPSEEK_API_KEY` reads in Node code without an `app.environment:` entry results in `undefined` at runtime, not a crash | `docker-compose.yml` `app.environment` (~line 45) AND `nlp-service.environment` (~line 80); regression-guarded by `scripts/integration-test.sh` Stage 1 env loop | Phase 5 |
+| 6 | DeepSeek's documented per-minute cap is 60 RPM — ours-default `_GEMINI_RPM=800` would 13× burst over DeepSeek's bucket. Each provider must own its own rate limiter. | new `providers/deepseek.py` (`DEEPSEEK_RPM` env, default 60) | Phase 4 |
+| 7 | Existing `_salvage_extraction` at `nlp-service/services/llm_client.py:446` works on raw JSON text — already provider-agnostic. Do not duplicate it inside providers, do not move it. | `nlp-service/services/llm_client.py:446` (keep) | Phase 2 (verify it stays at dispatcher layer) |
+| 8 | Per-session lock: a session locked to `deepseek-v4-pro` will hard-fail mid-run if operator removes `DEEPSEEK_API_KEY`; lifespan check is per-process, not per-call. Documented operator-facing footgun. | `app/src/lib/db.ts:1447` `getEffectiveCompileModel()` resolves the lock | Phase 6 (UI tooltip) |
+| 9 | `_DEFAULT_MODEL = "gemini-2.5-flash"` at `nlp-service/services/llm_client.py:121` is the safety-net default when a call site forgets to pass `model`. Real call sites all pass it from the per-session lock; do not casually rename it (it is the historical hardcode). | `nlp-service/services/llm_client.py:121` | not touched |
+| 10 | `_thinking_cache` at `nlp-service/services/llm_client.py:183` is 30s; a newly-set provider key takes up to 30s to be picked up via `/data/llm-config.json` reads | `nlp-service/services/llm_client.py:183` | not touched (acceptable per CLAUDE.md gotcha pattern) |
+| 11 | Gemini system_instruction parameter is already used at `:1333` and `:1487`. Six other schema-bound call sites still concatenate. Do not assume system_instruction works — verify per-call-site. | `nlp-service/services/llm_client.py` all 8 schema-bound sites | Phase 3 |
+| 12 | DeepSeek discount window expires at a hardcoded UTC instant; a wall-clock comparison in `deepseek.py` flips to list pricing automatically — but only if the container clock is UTC. Docker containers default to UTC; verify at deploy. | new `providers/deepseek.py` `DISCOUNT_UNTIL` constant | Phase 4 |
+
+### File-touch matrix
+
+| File | Change | Phase | Why |
+|---|---|---|---|
+| `nlp-service/services/llm_client.py:490, :634, :864, :882, :1269, :1519, :1616` | Append `"json"` trailer to 7 system prompts | Phase 1 | DeepSeek json_object mode requires the keyword; Gemini ignores it |
+| `nlp-service/services/providers/__init__.py` (NEW) | `get_provider(model)` factory; `translate_thinking_budget()` helper | Phase 2 | Single source of truth for model→provider dispatch and the thinking-budget shape difference |
+| `nlp-service/services/providers/base.py` (NEW) | `LLMProvider` Protocol; `LLMRequest`/`LLMResult` dataclasses; `ProviderError` hierarchy | Phase 2 | Normalised return shape so dispatch layer is provider-agnostic |
+| `nlp-service/services/providers/gemini.py` (NEW) | `GeminiProvider`: client construction, `_with_retry` with `_genai_errors.APIError`, `_record_usage` on Gemini fields, `_log_usage`, `_was_truncated` MAX_TOKENS check, `_MODEL_PRICES` for `gemini-*`, `ThinkingConfig` mapping | Phase 2 | Behaviour-preserving extract from `nlp-service/services/llm_client.py:62, :89-116, :297-443, :471-483` |
+| `nlp-service/services/providers/test_providers.py` (NEW) | pytest unit tests: factory dispatch, JSON-format injection, reasoning_effort translation, price-discount boundary, retry semantics | Phase 2 + Phase 4 | Six-gate "tests first" |
+| `nlp-service/services/llm_client.py:62, :89-116, :297-443, :471-483, :325-336` | Move Gemini-specific helpers into `providers/gemini.py`; module shrinks from 1794 → ~1100 lines | Phase 2 | One file = one responsibility (skill section 7) |
+| `nlp-service/services/llm_client.py:287, :217` | Generalise `"Daily Gemini spend limit"` error message and the docstring `"daily Gemini $ cap"` to `"Daily LLM spend"` / `"daily LLM $ cap"` | Phase 2 | Per Risks table — the cap is dollar-denominated and shared across providers |
+| `nlp-service/services/llm_client.py` 8 schema-bound call sites (incl. `:537, :702, :1559`) | Convert from concatenated prompt strings to `messages=[system, user]` shape | Phase 3 | Both providers cache better; DeepSeek json_object mode requires explicit roles. Quirk #4. |
+| `nlp-service/services/llm_client.py` (new constant) | Add `_DEEPSEEK_INPUT_CHAR_CAP = 200000` alongside `_GEMINI_EXTRACT_INPUT_CAP = 50000` (`:68`) | Phase 3 | Empirical: DeepSeek extracted clean from the 95K source; cap reflects that |
+| `nlp-service/services/llm_client.py:793-838` | Skip halved-input fallback when provider is DeepSeek | Phase 3 | Halved-path rationale is Gemini-bug-specific; 28/28 spike says salvage covers the rare DeepSeek failure |
+| `nlp-service/services/providers/deepseek.py` (NEW) | OpenAI-compatible `httpx` client targeting `https://api.deepseek.com`; `response_format={"type":"json_object"}`; `extra_body.thinking={type:enabled}`; `reasoning_effort` translation; retry on 408/429/5xx; usage parsing (`prompt_tokens`, `completion_tokens`, `prompt_cache_hit_tokens`); per-call cost with discount-window logic; own rate limiter at `DEEPSEEK_RPM` (default 60) | Phase 4 | Quirks #1, #2, #3, #6, #12 |
+| `nlp-service/main.py:86` | `startup_check` warns if neither `GEMINI_API_KEY` nor `DEEPSEEK_API_KEY` is set; deprecated `@app.on_event("startup")` decorator stays in Phase 1 | Phase 5 | Operators discover misconfig at boot |
+| `nlp-service/main.py:102` | `/health` response gains `provider_keys: {gemini: bool, deepseek: bool}` | Phase 5 | UI gating relies on this |
+| `docker-compose.yml` `app.environment` (~line 45) AND `nlp-service.environment` (~line 80) | Add `DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}` adjacent to existing `GEMINI_API_KEY` | Phase 5 | Quirk #5 |
+| `docker-compose.yml` repo root `.env.example` (if exists) | Append `DEEPSEEK_API_KEY=` empty default + one-line comment with `https://api-docs.deepseek.com` | Phase 5 | Operator self-discovery |
+| `scripts/integration-test.sh` Stage 1 env loop | Regression-guard `DEEPSEEK_API_KEY` alongside `GEMINI_API_KEY` and `FIRECRAWL_API_KEY` | Phase 5 | CLAUDE.md gotcha — every new `process.env.X` read needs a Stage 1 guard |
+| `app/src/lib/db.ts:2530-2534` | Expand `CHAT_MODELS` const: add `'deepseek-v4-pro'` (single explicit pin, no floating aliases) | Phase 6 | Decision rationale — single SKU, not chat/reasoner split |
+| `app/src/lib/db.ts` (new helper) | `getProviderForModel(m: string): 'gemini' | 'deepseek'` based on prefix | Phase 6 | UI uses this for optgroup placement |
+| `app/src/app/api/settings/route.ts:228, :238` | Update error strings to list expanded model set (validation already routes through `isChatModel`) | Phase 6 | Fix follows from `CHAT_MODELS` expansion |
+| `app/src/app/api/health/route.ts` | Extend response with `provider_keys: { gemini_present: !!process.env.GEMINI_API_KEY, deepseek_present: !!process.env.DEEPSEEK_API_KEY }` (presence-only; no outbound probe) | Phase 5 | UI gating |
+| `app/src/app/settings/page.tsx:1095-1112, :1160-1177` | Restructure both `<select>` blocks with grouped `<optgroup label="Gemini">` and `<optgroup label="DeepSeek">`; DeepSeek option `disabled={!healthData?.provider_keys?.deepseek_present}` + `title=` tooltip | Phase 6 | Manual matrix walked in verification |
+| `app/src/app/settings/page.tsx:1083-1092, :1152-1156` | Drop the word "Gemini" from copy ("Which model the compile pipeline uses…") | Phase 6 | Provider-neutral copy |
+
+---
+
+## Sub-agent execution rules
+
+| Phase | Parallel? | Pattern |
+|---|---|---|
+| Phase 1 | No | Single-file mechanical change in `nlp-service/services/llm_client.py` (7 trailer appends). Coordination overhead exceeds time savings. |
+| Phase 2 | No | Behaviour-preserving extract — every helper moves out of `llm_client.py` into `providers/gemini.py`. Single write set on `llm_client.py`. Sequential. |
+| Phase 3 | No | All 8 schema-bound call sites converge on `llm_client.py`; sub-agent split would race the same file. Sequential. |
+| Phase 4 | No | New `providers/deepseek.py` + new test file — could parallelise with Phase 5 in principle, but Phase 5's `main.py` `/health` change depends on Phase 4 having committed `DeepSeekProvider` class so the health check has a callable to import. Sequential. |
+| Phase 5 | No | Wires `docker-compose.yml`, `main.py`, `scripts/integration-test.sh`, `app/src/app/api/health/route.ts`. Small disjoint files; sequential within one operator session is faster than the agent-handoff overhead. |
+| Phase 6 | No | UI changes converge on `app/src/lib/db.ts` and `settings/page.tsx`. Manual matrix walked at the end requires a single coherent state. |
+| Phase 7 | No | End-to-end revalidation against `test_corpus/` is one observation, not a parallelisable workload. |
+
+**Honest answer to "should we use sub-agents":** Not advisable for execution. Phases 1–3 all converge on `nlp-service/services/llm_client.py`; Phase 6 converges on `app/src/lib/db.ts` + `settings/page.tsx`. The disjoint write-set discipline isn't satisfied for any phase boundary, and the verification gates (especially Phase 7 live re-validation) require a coherent checkpoint to compare against the spike baseline. Sub-agents likely *did* help during the planning phase (parallel research on DeepSeek API shape, pricing window math, prompt-trailer test); they will not help during execution.
+
+**Execution invariant for every sub-agent:** (Reserved for the unlikely case a future plan parallelises off this one.)
+
+1. Isolated git worktree — no shared filesystem changes.
+2. Six-gate drill applies — spec first, tests first, minimal implementation, spec alignment review, code quality review, final code review.
+3. `gitnexus_impact` before edits, `gitnexus_detect_changes` after.
+4. Agent does NOT merge its branch — reports back, controller (human + Claude) reviews diff and merges.
+5. Bounded file allowlist per agent — touching anything outside list = stop and report.
+
+---
+
+## What's left
+
+### Phase 1 — Append `"json"` trailer to 7 system prompts (no other changes)
+
+**Why:** DeepSeek json_object mode silently degrades to free-form text without the keyword (Quirk #1). Gemini ignores the trailer. Doing this first lets us run the existing nlp-service test suite against Gemini under the new prompts and isolate "trailer changed prompt behaviour" as a single variable before any abstraction churn begins.
+
+**Depends on:** None.
+
+**Status:** Not started.
+
+**1.1** Append the exact trailer string `"\n\nReturn the response as a single json object matching the schema described above. Do not include any text outside the json."` to the 7 prompts at `nlp-service/services/llm_client.py:490, :634, :864, :882, :1269, :1519, :1616`.
+
+**Why sequential, not parallel:** All 7 edits land in the same file.
+
+#### Phase 1 — File structure
+
+- Modify: `nlp-service/services/llm_client.py:490` — `_LINT_SYSTEM_PROMPT` trailer
+- Modify: `nlp-service/services/llm_client.py:634` — `_EXTRACTION_SYSTEM_PROMPT` trailer
+- Modify: `nlp-service/services/llm_client.py:864` — `_DISAMBIGUATION_SYSTEM_PROMPT` trailer
+- Modify: `nlp-service/services/llm_client.py:882` — `_DISAMBIGUATION_CONCEPT_SYSTEM_PROMPT` trailer
+- Modify: `nlp-service/services/llm_client.py:1269` — `_CROSSREF_SYSTEM_PROMPT` trailer
+- Modify: `nlp-service/services/llm_client.py:1519` — `_SELECT_PAGES_SYSTEM_PROMPT` trailer
+- Modify: `nlp-service/services/llm_client.py:1616` — `_SYNTHESIZE_SYSTEM_PROMPT` trailer
+- Test: `nlp-service/tests/test_llm_client.py` — existing extract/lint/disambiguate fixtures (no new test, regression-only)
+
+#### Phase 1 — Tasks
+
+##### Task 1.1: Trailer constant + first prompt
+
+**Files:**
+- Modify: `nlp-service/services/llm_client.py:490`
+
+- [ ] **Step 1: Add the trailer constant just below `_DEFAULT_MODEL`**
+
+```python
+_JSON_TRAILER = (
+    "\n\nReturn the response as a single json object matching the schema "
+    "described above. Do not include any text outside the json."
+)
+```
+
+- [ ] **Step 2: Append to `_LINT_SYSTEM_PROMPT` at the constant declaration**
+
+```python
+_LINT_SYSTEM_PROMPT = """\
+You are a wiki knowledge auditor. […existing body…]
+""" + _JSON_TRAILER
+```
+
+- [ ] **Step 3: Run an existing lint test to verify the prompt still parses**
+
+Run: `pytest nlp-service/tests/test_llm_client.py -k lint -v`
+Expected: PASS (same coverage as before — the trailer is additive)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add nlp-service/services/llm_client.py
+git commit -m "feat(llm): add json trailer to lint system prompt"
+```
+
+##### Task 1.2: Apply trailer to remaining 6 prompts
+
+**Files:**
+- Modify: `nlp-service/services/llm_client.py:634, :864, :882, :1269, :1519, :1616`
+
+- [ ] **Step 1: Append `+ _JSON_TRAILER` to each of the 6 remaining `_*_SYSTEM_PROMPT` constants**
+
+Pattern (apply to all 6):
+```python
+_EXTRACTION_SYSTEM_PROMPT = """\
+…existing body…
+""" + _JSON_TRAILER
+```
+
+- [ ] **Step 2: Run the prompt-touching tests**
+
+Run: `pytest nlp-service/tests/test_llm_client.py -k "extract or disambiguate or crossref or select_pages or synthesize" -v`
+Expected: PASS
+
+- [ ] **Step 3: Smoke-compile a known-good source from `nlp-service/test_corpus/`**
+
+Run: `bash scripts/integration-test.sh --stage 4`
+Expected: PASS — pages compile, JSON parses, no salvage attempts logged.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add nlp-service/services/llm_client.py
+git commit -m "feat(llm): append json trailer to remaining system prompts"
+```
+
+#### Phase 1 PR checklist
+
+- [ ] **Spec first:** `docs/plans/phase_1_spec.md` exists and covers the trailer string, the 7 target prompts, why both providers tolerate it, and the no-behaviour-change-for-Gemini guarantee
+- [ ] **Tests first:** existing `test_llm_client.py` fixtures touched by these prompts were green before the change and stay green after
+- [ ] **Implement:** trailer added to exactly 7 prompts, no other edits in `llm_client.py`
+- [ ] **Spec alignment review:** trailer text matches phase spec verbatim; no other prompt edits crept in
+- [ ] **Code quality review:** single `_JSON_TRAILER` constant (DRY), no inline trailer duplication
+- [ ] **Final code review:** `gitnexus_detect_changes` shows only the prompt-constant edits in `llm_client.py`; ready to merge
+
+#### Phase 1 kickoff checklist
+
+- [ ] 1.1 — `_JSON_TRAILER` constant added
+- [ ] 1.1 — `_LINT_SYSTEM_PROMPT` trailer appended; lint test green
+- [ ] 1.2 — remaining 6 prompts get trailer
+- [ ] 1.2 — full prompt-touching test suite green
+- [ ] 1.2 — `scripts/integration-test.sh --stage 4` passes
+- [ ] One commit per task, both pushed; CI green
+
+---
+
+### Phase 2 — Build `providers/base.py` + `providers/__init__.py` + extract Gemini logic into `providers/gemini.py`
+
+**Why:** The `LLMProvider` abstraction is what every Phase ≥3 work item assumes. Moving the Gemini-specific surface out of `llm_client.py` while keeping behaviour byte-for-byte equivalent isolates the abstraction churn from any semantic change. After this phase, `llm_client.py` becomes a thin dispatcher; helpers move to `providers/gemini.py`. CLAUDE.md gotcha lists 12+ Gemini call-parameter sites in this file — this phase consolidates them behind one provider class.
+
+**Depends on:** Phase 1 (trailers landed — so the prompts that move into providers are already in their final form).
+
+**Status:** Not started.
+
+**2.1** Create `providers/base.py` with `LLMProvider` Protocol, `LLMRequest`/`LLMResult` dataclasses, `ProviderError` hierarchy.
+
+**2.2** Create `providers/gemini.py` and move:
+- `_GEMINI_RPM` (`:62`), `_get_limiter` (`:325-336`)
+- `_MODEL_PRICES` (`:89-116`), `_get_model_prices` (`:105`)
+- `_record_usage` (`:297`), `_log_usage` (`:396`), `_was_truncated` (`:425`)
+- `_with_retry` (`:354-393`) — keeping `_APIError` import + `_RETRYABLE_STATUSES` (`:351`) co-located
+- `get_client()` (`:477-483`) — provider class owns its lazy client
+- `ThinkingConfig` mapping helpers used at the call sites
+
+**2.3** Create `providers/__init__.py` with `get_provider(model: str) -> LLMProvider` factory and `translate_thinking_budget(provider, call_site) -> Any` helper. Prefix dispatch: `gemini-*` → `GeminiProvider`, `deepseek-*` → raises `NotImplementedError` for now (Phase 4 wires it).
+
+**2.4** Generalise the cost-cap error message at `nlp-service/services/llm_client.py:287` from `"Daily Gemini spend limit"` to `"Daily LLM spend"`; update the docstring at `:217` similarly. (Per-call cost lookup now goes through the provider, not the global `_get_model_prices`.)
+
+**2.5** Update `nlp-service/tests/test_llm_client.py` mocks: every `mocker.patch("…client.models.generate_content")` becomes `mocker.patch("…providers.gemini.GeminiProvider.complete")` (or whichever public method the Protocol exposes).
+
+**Why sequential, not parallel:** Single write set on `llm_client.py` and the new package is created top-down (base → gemini → __init__).
+
+#### Phase 2 — File structure
+
+- Create: `nlp-service/services/providers/__init__.py` — `get_provider` factory + `translate_thinking_budget`
+- Create: `nlp-service/services/providers/base.py` — `LLMProvider` Protocol + `LLMRequest` + `LLMResult` + `ProviderError` hierarchy
+- Create: `nlp-service/services/providers/gemini.py` — Gemini-specific extract from `llm_client.py`
+- Create: `nlp-service/services/providers/test_providers.py` — pytest unit: factory dispatch (gemini-* OK, deepseek-* raises NotImplementedError, anthropic-* raises ValueError), price lookup
+- Modify: `nlp-service/services/llm_client.py:62, :89-116, :217, :287, :297-443, :471-483, :325-336` — remove the moved sections, generalise cost-cap message
+- Modify: `nlp-service/tests/test_llm_client.py` — repoint mocks at provider class
+
+#### Phase 2 — Tasks
+
+##### Task 2.1: `providers/base.py` Protocol + dataclasses
+
+**Files:**
+- Create: `nlp-service/services/providers/base.py`
+
+- [ ] **Step 1: Failing test in `test_providers.py` for `LLMRequest`/`LLMResult` shape**
+
+```python
+# nlp-service/services/providers/test_providers.py
+from nlp_service.services.providers.base import LLMRequest, LLMResult, LLMProvider
+
+def test_llm_request_minimal_shape():
+    req = LLMRequest(
+        model="gemini-2.5-flash",
+        messages=[{"role": "system", "content": "hi"}, {"role": "user", "content": "ok"}],
+        response_model=None,
+        thinking_budget=0,
+        max_output_tokens=2048,
+        temperature=0.0,
+        step="test_step",
+    )
+    assert req.model == "gemini-2.5-flash"
+
+def test_llm_result_carries_text_parsed_usage_finish():
+    res = LLMResult(text="ok", parsed=None, usage={}, finish_reason="STOP")
+    assert res.text == "ok"
+```
+
+- [ ] **Step 2: Run to verify FAIL (module doesn't exist)**
+
+Run: `pytest nlp-service/services/providers/test_providers.py -v`
+Expected: FAIL with `ModuleNotFoundError: providers`
+
+- [ ] **Step 3: Write `base.py`**
+
+```python
+# nlp-service/services/providers/base.py
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+from pydantic import BaseModel
+
+
+class ProviderError(Exception): pass
+class ProviderRateLimitedError(ProviderError): pass
+class ProviderTransientError(ProviderError): pass
+
+
+@dataclass
+class LLMRequest:
+    model: str
+    messages: list[dict[str, str]]
+    response_model: type[BaseModel] | None
+    thinking_budget: int
+    max_output_tokens: int
+    temperature: float
+    step: str
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class LLMResult:
+    text: str
+    parsed: BaseModel | None
+    usage: dict[str, int]
+    finish_reason: str
+
+
+class LLMProvider(Protocol):
+    name: str
+    def complete(self, req: LLMRequest) -> LLMResult: ...
+    def cost_usd(self, model: str, usage: dict[str, int]) -> float: ...
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+Run: `pytest nlp-service/services/providers/test_providers.py -v`
+Expected: PASS — both shape tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add nlp-service/services/providers/__init__.py nlp-service/services/providers/base.py nlp-service/services/providers/test_providers.py
+git commit -m "feat(llm): add provider Protocol + LLMRequest/Result dataclasses"
+```
+
+##### Task 2.2: Move Gemini-specific helpers into `providers/gemini.py`
+
+**Files:**
+- Create: `nlp-service/services/providers/gemini.py`
+- Modify: `nlp-service/services/llm_client.py:62, :89-116, :297-443, :471-483, :325-336` (remove)
+
+- [ ] **Step 1: Add a behaviour-equivalence test (RED)**
+
+```python
+# test_providers.py
+def test_gemini_provider_log_usage_format(capsys, gemini_response_fixture):
+    from nlp_service.services.providers.gemini import GeminiProvider
+    p = GeminiProvider()
+    p._log_usage("test_step", gemini_response_fixture)
+    captured = capsys.readouterr()
+    assert "[gemini] step=test_step finish=" in captured.err
+```
+
+Run: `pytest nlp-service/services/providers/test_providers.py::test_gemini_provider_log_usage_format -v` → FAIL (`gemini.py` doesn't exist).
+
+- [ ] **Step 2: Create `providers/gemini.py` and copy** `_GEMINI_RPM`, `_get_limiter`, `_MODEL_PRICES`, `_get_model_prices`, `_log_usage`, `_record_usage`, `_was_truncated`, `_with_retry`, `_RETRYABLE_STATUSES`, `_APIError` import block, `get_client` from `llm_client.py` into a `GeminiProvider` class (former module-level functions become private methods or stay module-level if stateless and only Gemini uses them).
+
+The `_log_usage` line `[gemini] step=…` stays Gemini-specific in the moved helper (the per-provider prefix is intentional — DeepSeek will emit `[deepseek] step=…` from its own equivalent helper).
+
+- [ ] **Step 3: `GeminiProvider.complete()` adapter**
+
+Method signature: `def complete(self, req: LLMRequest) -> LLMResult:` — translates `LLMRequest` to `genai.Client().models.generate_content(...)` call shape with `system_instruction` from `messages[0]["content"]` (when role=system) and `contents` from the user message; calls through `_with_retry`; reads `usage_metadata`; returns `LLMResult` with `parsed=req.response_model.model_validate_json(text)` if `req.response_model` else `parsed=None`.
+
+- [ ] **Step 4: Run the equivalence test**
+
+Run: `pytest nlp-service/services/providers/test_providers.py::test_gemini_provider_log_usage_format -v`
+Expected: PASS
+
+- [ ] **Step 5: Remove the moved code from `llm_client.py`**
+
+Delete `:62, :89-116, :297-443, :471-483, :325-336` (the helper functions and constants now living in `gemini.py`). Keep `_DEFAULT_MODEL`, `_check_and_record_cost`, `_salvage_extraction`, `_read_thinking_budget`, all `_*_SYSTEM_PROMPT` constants, all 11 call sites.
+
+- [ ] **Step 6: Replace each call site's direct `client.models.generate_content(...)` invocation with `provider = get_provider(model); provider.complete(LLMRequest(...))`**
+
+(Defer the `messages=[system, user]` shape change to Phase 3 — for Phase 2, build `messages` from the existing system+user split as it stands today; no semantic change for Gemini.)
+
+- [ ] **Step 7: Run the full nlp-service test suite**
+
+Run: `pytest nlp-service/tests/ nlp-service/services/providers/ -v`
+Expected: PASS — repointed mocks pass, behaviour-equivalence holds.
+
+- [ ] **Step 8: Smoke compile**
+
+Run: `bash scripts/integration-test.sh --stage 4`
+Expected: PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add nlp-service/services/llm_client.py nlp-service/services/providers/gemini.py nlp-service/services/providers/test_providers.py nlp-service/tests/test_llm_client.py
+git commit -m "refactor(llm): extract GeminiProvider into providers/gemini.py"
+```
+
+##### Task 2.3: `providers/__init__.py` factory + cost-cap message generalisation
+
+**Files:**
+- Create: `nlp-service/services/providers/__init__.py`
+- Modify: `nlp-service/services/llm_client.py:217, :287`
+
+- [ ] **Step 1: RED test for prefix dispatch**
+
+```python
+# test_providers.py
+def test_get_provider_dispatches_by_prefix():
+    from nlp_service.services.providers import get_provider
+    from nlp_service.services.providers.gemini import GeminiProvider
+    assert isinstance(get_provider("gemini-2.5-flash"), GeminiProvider)
+    import pytest
+    with pytest.raises(NotImplementedError):
+        get_provider("deepseek-v4-pro")
+    with pytest.raises(ValueError, match="unknown provider"):
+        get_provider("anthropic-claude-4-7")
+```
+
+Run: `pytest …::test_get_provider_dispatches_by_prefix -v` → FAIL (factory not implemented).
+
+- [ ] **Step 2: Implement factory**
+
+```python
+# nlp-service/services/providers/__init__.py
+from .base import LLMProvider, LLMRequest, LLMResult, ProviderError, ProviderRateLimitedError, ProviderTransientError
+from .gemini import GeminiProvider
+
+_REGISTRY: dict[str, LLMProvider] = {}
+
+def get_provider(model: str) -> LLMProvider:
+    if model.startswith("gemini-"):
+        return _REGISTRY.setdefault("gemini", GeminiProvider())
+    if model.startswith("deepseek-"):
+        raise NotImplementedError("DeepSeek provider lands in Phase 4")
+    raise ValueError(f"unknown provider for model {model!r}")
+
+def translate_thinking_budget(provider: str, call_site: str, raw: int) -> object:
+    if provider == "gemini":
+        return raw  # passthrough (int)
+    if provider == "deepseek":
+        if raw == 0:    return "disabled"
+        if raw <= 1024: return "low"
+        if raw <= 2048: return "medium"
+        if raw <= 8192: return "high"
+        return "max"
+    raise ValueError(f"unknown provider {provider!r}")
+```
+
+- [ ] **Step 3: GREEN**
+
+Run: `pytest nlp-service/services/providers/test_providers.py::test_get_provider_dispatches_by_prefix -v`
+Expected: PASS
+
+- [ ] **Step 4: Generalise cost-cap message**
+
+Edit `nlp-service/services/llm_client.py:287`:
+- old: `f"Daily Gemini spend limit (${daily_cap:.2f}) reached. "`
+- new: `f"Daily LLM spend limit (${daily_cap:.2f}) reached. "`
+
+Edit the surrounding docstring at `:217`:
+- old: `daily Gemini $ cap`
+- new: `daily LLM $ cap`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add nlp-service/services/providers/__init__.py nlp-service/services/providers/test_providers.py nlp-service/services/llm_client.py
+git commit -m "feat(llm): add provider factory + generalise cost-cap error to LLM"
+```
+
+#### Phase 2 PR checklist
+
+- [ ] **Spec first:** `docs/plans/phase_2_spec.md` exists and covers the Protocol surface (`LLMRequest`/`LLMResult` fields), the line ranges that move out of `llm_client.py`, the no-behaviour-change-for-Gemini guarantee, and the test-mock repointing
+- [ ] **Tests first:** `test_providers.py` shape and dispatch tests written and red before implementation
+- [ ] **Implement:** `providers/base.py`, `providers/gemini.py`, `providers/__init__.py` exist; `llm_client.py` shrinks (~1100 lines from 1794); `_salvage_extraction` and `_check_and_record_cost` stay at dispatcher layer
+- [ ] **Spec alignment review:** every helper named in the spec line range moved exactly to the named target file; cost-cap message updated to the exact spec string
+- [ ] **Code quality review:** single source of truth for model→provider dispatch; `[gemini]` log prefix preserved in moved helper; `_thinking_cache` not duplicated
+- [ ] **Final code review:** `gitnexus_detect_changes` shows the expected file scope; `pytest nlp-service/tests/ nlp-service/services/providers/` green; ready to merge
+
+#### Phase 2 kickoff checklist
+
+- [ ] 2.1 — `base.py` Protocol + dataclasses; shape tests green
+- [ ] 2.2 — `gemini.py` houses Gemini helpers; behaviour-equivalence test green
+- [ ] 2.2 — `llm_client.py` call sites use `get_provider().complete(LLMRequest)` shim; full test suite green; integration-test stage 4 green
+- [ ] 2.3 — `__init__.py` factory; dispatch test green
+- [ ] 2.3 — cost-cap error generalised; docstring updated
+- [ ] One commit per task; CI green
+
+---
+
+### Phase 3 — Convert 8 schema-bound call sites to `messages=[system, user]` shape
+
+**Why:** Both providers cache better with explicit roles; DeepSeek json_object mode requires it (Quirk #4); two of the 8 call sites already use `system_instruction` (`:1333`, `:1487`) so the pattern is proven. The other 6 today concatenate system+user into one prompt string (visible at `:537, :702, :1559`). Converting before the DeepSeek provider lands keeps "did the messages-shape change break Gemini" isolated as a single variable.
+
+**Depends on:** Phase 2 (`LLMRequest.messages` shape exists).
+
+**Status:** Not started.
+
+**3.1** Convert all 8 schema-bound call sites in `nlp-service/services/llm_client.py` to construct `messages=[{"role":"system","content":<system_prompt>}, {"role":"user","content":<user_payload>}]`. The `GeminiProvider.complete()` adapter from Phase 2.2 already maps role=system → `system_instruction` parameter on the genai SDK call.
+
+**3.2** Add `_DEEPSEEK_INPUT_CHAR_CAP = int(os.environ.get("DEEPSEEK_INPUT_CHAR_CAP", "200000"))` alongside `_GEMINI_EXTRACT_INPUT_CAP` at `:68`. Empirically warranted: DeepSeek extracted clean from the 95K source. The cap is read from `LLMRequest.extra["input_char_cap"]` or set at the call site based on `get_provider_for_model(model)` lookup.
+
+**3.3** Skip the halved-input fallback path at `:793-838` when `provider_name == "deepseek"`. Wrap it in `if get_provider_for_model(model) == "gemini":` — the fallback's "different prompt path escapes the loop" rationale is Gemini-bug-specific.
+
+**Why sequential, not parallel:** All 8 conversions land in the same file; halved-fallback skip is an `if`-gate at one site.
+
+#### Phase 3 — File structure
+
+- Modify: `nlp-service/services/llm_client.py` 8 schema-bound call sites (incl. `:537, :702, :1559`)
+- Modify: `nlp-service/services/llm_client.py:68` — add `_DEEPSEEK_INPUT_CHAR_CAP`
+- Modify: `nlp-service/services/llm_client.py:793-838` — gate halved-input fallback by provider
+- Test: `nlp-service/tests/test_llm_client.py` — extend extract/lint tests to assert `messages` shape was passed through
+
+#### Phase 3 — Tasks
+
+##### Task 3.1: Convert all 8 schema-bound call sites
+
+**Files:**
+- Modify: `nlp-service/services/llm_client.py` (8 call sites)
+
+- [ ] **Step 1: RED — assert messages shape at one call site**
+
+```python
+def test_extract_source_passes_messages_shape(mocker):
+    captured = {}
+    def fake_complete(self, req):
+        captured["messages"] = req.messages
+        from nlp_service.services.providers.base import LLMResult
+        return LLMResult(text='{"items":[]}', parsed=None, usage={}, finish_reason="STOP")
+    mocker.patch("nlp_service.services.providers.gemini.GeminiProvider.complete", fake_complete)
+    from nlp_service.services.llm_client import extract_source
+    extract_source("source text", page_id="p1", model="gemini-2.5-flash")
+    assert captured["messages"][0]["role"] == "system"
+    assert captured["messages"][1]["role"] == "user"
+    assert captured["messages"][0]["content"].endswith("Do not include any text outside the json.")
+```
+
+Run: `pytest …::test_extract_source_passes_messages_shape -v` → FAIL (today the call site concatenates).
+
+- [ ] **Step 2: GREEN — convert `extract_source` to messages shape**
+
+At `:702` (and the other 7 schema-bound sites), replace the concatenated prompt build with:
+
+```python
+messages = [
+    {"role": "system", "content": _EXTRACTION_SYSTEM_PROMPT},
+    {"role": "user", "content": user_payload},
+]
+result = provider.complete(LLMRequest(
+    model=model,
+    messages=messages,
+    response_model=LLMExtractionResponse,
+    thinking_budget=_read_thinking_budget("extract"),
+    max_output_tokens=32768,
+    temperature=0.0,
+    step="extract",
+))
+```
+
+Repeat for `lint_scan` (`:537`), `disambiguate` (the two variants near the disambiguation prompts), `crossref` (`:1269` site), `select_pages` (`:1559`), `synthesize` (`:1616` site), and the remaining schema-bound site.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `pytest nlp-service/tests/ nlp-service/services/providers/ -v`
+Expected: PASS
+
+- [ ] **Step 4: Diff JSON output against a recorded baseline from `nlp-service/test_corpus/`**
+
+Pick one source, run `bash scripts/integration-test.sh --stage 4` end-to-end on Gemini. Compare the produced page JSON against a baseline saved to `validation/baseline/<source>.json` (or `/data/sv_results/` if the team prefers off-branch).
+
+Tolerance: entity counts within ±10% of baseline (per Section 7 of the source spec). If not within tolerance, **stop and investigate** — likely a `system_instruction` regression at one of the 8 sites.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add nlp-service/services/llm_client.py nlp-service/tests/test_llm_client.py
+git commit -m "refactor(llm): use messages=[system,user] at all schema-bound call sites"
+```
+
+##### Task 3.2: Add `_DEEPSEEK_INPUT_CHAR_CAP` + gate halved-input fallback
+
+**Files:**
+- Modify: `nlp-service/services/llm_client.py:68, :793-838`
+
+- [ ] **Step 1: RED — extract path uses 200K cap when provider is deepseek**
+
+```python
+def test_extract_uses_deepseek_cap_when_deepseek_model(mocker):
+    captured = {}
+    def fake_complete(self, req):
+        captured["user_chars"] = len(req.messages[1]["content"])
+        from nlp_service.services.providers.base import LLMResult
+        return LLMResult(text='{"items":[]}', parsed=None, usage={}, finish_reason="STOP")
+    # provider gets dispatched by model prefix; mock the deepseek provider class once Phase 4 lands
+    # for now, mock get_provider directly
+    ...
+    extract_source("a" * 90000, page_id="p1", model="deepseek-v4-pro")
+    assert captured["user_chars"] >= 80000  # not truncated to 50000
+```
+
+This test will compile after Phase 4 lands `DeepSeekProvider`. For Phase 3 in isolation, write the test so it XFAILs until Phase 4 — or stub the provider in the test fixture.
+
+- [ ] **Step 2: GREEN — add the cap constant and use it**
+
+```python
+_DEEPSEEK_INPUT_CHAR_CAP = int(os.environ.get("DEEPSEEK_INPUT_CHAR_CAP", "200000"))
+
+def _input_cap_for(model: str) -> int:
+    if model.startswith("deepseek-"):
+        return _DEEPSEEK_INPUT_CHAR_CAP
+    return _GEMINI_EXTRACT_INPUT_CAP
+```
+
+At the extract truncation site, replace `_GEMINI_EXTRACT_INPUT_CAP` with `_input_cap_for(model)`.
+
+- [ ] **Step 3: Gate halved-input fallback at `:793-838`**
+
+Wrap the existing fallback block:
+
+```python
+if model.startswith("gemini-"):
+    # existing halved-input retry path
+    …
+else:
+    # DeepSeek path — _salvage_extraction handles the rare failure
+    raise LLMCompileError(f"extract_failed: {e}") from e
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add nlp-service/services/llm_client.py
+git commit -m "feat(llm): per-provider input-char cap and Gemini-only halved fallback"
+```
+
+#### Phase 3 PR checklist
+
+- [ ] **Spec first:** `docs/plans/phase_3_spec.md` exists and lists the 8 schema-bound call sites by file:line + names + the exact `messages` shape, plus the per-provider input cap rule and halved-fallback gate
+- [ ] **Tests first:** `test_extract_source_passes_messages_shape` (and equivalents per call site) red before implementation
+- [ ] **Implement:** all 8 call sites converted; per-provider cap helper added; halved-fallback gated by `gemini-*` prefix
+- [ ] **Spec alignment review:** baseline JSON diff within ±10% on entity counts; the 2 sites that already used `system_instruction` were not regressed
+- [ ] **Code quality review:** no concatenated-prompt strings remain at any of the 8 sites; the `_input_cap_for` helper is used uniformly
+- [ ] **Final code review:** `gitnexus_detect_changes` shows only `llm_client.py` + the test extension; CI green; ready to merge
+
+#### Phase 3 kickoff checklist
+
+- [ ] 3.1 — `messages` shape test added (RED)
+- [ ] 3.1 — all 8 call sites converted (GREEN)
+- [ ] 3.1 — baseline JSON diff within tolerance
+- [ ] 3.2 — `_DEEPSEEK_INPUT_CHAR_CAP` + `_input_cap_for` helper added
+- [ ] 3.2 — halved-fallback gated by `gemini-*` prefix
+- [ ] One commit per task; CI green
+
+---
+
+### Phase 4 — Implement `providers/deepseek.py`
+
+**Why:** This is the new code that the entire plan exists to add. Provider, retry, usage parsing, json_object mode, reasoning_effort translation, cost table with discount-window logic, own rate limiter at `DEEPSEEK_RPM`. Phases 1–3 set up the substrate; Phase 4 fills the second slot.
+
+**Depends on:** Phase 2 (`LLMProvider` Protocol + factory exist), Phase 3 (`messages` shape used everywhere), Phase 1 (`"json"` trailer present).
+
+**Status:** Not started.
+
+**4.1** Implement `DeepSeekProvider` class in `providers/deepseek.py`: constructor reads `DEEPSEEK_API_KEY`, builds an `httpx.Client(base_url="https://api.deepseek.com")`; `complete()` posts to `/v1/chat/completions` with `model`, `messages`, `response_format={"type":"json_object"}` when `req.response_model is not None`, `extra_body.thinking={"type":"enabled"}` when `req.thinking_budget > 0`, `reasoning_effort` translated via the Phase 2.3 helper.
+
+**4.2** Retry semantics: 408/429/500/502/503/504 with exponential backoff (mirror `_with_retry`), max 3 attempts, base delay 0.5s — own copy of `_RETRYABLE_STATUSES`. Rate limiter: in-process pyrate-limiter bucket at `DEEPSEEK_RPM` (env, default 60).
+
+**4.3** Usage parsing: read `prompt_tokens`, `completion_tokens`, `prompt_cache_hit_tokens` from response; emit `[deepseek] step=… finish=… in=… out=… cache_hit=…` log line; record cost via the dispatcher's `_check_and_record_cost`.
+
+**4.4** Cost computation with discount window. Constants:
+```python
+DISCOUNT_UNTIL = datetime(2026, 5, 31, 15, 59, 0, tzinfo=timezone.utc)
+_DEEPSEEK_PRICES_DISCOUNT = {"input": 0.07, "output": 0.27, "cache": 0.014}
+_DEEPSEEK_PRICES_LIST     = {"input": 0.27, "output": 1.10, "cache": 0.054}
+```
+With env overrides `DEEPSEEK_INPUT_USD_PER_M` / `DEEPSEEK_OUTPUT_USD_PER_M` / `DEEPSEEK_CACHE_USD_PER_M` taking precedence.
+
+**4.5** Update `providers/__init__.py` factory: `deepseek-*` now returns `DeepSeekProvider()`.
+
+**4.6** Unit tests in `test_providers.py`: factory dispatch (`deepseek-v4-pro` → `DeepSeekProvider`), JSON-format injection (assert request body has `response_format={"type":"json_object"}` when `response_model` is set), reasoning_effort translation (5 mapping cases), price-discount boundary (one second before `DISCOUNT_UNTIL` returns discount, one second after returns list), retry on 408/429/5xx (mocked `httpx`).
+
+**4.7** Live smoke call: when `DEEPSEEK_API_KEY` is present, run one extract on a small fixture from `test_corpus/` and assert no salvage attempts logged.
+
+**Why sequential, not parallel:** Single new file, single test extension; no parallel write surface.
+
+#### Phase 4 — File structure
+
+- Create: `nlp-service/services/providers/deepseek.py` — `DeepSeekProvider` class, retry, usage parsing, cost table
+- Modify: `nlp-service/services/providers/__init__.py` — wire `deepseek-*` to `DeepSeekProvider`
+- Modify: `nlp-service/services/providers/test_providers.py` — extend with DeepSeek-specific tests
+
+#### Phase 4 — Tasks
+
+##### Task 4.1: `DeepSeekProvider.complete()` happy path
+
+**Files:**
+- Create: `nlp-service/services/providers/deepseek.py`
+- Modify: `nlp-service/services/providers/test_providers.py`
+
+- [ ] **Step 1: RED — JSON-format injection test (mocked `httpx`)**
+
+```python
+def test_deepseek_complete_injects_json_response_format(mocker):
+    from nlp_service.services.providers.deepseek import DeepSeekProvider
+    from nlp_service.services.providers.base import LLMRequest
+    from pydantic import BaseModel
+
+    class Out(BaseModel):
+        ok: bool
+
+    captured = {}
+    class FakeResp:
+        status_code = 200
+        def json(self):
+            return {
+                "choices": [{"message": {"content": '{"ok": true}'}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 5, "prompt_cache_hit_tokens": 0},
+            }
+    def fake_post(self, url, json=None, **kw):
+        captured["body"] = json
+        return FakeResp()
+    mocker.patch("httpx.Client.post", fake_post)
+
+    p = DeepSeekProvider()
+    req = LLMRequest(model="deepseek-v4-pro", messages=[{"role":"system","content":"… json …"},{"role":"user","content":"go"}], response_model=Out, thinking_budget=0, max_output_tokens=2048, temperature=0.0, step="t")
+    res = p.complete(req)
+    assert captured["body"]["response_format"] == {"type": "json_object"}
+    assert res.parsed.ok is True
+```
+
+Run: `pytest …::test_deepseek_complete_injects_json_response_format -v` → FAIL.
+
+- [ ] **Step 2: GREEN — minimal `DeepSeekProvider`**
+
+```python
+# nlp-service/services/providers/deepseek.py
+from __future__ import annotations
+import os, sys, time
+from datetime import datetime, timezone
+from typing import Any
+import httpx
+from pyrate_limiter import Duration, InMemoryBucket, Limiter, Rate
+from .base import LLMProvider, LLMRequest, LLMResult, ProviderError, ProviderRateLimitedError
+
+_DEEPSEEK_API_KEY = os.environ.get("DEEPSEEK_API_KEY", "").strip()
+_DEEPSEEK_RPM     = int(os.environ.get("DEEPSEEK_RPM", "60"))
+_RETRYABLE_STATUSES = frozenset({408, 429, 500, 502, 503, 504})
+
+DISCOUNT_UNTIL = datetime(2026, 5, 31, 15, 59, 0, tzinfo=timezone.utc)
+_PRICES_DISCOUNT = {"input": 0.07, "output": 0.27, "cache": 0.014}
+_PRICES_LIST     = {"input": 0.27, "output": 1.10, "cache": 0.054}
+
+
+def _prices_now() -> dict[str, float]:
+    base = _PRICES_DISCOUNT if datetime.now(timezone.utc) < DISCOUNT_UNTIL else _PRICES_LIST
+    return {
+        "input":  float(os.environ.get("DEEPSEEK_INPUT_USD_PER_M",  base["input"])),
+        "output": float(os.environ.get("DEEPSEEK_OUTPUT_USD_PER_M", base["output"])),
+        "cache":  float(os.environ.get("DEEPSEEK_CACHE_USD_PER_M",  base["cache"])),
+    }
+
+
+class DeepSeekProvider:
+    name = "deepseek"
+
+    def __init__(self) -> None:
+        if not _DEEPSEEK_API_KEY:
+            raise RuntimeError("DEEPSEEK_API_KEY not set")
+        self._client = httpx.Client(
+            base_url="https://api.deepseek.com",
+            headers={"Authorization": f"Bearer {_DEEPSEEK_API_KEY}"},
+            timeout=60.0,
+        )
+        self._limiter = Limiter(
+            InMemoryBucket([Rate(_DEEPSEEK_RPM, Duration.MINUTE)]),
+            raise_when_fail=False, max_delay=60_000,
+        )
+
+    def complete(self, req: LLMRequest) -> LLMResult:
+        body: dict[str, Any] = {
+            "model": req.model,
+            "messages": req.messages,
+            "max_tokens": req.max_output_tokens,
+            "temperature": req.temperature,
+        }
+        if req.response_model is not None:
+            body["response_format"] = {"type": "json_object"}
+        if req.thinking_budget > 0:
+            body["extra_body"] = {"thinking": {"type": "enabled"}}
+            from . import translate_thinking_budget
+            body["reasoning_effort"] = translate_thinking_budget("deepseek", req.step, req.thinking_budget)
+        return self._post_with_retry(body, req)
+
+    def _post_with_retry(self, body: dict, req: LLMRequest) -> LLMResult:
+        last_exc: Exception | None = None
+        for attempt in range(3):
+            if not self._limiter.try_acquire("deepseek"):
+                raise ProviderRateLimitedError(f"llm_rate_limited: bucket exhausted on {req.step}")
+            try:
+                r = self._client.post("/v1/chat/completions", json=body)
+                if r.status_code == 200:
+                    data = r.json()
+                    text = data["choices"][0]["message"]["content"]
+                    finish = data["choices"][0]["finish_reason"]
+                    usage = data.get("usage", {})
+                    self._log_usage(req.step, finish, usage)
+                    parsed = req.response_model.model_validate_json(text) if req.response_model else None
+                    return LLMResult(text=text, parsed=parsed, usage=usage, finish_reason=finish)
+                if r.status_code in _RETRYABLE_STATUSES:
+                    last_exc = ProviderError(f"deepseek http {r.status_code}: {r.text[:200]}")
+                else:
+                    raise ProviderError(f"deepseek http {r.status_code}: {r.text[:500]}")
+            except httpx.RequestError as e:
+                last_exc = e
+            if attempt < 2:
+                delay = 0.5 * (2 ** attempt)
+                print(f"[llm-retry] deepseek {req.step} attempt {attempt+1}/3 after {type(last_exc).__name__}: sleeping {delay}s",
+                      file=sys.stderr, flush=True)
+                time.sleep(delay)
+        assert last_exc is not None
+        raise last_exc
+
+    def _log_usage(self, step: str, finish: str, usage: dict) -> None:
+        try:
+            in_  = usage.get("prompt_tokens", 0)
+            out_ = usage.get("completion_tokens", 0)
+            hit_ = usage.get("prompt_cache_hit_tokens", 0)
+            print(f"[deepseek] step={step} finish={finish} in={in_} out={out_} cache_hit={hit_}",
+                  file=sys.stderr, flush=True)
+        except Exception:
+            pass
+
+    def cost_usd(self, model: str, usage: dict[str, int]) -> float:
+        prices = _prices_now()
+        prompt = usage.get("prompt_tokens", 0)
+        cached = usage.get("prompt_cache_hit_tokens", 0)
+        out_   = usage.get("completion_tokens", 0)
+        return ((prompt - cached) / 1_000_000) * prices["input"] \
+             + (cached            / 1_000_000) * prices["cache"] \
+             + (out_              / 1_000_000) * prices["output"]
+```
+
+- [ ] **Step 3: GREEN test**
+
+Run: `pytest nlp-service/services/providers/test_providers.py::test_deepseek_complete_injects_json_response_format -v`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add nlp-service/services/providers/deepseek.py nlp-service/services/providers/test_providers.py
+git commit -m "feat(llm): add DeepSeekProvider with json_object mode + cost table"
+```
+
+##### Task 4.2: Reasoning-effort translation + retry semantics + price-boundary tests
+
+**Files:**
+- Modify: `nlp-service/services/providers/test_providers.py`
+
+- [ ] **Step 1: Translation table tests**
+
+```python
+@pytest.mark.parametrize("budget,expected", [(0, "disabled"), (1024, "low"), (2048, "medium"), (8192, "high"), (32768, "max")])
+def test_translate_thinking_budget_for_deepseek(budget, expected):
+    from nlp_service.services.providers import translate_thinking_budget
+    assert translate_thinking_budget("deepseek", "extract", budget) == expected
+```
+
+Run: PASS already from Phase 2.3 — re-asserting the contract.
+
+- [ ] **Step 2: Retry on 429**
+
+```python
+def test_deepseek_retries_on_429(mocker):
+    calls = {"n": 0}
+    class Resp:
+        def __init__(self, status):
+            self.status_code = status
+            self.text = "rate"
+        def json(self):
+            return {"choices":[{"message":{"content":"{}"},"finish_reason":"stop"}],"usage":{}}
+    def fake_post(self, url, json=None, **kw):
+        calls["n"] += 1
+        return Resp(429) if calls["n"] < 2 else Resp(200)
+    mocker.patch("httpx.Client.post", fake_post)
+    mocker.patch("time.sleep", lambda *_: None)
+    from nlp_service.services.providers.deepseek import DeepSeekProvider
+    from nlp_service.services.providers.base import LLMRequest
+    p = DeepSeekProvider()
+    p.complete(LLMRequest(model="deepseek-v4-pro", messages=[{"role":"user","content":"x"}], response_model=None, thinking_budget=0, max_output_tokens=10, temperature=0.0, step="t"))
+    assert calls["n"] == 2
+```
+
+- [ ] **Step 3: Discount-boundary test**
+
+```python
+def test_deepseek_pricing_flips_at_discount_until(monkeypatch):
+    from nlp_service.services.providers.deepseek import _prices_now, DISCOUNT_UNTIL
+    import datetime as _dt
+    class _F(_dt.datetime):
+        @classmethod
+        def now(cls, tz=None): return DISCOUNT_UNTIL - _dt.timedelta(seconds=1)
+    monkeypatch.setattr("nlp_service.services.providers.deepseek.datetime", _F)
+    assert _prices_now()["input"] < 0.10  # discount
+    class _A(_dt.datetime):
+        @classmethod
+        def now(cls, tz=None): return DISCOUNT_UNTIL + _dt.timedelta(seconds=1)
+    monkeypatch.setattr("nlp_service.services.providers.deepseek.datetime", _A)
+    assert _prices_now()["input"] >= 0.20  # list
+```
+
+- [ ] **Step 4: Run all and commit**
+
+Run: `pytest nlp-service/services/providers/test_providers.py -v`
+Expected: PASS — all DeepSeek tests green.
+
+```bash
+git add nlp-service/services/providers/test_providers.py
+git commit -m "test(llm): cover DeepSeek retry and discount-boundary"
+```
+
+##### Task 4.3: Wire `DeepSeekProvider` into `providers/__init__.py` factory
+
+**Files:**
+- Modify: `nlp-service/services/providers/__init__.py`
+
+- [ ] **Step 1: RED — flip the existing dispatch test**
+
+Update `test_get_provider_dispatches_by_prefix` (Phase 2.3 wrote it) so `deepseek-v4-pro` now expects `DeepSeekProvider`, not `NotImplementedError`. The test goes RED.
+
+- [ ] **Step 2: GREEN**
+
+Replace the `NotImplementedError` branch with:
+```python
+if model.startswith("deepseek-"):
+    from .deepseek import DeepSeekProvider
+    return _REGISTRY.setdefault("deepseek", DeepSeekProvider())
+```
+
+- [ ] **Step 3: Run a live smoke call (gated)**
+
+Skip if `DEEPSEEK_API_KEY` not set. When set, run one extract on the smallest source in `test_corpus/`; assert response carries `_log_usage` line `[deepseek] step=extract`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add nlp-service/services/providers/__init__.py nlp-service/services/providers/test_providers.py
+git commit -m "feat(llm): wire DeepSeekProvider into provider factory"
+```
+
+#### Phase 4 PR checklist
+
+- [ ] **Spec first:** `docs/plans/phase_4_spec.md` exists and covers `DeepSeekProvider` shape, retry semantics, the `DISCOUNT_UNTIL` constant + env overrides, the `DEEPSEEK_RPM=60` default and rationale, and the `_log_usage` `[deepseek]` prefix
+- [ ] **Tests first:** JSON-format injection, reasoning-effort translation, retry on 429, discount-boundary tests all red before implementation
+- [ ] **Implement:** `providers/deepseek.py` exists; factory wires `deepseek-*`; live smoke call passes when key is present
+- [ ] **Spec alignment review:** prices match published rates as of fetch date (record fetch URL + date in the spec); `DISCOUNT_UNTIL` matches DeepSeek's published deadline 2026-05-31T15:59:00Z
+- [ ] **Code quality review:** own rate limiter (not borrowed from Gemini); own retry loop semantics; usage field names match DeepSeek's actual response shape
+- [ ] **Final code review:** `gitnexus_detect_changes` shows `providers/deepseek.py`, `providers/__init__.py`, `providers/test_providers.py` only; CI green; ready to merge
+
+#### Phase 4 kickoff checklist
+
+- [ ] 4.1 — JSON-format injection test (RED → GREEN); `DeepSeekProvider.complete` shipped
+- [ ] 4.2 — translation, retry, discount-boundary tests green
+- [ ] 4.3 — factory wired; live smoke call (when key present) green
+- [ ] One commit per task; CI green
+
+---
+
+### Phase 5 — Wire `docker-compose.yml` + `main.py` startup_check + `/api/health` flags
+
+**Why:** Without these wirings, the Settings UI in Phase 6 can't gate the dropdown options, and operators get a silent `undefined` instead of a clear startup warning when the key is missing (Quirk #5).
+
+**Depends on:** Phase 4 (`DeepSeekProvider` exists so `main.py` can import-check it).
+
+**Status:** Not started.
+
+**5.1** Edit `docker-compose.yml`: add `DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}` to both `app.environment` (~line 45) and `nlp-service.environment` (~line 80) blocks adjacent to the existing `GEMINI_API_KEY` lines.
+
+**5.2** If `.env.example` exists at repo root, append `DEEPSEEK_API_KEY=` (empty default) with a one-line comment pointing to `https://api-docs.deepseek.com`.
+
+**5.3** Update `scripts/integration-test.sh` Stage 1 env loop to regression-guard `DEEPSEEK_API_KEY` alongside the existing `GEMINI_API_KEY` and `FIRECRAWL_API_KEY` checks.
+
+**5.4** Edit `nlp-service/main.py:86`: `startup_check` warns if neither `GEMINI_API_KEY` nor `DEEPSEEK_API_KEY` is set; logs an info line if both are present (only one is consulted per call). The deprecated `@app.on_event("startup")` decorator stays in Phase 1 — switch to FastAPI lifespan in a separate cleanup PR.
+
+**5.5** Edit `nlp-service/main.py:102`: `/health` response gains `provider_keys: {gemini: bool, deepseek: bool}`.
+
+**5.6** Edit `app/src/app/api/health/route.ts`: extend response with `provider_keys: { gemini_present: !!process.env.GEMINI_API_KEY, deepseek_present: !!process.env.DEEPSEEK_API_KEY }` (presence-only, no outbound network probe).
+
+**Why sequential, not parallel:** Each file is small, but they form a chain (compose → integration-test → backend health → frontend health). Sequencing avoids reasoning about partial states.
+
+#### Phase 5 — File structure
+
+- Modify: `docker-compose.yml` `app.environment` (~line 45) AND `nlp-service.environment` (~line 80)
+- Modify: `.env.example` (if present at repo root)
+- Modify: `scripts/integration-test.sh` Stage 1 env loop
+- Modify: `nlp-service/main.py:86, :102`
+- Modify: `app/src/app/api/health/route.ts`
+
+#### Phase 5 — Tasks
+
+##### Task 5.1: docker-compose + .env.example + integration-test guard
+
+- [ ] **Step 1: Edit `docker-compose.yml`**
+
+Add to `app.environment`:
+```yaml
+      DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
+```
+Add the same line to `nlp-service.environment`.
+
+- [ ] **Step 2: If `.env.example` exists, append**
+
+```bash
+# https://api-docs.deepseek.com
+DEEPSEEK_API_KEY=
+```
+
+- [ ] **Step 3: Update `scripts/integration-test.sh` Stage 1**
+
+Add `DEEPSEEK_API_KEY` to the env-loop array alongside `GEMINI_API_KEY` and `FIRECRAWL_API_KEY`.
+
+- [ ] **Step 4: Validate compose**
+
+Run: `docker compose -f docker-compose.yml config`
+Expected: exit 0; both `GEMINI_API_KEY` and `DEEPSEEK_API_KEY` substituted.
+
+- [ ] **Step 5: Run integration-test stage 1**
+
+Run: `bash scripts/integration-test.sh --stage 1`
+Expected: PASS — env-presence checks pass with both keys set, fail loudly with either missing (loop covers both).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docker-compose.yml .env.example scripts/integration-test.sh
+git commit -m "chore(env): wire DEEPSEEK_API_KEY through compose + integration test"
+```
+
+##### Task 5.2: `nlp-service/main.py` startup + /health
+
+**Files:**
+- Modify: `nlp-service/main.py:86, :102`
+
+- [ ] **Step 1: RED — `/health` test asserts `provider_keys` shape**
+
+```python
+def test_health_exposes_provider_keys():
+    from fastapi.testclient import TestClient
+    from nlp_service.main import app
+    c = TestClient(app)
+    r = c.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert "provider_keys" in body
+    assert set(body["provider_keys"].keys()) == {"gemini", "deepseek"}
+```
+
+Run: `pytest nlp-service/tests/test_main.py::test_health_exposes_provider_keys -v` → FAIL.
+
+- [ ] **Step 2: GREEN**
+
+Today the route returns a Pydantic `HealthResponse(status="ok")` model — extend that model with the `provider_keys` field, don't switch to a bare dict.
+
+```python
+# extend HealthResponse model in the same file
+class _ProviderKeys(BaseModel):
+    gemini: bool
+    deepseek: bool
+
+class HealthResponse(BaseModel):
+    status: str
+    provider_keys: _ProviderKeys
+
+# at :86 startup_check, replace the existing single-key warning
+gemini_key   = os.environ.get("GEMINI_API_KEY", "").strip()
+deepseek_key = os.environ.get("DEEPSEEK_API_KEY", "").strip()
+if not gemini_key and not deepseek_key:
+    logger.warning("Neither GEMINI_API_KEY nor DEEPSEEK_API_KEY is set; LLM endpoints will fail.")
+
+# at :103 /health response
+return HealthResponse(
+    status="ok",
+    provider_keys=_ProviderKeys(gemini=bool(gemini_key), deepseek=bool(deepseek_key)),
+)
+```
+
+- [ ] **Step 3: GREEN test**
+
+Run: `pytest nlp-service/tests/test_main.py::test_health_exposes_provider_keys -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add nlp-service/main.py nlp-service/tests/test_main.py
+git commit -m "feat(health): expose provider_keys flags in /health"
+```
+
+##### Task 5.3: `app/src/app/api/health/route.ts` mirror
+
+- [ ] **Step 1: Read existing route**
+
+```bash
+cat app/src/app/api/health/route.ts
+```
+
+- [ ] **Step 2: Edit response body**
+
+Add to the JSON the route returns:
+```ts
+provider_keys: {
+  gemini_present: !!process.env.GEMINI_API_KEY,
+  deepseek_present: !!process.env.DEEPSEEK_API_KEY,
+},
+```
+
+- [ ] **Step 3: Verify**
+
+Run (with the dev server up): `curl http://localhost:3000/api/health | jq .provider_keys`
+Expected: `{"gemini_present": <bool>, "deepseek_present": <bool>}`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/app/api/health/route.ts
+git commit -m "feat(health): expose provider_keys flags in Next.js /api/health"
+```
+
+#### Phase 5 PR checklist
+
+- [ ] **Spec first:** `docs/plans/phase_5_spec.md` exists and lists the env wiring locations, the `/health` JSON schema delta, and the integration-test-stage-1 guard
+- [ ] **Tests first:** `/health` provider_keys test red before backend implementation; integration-test stage 1 adapts to require `DEEPSEEK_API_KEY`
+- [ ] **Implement:** docker-compose has both env entries in both services; `.env.example` updated; integration-test stage 1 covers both keys; nlp-service `/health` and Next.js `/api/health` both return provider_keys
+- [ ] **Spec alignment review:** field names exactly `gemini` / `deepseek` (nlp-service) and `gemini_present` / `deepseek_present` (Next.js) — Phase 6 reads the latter; mismatch breaks the dropdown gate
+- [ ] **Code quality review:** no outbound key probe in either health route; warnings only, no hard failure if both keys missing (operator may be running tests without LLMs)
+- [ ] **Final code review:** `docker compose config` exits 0; both `curl` checks return expected shape; CI green; ready to merge
+
+#### Phase 5 kickoff checklist
+
+- [ ] 5.1 — docker-compose env entries added; .env.example updated; integration-test stage 1 guard extended; `docker compose config` exit 0
+- [ ] 5.2 — nlp-service startup_check warns when neither key present; `/health` returns `provider_keys`; test green
+- [ ] 5.3 — Next.js `/api/health` returns `provider_keys` with the `_present` suffix
+- [ ] One commit per task; CI green
+
+---
+
+### Phase 6 — Settings UI: expand `CHAT_MODELS`, add optgroups, gate by health flag, expand validators, update copy
+
+**Why:** This is the user-visible delivery. Operators discover DeepSeek via the dropdown, see disabled-with-tooltip when their key isn't set, and pick `deepseek-v4-pro` to opt in for that session. CLAUDE.md gotcha — per-session model lock already accepts arbitrary string, so no migration.
+
+**Depends on:** Phase 5 (`/api/health` returns `provider_keys`).
+
+**Status:** Not started.
+
+**6.1** Edit `app/src/lib/db.ts:2530-2534`: add `'deepseek-v4-pro'` to `CHAT_MODELS` const (single explicit pin, no floating aliases). `isChatModel` validator at `:2538` picks up the new entry automatically. Add helper `getProviderForModel(m: string): 'gemini' | 'deepseek'` based on prefix.
+
+**6.2** Edit `app/src/app/api/settings/route.ts:228, :238`: error strings now list expanded model set. Validation already routes through `isChatModel`.
+
+**6.3** Edit `app/src/app/settings/page.tsx:1095-1112` (compile dropdown) and `:1160-1177` (chat dropdown): restructure both `<select>` blocks with grouped `<optgroup label="Gemini">` and `<optgroup label="DeepSeek">`. DeepSeek option: `disabled={!healthData?.provider_keys?.deepseek_present}`, `title="Set DEEPSEEK_API_KEY in your environment to enable"`.
+
+**6.4** Edit `app/src/app/settings/page.tsx:1083-1092` (compile copy) and `:1152-1156` (chat copy): drop the word "Gemini" from descriptions ("Which model the compile pipeline uses…"). Health data fetched via existing settings page load (no new API call).
+
+**Why sequential, not parallel:** All UI edits land in two files (`db.ts`, `settings/page.tsx`); manual matrix walk at the end requires a single coherent state.
+
+#### Phase 6 — File structure
+
+- Modify: `app/src/lib/db.ts:2530-2534, :2538` — `CHAT_MODELS` expansion + `getProviderForModel` helper
+- Modify: `app/src/app/api/settings/route.ts:228, :238` — error strings
+- Modify: `app/src/app/settings/page.tsx:1083-1112, :1152-1177` — copy + dropdown restructure
+
+#### Phase 6 — Tasks
+
+##### Task 6.1: Expand `CHAT_MODELS` + `getProviderForModel` helper
+
+- [ ] **Step 1: Read current `CHAT_MODELS`**
+
+```bash
+sed -n '2525,2545p' app/src/lib/db.ts
+```
+
+- [ ] **Step 2: Edit `CHAT_MODELS` and add helper**
+
+Replace `:2530-2534`:
+```ts
+export const CHAT_MODELS = [
+  'gemini-2.5-flash-lite',
+  'gemini-2.5-flash',
+  'gemini-2.5-pro',
+  'deepseek-v4-pro',
+] as const;
+```
+
+Add below `isChatModel`:
+```ts
+export function getProviderForModel(m: string): 'gemini' | 'deepseek' {
+  if (m.startsWith('deepseek-')) return 'deepseek';
+  return 'gemini';
+}
+```
+
+- [ ] **Step 3: Update settings POST validator error strings at `app/src/app/api/settings/route.ts:228, :238`**
+
+The error strings list the valid model set. Update them to include `'deepseek-v4-pro'` so a 400 response remains accurate.
+
+- [ ] **Step 4: Type-check**
+
+Run: `cd app && npm run typecheck`
+Expected: PASS — `'deepseek-v4-pro'` is now a valid `ChatModel`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/lib/db.ts app/src/app/api/settings/route.ts
+git commit -m "feat(settings): allow deepseek-v4-pro in CHAT_MODELS + provider helper"
+```
+
+##### Task 6.2: Settings page dropdowns + copy
+
+**Files:**
+- Modify: `app/src/app/settings/page.tsx:1083-1112, :1152-1177`
+
+- [ ] **Step 1: Read both dropdown blocks**
+
+```bash
+sed -n '1080,1115p' app/src/app/settings/page.tsx
+sed -n '1150,1180p' app/src/app/settings/page.tsx
+```
+
+- [ ] **Step 2: Restructure compile dropdown with optgroups**
+
+Pattern (apply to both compile and chat dropdowns):
+```tsx
+<select value={compileModel} onChange={…}>
+  <optgroup label="Gemini">
+    <option value="gemini-2.5-flash-lite">Flash Lite</option>
+    <option value="gemini-2.5-flash">Flash</option>
+    <option value="gemini-2.5-pro">Pro</option>
+  </optgroup>
+  <optgroup label="DeepSeek">
+    <option
+      value="deepseek-v4-pro"
+      disabled={!healthData?.provider_keys?.deepseek_present}
+      title={healthData?.provider_keys?.deepseek_present
+        ? undefined
+        : "Set DEEPSEEK_API_KEY in your environment to enable"}
+    >
+      V4 Pro
+    </option>
+  </optgroup>
+</select>
+```
+
+- [ ] **Step 3: Update copy at `:1083-1092` and `:1152-1156`**
+
+Drop the word "Gemini" — for example, "Which Gemini model the compile pipeline uses…" → "Which model the compile pipeline uses…".
+
+- [ ] **Step 4: Manual matrix walk (the verification)**
+
+Start the dev server: `cd app && npm run dev`. For each of the four key combinations:
+- Only `GEMINI_API_KEY` set: DeepSeek option should appear disabled with tooltip; selecting Gemini saves cleanly
+- Only `DEEPSEEK_API_KEY` set: Gemini options disabled; selecting `deepseek-v4-pro` saves cleanly; subsequent compile uses DeepSeek
+- Both set: both selectable; switching saves cleanly
+- Neither set: both groups disabled; settings save still works (per-session lock not engaged); banner / tooltip directs to env file
+
+For each combination, kick off one small compile and assert the per-session lock at `compile_progress.compile_model` matches the selection.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/app/settings/page.tsx
+git commit -m "feat(ui): optgrouped Gemini/DeepSeek model dropdowns gated by health flags"
+```
+
+#### Phase 6 PR checklist
+
+- [ ] **Spec first:** `docs/plans/phase_6_spec.md` exists and lists the four-corner manual matrix, the optgroup structure, the disabled+tooltip behaviour, and the copy edits
+- [ ] **Tests first:** `npm run typecheck` is green pre-edit (so the type-error after `CHAT_MODELS` expansion is the RED signal); manual matrix is the integration-level "test"
+- [ ] **Implement:** `CHAT_MODELS` expanded; `getProviderForModel` helper added; both dropdowns optgrouped; copy provider-neutral
+- [ ] **Spec alignment review:** the per-session lock writes the model string (`deepseek-v4-pro`) verbatim to `compile_progress.compile_model`; `getEffectiveCompileModel` returns it on next call; subsequent extract dispatches to `DeepSeekProvider`
+- [ ] **Code quality review:** no inline string lists of models in the page (uses `CHAT_MODELS`); no fake "free trial" / "estimated cost" copy that would falsify the discount window
+- [ ] **Final code review:** the four manual-matrix corners walked and recorded in PR description; CI green; ready to merge
+
+#### Phase 6 kickoff checklist
+
+- [ ] 6.1 — `CHAT_MODELS` expanded; `getProviderForModel` helper added; settings POST validator error strings updated; typecheck green
+- [ ] 6.2 — both dropdowns optgrouped; copy provider-neutral
+- [ ] 6.2 — four-corner manual matrix walked: only-Gemini, only-DeepSeek, both, neither — recorded in PR description
+- [ ] One commit per task; CI green
+
+---
+
+### Phase 7 — End-to-end re-validation against `nlp-service/test_corpus/`
+
+**Why:** Spec section 7 demands a 28-call analogue against the preserved corpus through the new dispatched path. Each source extracts clean on Gemini AND DeepSeek; quality (entity counts) within ±10% of the spike baseline. This is the single observation that proves the abstraction churn didn't regress quality.
+
+**Depends on:** Phases 1–6 all green and merged.
+
+**Status:** Not started.
+
+**7.1** Run the existing corpus through Gemini via the new dispatched path. Capture per-source entity counts. Diff against the spike baseline.
+
+**7.2** Run the same corpus through DeepSeek. Capture per-source entity counts. Compare.
+
+**7.3** Compare both against the original 28-call spike numbers. Tolerance: ±10% per source.
+
+**7.4** Record results in `validation/2026-05-XX-multi-provider/` (or `/data/sv_results/`, per CLAUDE.md preference for not committing validation artifacts).
+
+**Why sequential, not parallel:** End-to-end is one observation; parallel runs muddy the rate-limiter accounting.
+
+#### Phase 7 — File structure
+
+- Reuse: `nlp-service/test_corpus/` (7 sources + manifest)
+- Create (off-branch or in `validation/`): `validation/2026-05-XX-multi-provider/results.json` — recorded baseline + per-source comparison
+- No code changes; this phase is a verification phase
+
+#### Phase 7 — Tasks
+
+##### Task 7.1: Run corpus through Gemini and DeepSeek
+
+- [ ] **Step 1: Set both keys, kick off the corpus runner**
+
+Run: `bash scripts/integration-test.sh --stage 4 --corpus all --provider gemini`
+Run: `bash scripts/integration-test.sh --stage 4 --corpus all --provider deepseek`
+
+(If the runner doesn't take a `--provider` flag, run twice with the corresponding model-string env override.)
+
+- [ ] **Step 2: Capture per-source entity counts**
+
+Read produced page JSON. Tally entity count per source. Save to `validation/2026-05-XX-multi-provider/results.json` with shape:
+```json
+{
+  "gemini":   {"<source_id>": {"entities": N, "concepts": M, "claims": K, "salvage_attempts": 0}, …},
+  "deepseek": {"<source_id>": {"entities": N, "concepts": M, "claims": K, "salvage_attempts": 0}, …}
+}
+```
+
+- [ ] **Step 3: Diff against spike baseline**
+
+For each provider × source: assert entity count within ±10% of the recorded baseline. If any source breaches the tolerance, **stop and investigate** — open issue, do not merge Phase 7.
+
+- [ ] **Step 4: Record outcome in PR description**
+
+Single table per provider × source. Anything outside tolerance gets a remediation row.
+
+- [ ] **Step 5: No commit (validation artifacts off-branch). Tag the verified-merge state.**
+
+```bash
+git tag -a feat-multi-provider-llm-verified -m "Phase 7 corpus revalidation green"
+git push --tags
+```
+
+#### Phase 7 PR checklist
+
+- [ ] **Spec first:** `docs/plans/phase_7_spec.md` defines the corpus surface (which 7 sources), the entity-count metric, the ±10% tolerance, and the recording format
+- [ ] **Tests first:** the spike baseline is the test fixture; the new run is asserted against it
+- [ ] **Implement:** N/A (verification only) — both providers run on the full corpus, results captured
+- [ ] **Spec alignment review:** every source's count delta within tolerance; salvage_attempts == 0 on DeepSeek per spike
+- [ ] **Code quality review:** N/A
+- [ ] **Final code review:** results table embedded in the merge-PR description; CI green on the branch; ready to merge
+
+#### Phase 7 kickoff checklist
+
+- [ ] 7.1 — both providers run on the full corpus; entity counts captured
+- [ ] 7.1 — every per-source delta within ±10% of spike baseline
+- [ ] 7.1 — results recorded in `validation/…/results.json` (or `/data/sv_results/`)
+- [ ] Tag pushed; branch ready for merge
+
+---
+
+## Risks + escape hatches
+
+- **Risk:** Per-session lock with rotated keys: a session locked to `deepseek-v4-pro` fails mid-session if the operator removes `DEEPSEEK_API_KEY` (Quirk #8). **Hatch:** First-call returns a clear error from `DeepSeekProvider.__init__` (`RuntimeError: DEEPSEEK_API_KEY not set`); document in operator guide; lifespan-time check is per-process and cannot catch mid-run rotations — accept and document.
+- **Risk:** Pricing-cap drift across providers — `/data/llm-cap.json` is dollar-denominated, so mixing providers within a day works correctly, but the hardcoded `"Daily Gemini spend"` message at `nlp-service/services/llm_client.py:287` would mislead an operator. **Hatch:** Phase 2.4 generalises the message to `"Daily LLM spend"`. Closed in this plan, not deferred.
+- **Risk:** Free-form call sites (`draft_page`, `generate_schema`, `generate_digest`) carry no `response_format` requirement, so DeepSeek serves them — but creative-text style differs from Gemini. **Hatch:** Quality risk, not correctness. Manual eyeball review of one drafted page per provider before promoting in Settings UI; out of automated test scope; document in Phase 7 PR description.
+- **Risk:** Stale 30s `_thinking_cache` (`nlp-service/services/llm_client.py:183`) means a newly-set provider key takes up to 30s to pick up. **Hatch:** Acceptable — document in operator guide; CLAUDE.md gotcha pattern (cache TTLs are intentional).
+- **Risk:** `_RETRYABLE_STATUSES` (`nlp-service/services/llm_client.py:351`) was tuned for Gemini's error model. **Hatch:** DeepSeek docs confirm 408/429/500/502/503/504 retry semantics hold; same set works on DeepSeek (now lives in `providers/deepseek.py` with the same constant). Verified at Phase 4.2 retry test.
+- **Risk:** The 8 schema-bound call-site conversion in Phase 3 is the highest-risk refactor; a `system_instruction` regression at any one of them would silently degrade output quality. **Hatch:** Phase 3.1 includes JSON-output baseline diff (±10% entity-count tolerance) on a known fixture from `nlp-service/test_corpus/`; any breach stops the phase before Phase 4 begins.
+- **Risk:** The existing test fixtures use `mocker.patch` on Gemini-specific surfaces; after Phase 2 the patch targets must be repointed. **Hatch:** Phase 2.5 explicitly repoints all `client.models.generate_content` mocks at `providers.gemini.GeminiProvider.complete`; the `pytest -v` run gate at Phase 2.2 step 7 catches any miss.
+- **Risk:** Discount-window math relies on container clock being UTC (Quirk #12). **Hatch:** Docker containers default to UTC; verify in Phase 4 spec; if a deploy ends up on local TZ, the env overrides `DEEPSEEK_INPUT_USD_PER_M` etc. let the operator pin pricing manually.
+- **Risk:** DeepSeek's `prompt_cache_hit_tokens` field name might drift if their API changes; we'd silently undercount cache discount. **Hatch:** Phase 4.1's `_log_usage` emits `cache_hit=N` so an operator watching logs sees the value; if it's persistently 0 against expectations, the field name has drifted — fix-forward.
+- **Risk:** The `npx gitnexus@1.6.1 analyze` re-index after phase commits — pinned 1.6.1 because 1.6.3 has Windows EPERM-symlinks and 1.6.2 fails arborist (CLAUDE.md). **Hatch:** Don't bump the gitnexus pin in this plan; if the version becomes blocking, separate plan.
+
+---
+
+## Done definition for the whole plan
+
+- All 7 phases merged to `feat/multi-provider-llm`, then merged to `main`
+- `pytest nlp-service/services/providers/test_providers.py` — green, including factory dispatch (gemini-* / deepseek-* / unknown), JSON-format injection, reasoning_effort translation, price-discount boundary, retry semantics
+- `pytest nlp-service/tests/test_llm_client.py` — green; mocks repointed at `providers.gemini.GeminiProvider.complete`
+- `docker compose -f docker-compose.yml config` — exits 0 with both `GEMINI_API_KEY` and `DEEPSEEK_API_KEY` substituted
+- `curl http://localhost:3000/api/health | jq .provider_keys` — returns `{gemini_present: bool, deepseek_present: bool}`
+- Settings UI four-corner matrix walked and recorded in the merge-PR description: only-Gemini, only-DeepSeek, both, neither — dropdown disabled-with-tooltip behaviour matches expectation in each
+- All 7 sources in `nlp-service/test_corpus/` extract clean on Gemini AND on DeepSeek through the new dispatched path; entity count per source within ±10% of the spike baseline
+- 0 salvage attempts logged on DeepSeek across the full corpus run (matches the 28-call spike result)
+- `_log_usage` emits `[gemini] step=…` for Gemini calls and `[deepseek] step=… cache_hit=…` for DeepSeek calls
+- `nlp-service/services/llm_client.py` shrinks from 1794 lines to ≤1200 lines (provider helpers moved out)
+- `scripts/integration-test.sh --stage 1` regression-guards `DEEPSEEK_API_KEY` alongside `GEMINI_API_KEY` and `FIRECRAWL_API_KEY`
+- `gitnexus_detect_changes` shows the expected file scope: `nlp-service/services/providers/`, `nlp-service/services/llm_client.py`, `nlp-service/main.py`, `app/src/lib/db.ts`, `app/src/app/settings/page.tsx`, `app/src/app/api/health/route.ts`, `app/src/app/api/settings/route.ts`, `docker-compose.yml`, `scripts/integration-test.sh`, `.env.example` (if present)
+- Existing CI integration test stages 0,1,4,11,12,13,20,21 still pass
+
+---
+
+## References
+
+- Capability roadmap: `docs/Tui-read.me`; execution source of truth: this plan
+- CLAUDE.md project instructions: `d:\KomplCore\CLAUDE.md` — non-negotiable architecture rules, gotchas, n8n workflow map, gitnexus self-check
+- Source spec / planning artifact (this plan formalises): `~/.claude/plans/plan-the-streaming-detector-ancient-candle.md` (the **superseded streaming-detector mitigation, never executed**, drafted 2026-04-XX)
+- LLM call-parameter source of truth: `nlp-service/services/llm_client.py` (12+ call sites; CLAUDE.md gotcha)
+- LLM-test second source of truth: `nlp-service/tests/test_llm_client.py` (asserts thinking_budget / max_output_tokens / temperature values)
+- Per-session lock pattern: `app/src/lib/db.ts:1447` `getEffectiveCompileModel()`; per-session column `compile_progress.compile_model` (migration v20)
+- Settings dropdown source of truth: `app/src/app/settings/page.tsx:1095-1112, :1160-1177` and `app/src/lib/db.ts:2530-2534`
+- Health endpoints: `nlp-service/main.py:102` and `app/src/app/api/health/route.ts`
+- Validation corpus: `nlp-service/test_corpus/` (7 sources + manifest preserved on `feat/multi-provider-llm`)
+- Decision-rationale memory: `feedback_collab_working_style.md` (research-first for stale-prone tools, parallel-agent coordination)
+- DeepSeek API docs (fetched 2026-05-05): `https://api-docs.deepseek.com/api/create-chat-completion` — `response_format`, `reasoning_effort`, `prompt_cache_hit_tokens` field
+- DeepSeek pricing page (fetched 2026-05-05): `https://api-docs.deepseek.com/quick_start/pricing` — discount window through 2026-05-31T15:59:00Z, list rates after
+- google-genai SDK retry context (research artifact section 3): `docs/research/2026-04-09-llm-compile.md`
+- Skill source: `~/.claude/skills/implementation-plan-creator/SKILL.md` (canonical) and `~/Documents/implementation-plan-creator-rules.md` (working draft)

--- a/docs/plans/phase_1_spec.md
+++ b/docs/plans/phase_1_spec.md
@@ -1,0 +1,89 @@
+# Phase 1 Spec — Append `"json"` trailer to 7 system prompts
+
+**Plan:** [docs/plans/2026-05-05-deepseek-second-llm-provider.md](2026-05-05-deepseek-second-llm-provider.md)
+**Branch:** `feat/multi-provider-llm`
+**Status:** Active.
+
+## Scope
+
+Append a single shared trailer string `_JSON_TRAILER` to each of the 7 LLM-facing system prompts in [nlp-service/services/llm_client.py](../../nlp-service/services/llm_client.py). No other edits.
+
+**In scope:**
+- `_LINT_SYSTEM_PROMPT` ([nlp-service/services/llm_client.py:490](../../nlp-service/services/llm_client.py#L490))
+- `_EXTRACTION_SYSTEM_PROMPT` ([nlp-service/services/llm_client.py:634](../../nlp-service/services/llm_client.py#L634))
+- `_DISAMBIGUATION_SYSTEM_PROMPT` ([nlp-service/services/llm_client.py:864](../../nlp-service/services/llm_client.py#L864))
+- `_DISAMBIGUATION_CONCEPT_SYSTEM_PROMPT` ([nlp-service/services/llm_client.py:882](../../nlp-service/services/llm_client.py#L882))
+- `_CROSSREF_SYSTEM_PROMPT` ([nlp-service/services/llm_client.py:1269](../../nlp-service/services/llm_client.py#L1269))
+- `_SELECT_PAGES_SYSTEM_PROMPT` ([nlp-service/services/llm_client.py:1519](../../nlp-service/services/llm_client.py#L1519))
+- `_SYNTHESIZE_SYSTEM_PROMPT` ([nlp-service/services/llm_client.py:1616](../../nlp-service/services/llm_client.py#L1616))
+
+**Out of scope:**
+- Any other prompt edit (no rephrasing, no trimming, no schema-hint changes beyond the trailer)
+- Provider abstraction work (Phase 2)
+- `messages=[system, user]` shape conversion (Phase 3)
+- Any DeepSeek wiring (Phase 4+)
+
+## Data contracts
+
+The trailer is a module-level constant placed immediately below `_DEFAULT_MODEL` ([nlp-service/services/llm_client.py:121](../../nlp-service/services/llm_client.py#L121)):
+
+```python
+_JSON_TRAILER = (
+    "\n\nReturn the response as a single json object matching the schema "
+    "described above. Do not include any text outside the json."
+)
+```
+
+Each of the 7 prompt constants is suffixed via string concatenation at the constant-declaration site:
+
+```python
+_LINT_SYSTEM_PROMPT = """\
+…existing body…
+""" + _JSON_TRAILER
+```
+
+The leading `\n\n` in `_JSON_TRAILER` guarantees a paragraph break regardless of whether the existing prompt body ends in `\n`.
+
+## Public API / tool / config changes
+
+None. No FastAPI route surfaces, no Pydantic models, no env vars, no DB schema, no settings keys, no docker-compose changes, no n8n workflow JSON. Internal-only string-content edit.
+
+## Success criteria
+
+1. `_JSON_TRAILER` exists exactly once as a module-level constant
+2. All 7 listed prompts end with the trailer (verifiable by `endswith` check)
+3. The literal word `"json"` appears at least once in each prompt body (DeepSeek json_object mode requirement, Quirk #1 in master plan)
+4. Existing tests in `nlp-service/tests/test_llm_client.py` covering lint/extract/disambiguate/crossref/select_pages/synthesize stay green
+5. `bash scripts/integration-test.sh --stage 4` passes against a known-good source from `nlp-service/test_corpus/`
+6. `gitnexus_detect_changes` shows only `nlp-service/services/llm_client.py` modified
+
+## Out-of-scope items
+
+(See Scope above.) Anything beyond the literal trailer append is a separate phase.
+
+## Safety constraints
+
+- **No behaviour change for Gemini.** Gemini ignores the additional natural-language instruction — the trailer is a no-op for its structured-output path. The integration-test stage 4 smoke run is the gate.
+- **No prompt body rewording.** Any temptation to "improve" the existing prompts during this pass is out of scope. Phase 1 is one variable at a time.
+- **Risk LOW per `gitnexus_impact` on `lint_scan`** — single direct caller (`pipeline_lint_scan`), no signature change, no new dependency. Same shape applies to the other 6 prompts (each used by exactly one routing function).
+
+## Test strategy
+
+- **Pre-implementation:** capture the existing pass set on the prompt-touching tests as the green baseline
+  - `pytest nlp-service/tests/test_llm_client.py -k "lint or extract or disambiguate or crossref or select_pages or synthesize" -v` — record passing test names
+- **Per-task:** after each prompt edit, re-run the same selector; expect the same passing set
+- **Phase exit:** `bash scripts/integration-test.sh --stage 4` against a known-good corpus source; entity-count output sanity-checked against expectations (no parse failures, no salvage attempts logged)
+
+## Decomposition into tasks
+
+**Task 1.1** — Add `_JSON_TRAILER` constant; append to `_LINT_SYSTEM_PROMPT`. Smallest reviewable diff that establishes the pattern.
+
+**Task 1.2** — Append `+ _JSON_TRAILER` to the remaining 6 prompts. Mechanical follow-through.
+
+Each task is a single commit. One file (`nlp-service/services/llm_client.py`) is modified across both tasks.
+
+## References
+
+- Master plan: [2026-05-05-deepseek-second-llm-provider.md](2026-05-05-deepseek-second-llm-provider.md) (Phase 1)
+- Quirk #1 (DeepSeek json_object requires the keyword): master plan Context table
+- Impact analysis ran 2026-05-05 on `lint_scan` — risk LOW, 1 direct caller

--- a/docs/plans/phase_2_spec.md
+++ b/docs/plans/phase_2_spec.md
@@ -1,0 +1,173 @@
+# Phase 2 Spec — Provider Protocol + extract Gemini logic into providers/gemini.py
+
+**Plan:** [docs/plans/2026-05-05-deepseek-second-llm-provider.md](2026-05-05-deepseek-second-llm-provider.md)
+**Branch:** `feat/multi-provider-llm`
+**Status:** Active.
+**Depends on:** Phase 1 (commits `a2af21f`, `735c91f`, `9734f9c` — `_JSON_TRAILER` + 7 prompt trailers landed; 151 nlp-service tests green; integration stages 0/1/4 PASS).
+
+## Scope
+
+Behaviour-preserving extract of all Gemini-specific surface from [nlp-service/services/llm_client.py](../../nlp-service/services/llm_client.py) into a new `nlp-service/services/providers/` package. The dispatcher (`llm_client.py`) becomes provider-agnostic; every Gemini call goes through `provider = get_provider(model); provider.complete(LLMRequest(...))`.
+
+**In scope:**
+- New package `nlp-service/services/providers/` with `__init__.py`, `base.py`, `gemini.py`, `test_providers.py`
+- Move out of `llm_client.py` into `gemini.py`:
+  - `_GEMINI_API_KEY` ([:61](../../nlp-service/services/llm_client.py#L61)), `_GEMINI_RPM` ([:62](../../nlp-service/services/llm_client.py#L62)), `_get_limiter` and `_limiter` ([:325-336](../../nlp-service/services/llm_client.py#L325))
+  - `_MODEL_PRICES`, env price overrides, `_get_model_prices` ([:89-116](../../nlp-service/services/llm_client.py#L89))
+  - `_log_usage`, `_record_usage`, `_was_truncated` ([:297-443](../../nlp-service/services/llm_client.py#L297))
+  - `_with_retry`, `_RETRYABLE_STATUSES`, `_APIError` import block ([:44-53, :351, :354-393](../../nlp-service/services/llm_client.py#L351))
+  - `get_client`, `_client` ([:474-483](../../nlp-service/services/llm_client.py#L474))
+- Rewire every LLM call site in `llm_client.py` (the 11 call sites named in the master plan) to use `provider.complete(LLMRequest(...))`
+- Generalise `"Daily Gemini spend limit"` ([:287](../../nlp-service/services/llm_client.py#L287)) → `"Daily LLM spend limit"`; docstring `"daily Gemini $ cap"` ([:217](../../nlp-service/services/llm_client.py#L217)) → `"daily LLM $ cap"`
+- Repoint test mocks in [nlp-service/tests/test_llm_client.py](../../nlp-service/tests/test_llm_client.py) from `client.models.generate_content` to `providers.gemini.GeminiProvider.complete`
+
+**Out of scope:**
+- DeepSeek implementation (Phase 4)
+- `messages=[system, user]` shape conversion at call sites (Phase 3 — Phase 2 keeps the existing system+user concatenation pattern, just routed through the Protocol)
+- Renaming `GEMINI_*` env vars to `LLM_*`
+- Switching `@app.on_event("startup")` to FastAPI lifespan
+- Touching `_DEFAULT_MODEL = "gemini-2.5-flash"` ([:121](../../nlp-service/services/llm_client.py#L121)) — the historical hardcoded safety-net default stays
+- `_salvage_extraction` ([:446](../../nlp-service/services/llm_client.py#L446)) — already provider-agnostic, stays at dispatcher layer
+- `_check_and_record_cost` ([:259](../../nlp-service/services/llm_client.py#L259)) — stays at dispatcher; provider supplies per-call cost via `provider.cost_usd(model, usage)`
+- `_read_thinking_budget` ([:186](../../nlp-service/services/llm_client.py#L186)) and the 30s `_thinking_cache` — stay at dispatcher
+
+## Data contracts
+
+### `providers/base.py`
+
+```python
+@dataclass
+class LLMRequest:
+    model: str                                   # "gemini-2.5-flash" / "deepseek-v4-pro"
+    messages: list[dict[str, str]]               # [{"role":"system","content":...}, {"role":"user","content":...}]
+    response_model: type[BaseModel] | None       # Pydantic schema for structured output, or None for free-form
+    thinking_budget: int                         # raw budget; provider translates (Gemini int, DeepSeek enum)
+    max_output_tokens: int
+    temperature: float
+    step: str                                    # log/cost-tracking label (e.g. "extract", "lint")
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class LLMResult:
+    text: str                                    # raw response text (post-parsing/concatenation)
+    parsed: BaseModel | None                     # response_model.model_validate_json(text) if requested
+    usage: dict[str, int]                        # provider-native token counts (passed through to cost calc)
+    finish_reason: str                           # "STOP" | "MAX_TOKENS" | "ERROR" | provider-specific
+
+
+class LLMProvider(Protocol):
+    name: str                                    # "gemini" / "deepseek"
+    def complete(self, req: LLMRequest) -> LLMResult: ...
+    def cost_usd(self, model: str, usage: dict[str, int]) -> float: ...
+
+
+class ProviderError(Exception): pass
+class ProviderRateLimitedError(ProviderError): pass
+class ProviderTransientError(ProviderError): pass
+```
+
+### `providers/gemini.py` — `GeminiProvider`
+
+- `name = "gemini"`
+- `complete(req)`:
+  1. Acquires the in-process pyrate-limiter token (`_get_limiter().try_acquire("gemini")`); raises `ProviderRateLimitedError` if bucket exhausted
+  2. Translates `req.messages` → genai SDK call: role=system → `system_instruction` parameter; role=user → `contents`
+  3. Builds `types.GenerateContentConfig` with `req.thinking_budget`, `req.max_output_tokens`, `req.temperature`, `response_schema=req.response_model` if set, `response_mime_type="application/json"` if structured
+  4. Wraps the call in `_with_retry` for transient errors (408/429/5xx), max 3 attempts, 0.5s base delay
+  5. Reads `usage_metadata`; emits `[gemini] step=… finish=… in=… out=… thinking=…` log line
+  6. If `req.response_model` set, parses via `response_model.model_validate_json(response.text)`
+  7. Returns `LLMResult(text=response.text, parsed=parsed, usage={...}, finish_reason=...)`
+- `cost_usd(model, usage)` reads `_MODEL_PRICES[model]` (with env overrides) and computes `(prompt-cached)*input + cached*cache + (output+thinking)*output / 1e6`
+
+The Gemini-specific log prefix `[gemini]` stays — DeepSeek will emit `[deepseek]` from its own equivalent helper in Phase 4. The grep'able pattern is the per-provider observability hook.
+
+### `providers/__init__.py` — factory
+
+```python
+def get_provider(model: str) -> LLMProvider:
+    if model.startswith("gemini-"):
+        return _REGISTRY.setdefault("gemini", GeminiProvider())
+    if model.startswith("deepseek-"):
+        raise NotImplementedError("DeepSeek provider lands in Phase 4")
+    raise ValueError(f"unknown provider for model {model!r}")
+
+def translate_thinking_budget(provider: str, call_site: str, raw: int) -> object:
+    if provider == "gemini":  return raw                   # int passthrough
+    if provider == "deepseek":
+        if raw == 0:    return "disabled"
+        if raw <= 1024: return "low"
+        if raw <= 2048: return "medium"
+        if raw <= 8192: return "high"
+        return "max"
+    raise ValueError(f"unknown provider {provider!r}")
+```
+
+`_REGISTRY` caches one instance per provider name (`GeminiProvider` is a stateful singleton because it owns the genai client and the rate-limiter bucket).
+
+## Public API / tool / config changes
+
+None visible to callers outside `nlp-service/services/`. The 11 internal call sites in `llm_client.py` change shape but their public function signatures (`extract_source(...)`, `lint_scan(...)`, etc.) and the FastAPI endpoints downstream remain identical.
+
+## Success criteria
+
+1. `providers/base.py`, `providers/gemini.py`, `providers/__init__.py`, `providers/test_providers.py` exist and import cleanly
+2. `from services.providers import get_provider; get_provider("gemini-2.5-flash")` returns a `GeminiProvider` instance
+3. `get_provider("deepseek-v4-pro")` raises `NotImplementedError`; `get_provider("anthropic-…")` raises `ValueError`
+4. Every LLM call site in `llm_client.py` constructs an `LLMRequest` and calls `provider.complete(...)` — no direct `client.models.generate_content` invocations remain
+5. `pytest nlp-service/tests/test_llm_client.py` — 7/7 green (mocks repointed)
+6. `pytest nlp-service/tests/` — 151/151 green
+7. `pytest nlp-service/services/providers/test_providers.py` — green (factory dispatch, shape, behaviour-equivalence on `_log_usage` format)
+8. `bash scripts/integration-test.sh` stages 0/1/4 — PASS
+9. `nlp-service/services/llm_client.py` line count drops below 1500 (helpers moved out; Phase 1 added 8 lines for `_JSON_TRAILER`; net target ~1100-1200)
+10. `gitnexus_detect_changes` shows scope: `nlp-service/services/llm_client.py` + `nlp-service/services/providers/*` + `nlp-service/tests/test_llm_client.py`
+
+## Out-of-scope items
+
+(See Scope above.) Phase 3 converts call-site message shapes; Phase 4 wires DeepSeek; renaming env vars is deferred per master plan.
+
+## Safety constraints
+
+- **Behaviour-preserving extract.** No semantic change for Gemini. The 151 unit tests + the integration stage 4 smoke run is the gate.
+- **One commit per task.** 2.1 (base + RED tests), 2.2 (gemini.py + rewire + mock repoint), 2.3 (factory + cost-cap message). Each commit must leave the suite green so bisect remains useful.
+- **No call-site message-shape change in Phase 2.** The temptation to convert system+user concatenation to `messages=[system, user]` while moving code is real; resist it. Phase 3 owns that conversion.
+- **No DeepSeek-shaped code in Phase 2.** The factory raises `NotImplementedError` for `deepseek-*`. Phase 4 lands the actual provider.
+- **`_thinking_cache`'s 30s TTL stays.** Stale-key warning per master plan Risks; not a Phase 2 concern.
+
+## Test strategy
+
+### Pre-implementation
+- Capture baseline: `pytest nlp-service/tests/ -v` → 151/151 green (already verified on commit `9734f9c`)
+
+### Per-task
+- **2.1** RED → GREEN: shape tests for `LLMRequest`, `LLMResult` in `providers/test_providers.py`; module-import tests
+- **2.2** RED → GREEN: `_log_usage` format equivalence test; full nlp-service suite must remain 151/151 after rewire
+- **2.3** RED → GREEN: factory dispatch test (gemini-* → instance, deepseek-* → NotImplementedError, anthropic-* → ValueError); cost-cap message test asserting the new "Daily LLM spend" string
+
+### Phase exit
+- `pytest nlp-service/tests/ nlp-service/services/providers/` — all green
+- `bash scripts/integration-test.sh` stages 0/1/4 — PASS
+- `git diff main..HEAD -- nlp-service/services/llm_client.py | wc -l` — significant reduction (provider helpers gone)
+
+## Risks + escape hatches
+
+- **Risk:** `mocker.patch("…client.models.generate_content")` in test fixtures will silently mock the wrong target after the rewire. **Hatch:** Phase 2.2 step 7 runs the full suite — failures pinpoint mocks to repoint. The plan's `gitnexus_impact` already counted these mocks as a likely +1-2h slip.
+- **Risk:** Singleton `GeminiProvider` instance caches the genai client and the rate-limiter bucket; tests that stub the env between cases could hit a stale instance. **Hatch:** Lazy initialization in `__init__` reads `_GEMINI_API_KEY` at call time, not import time; tests can `_REGISTRY.clear()` if needed (expose as `_reset_for_tests()` or similar).
+- **Risk:** Translating `messages=[system, user]` → genai `system_instruction` + `contents` may regress at call sites that today pass system+user concatenated as a single `contents` string. **Hatch:** Phase 2 keeps the existing concatenation pattern. The `complete()` adapter accepts both shapes — if `messages[0].role == "system"` the system prompt is split out; otherwise the entire payload goes into `contents`. Phase 3 converts the call sites to the explicit-roles shape. (This means Phase 2's adapter is dual-shape-tolerant; Phase 3 narrows it.)
+- **Risk:** The `[gemini] step=…` log line is the grep'able observability hook for cost-watching; moving the helper into `gemini.py` is fine, but its callers must continue invoking it on every successful response. **Hatch:** `complete()` is the sole call-site in Phase 2; it always invokes `_log_usage` before returning. One choke point.
+
+## Decomposition
+
+**Task 2.1** — `providers/base.py` Protocol + dataclasses + error hierarchy + RED+GREEN shape tests.
+
+**Task 2.2** — `providers/gemini.py` with helpers moved + `complete()` adapter + rewire all 11 LLM call sites in `llm_client.py` + repoint test mocks. Largest commit; the suite must stay 151/151 green.
+
+**Task 2.3** — `providers/__init__.py` factory + `translate_thinking_budget` helper + generalise cost-cap error message. RED+GREEN factory dispatch tests.
+
+## References
+
+- Master plan: [2026-05-05-deepseek-second-llm-provider.md](2026-05-05-deepseek-second-llm-provider.md) (Phase 2)
+- Phase 1 commits: `a2af21f`, `735c91f`, `9734f9c`
+- Existing test fixture pattern: [nlp-service/tests/test_llm_client.py](../../nlp-service/tests/test_llm_client.py) — 7 tests for draft_page + source_summary; mocks `client.models.generate_content`
+- Cookbook issue #1091 (google-genai retry semantics) — referenced in `llm_client.py` `_with_retry` docstring at [:340-348](../../nlp-service/services/llm_client.py#L340)
+- pyrate-limiter `Limiter` API — used in `_get_limiter` at [:325-336](../../nlp-service/services/llm_client.py#L325)

--- a/docs/plans/phase_3_spec.md
+++ b/docs/plans/phase_3_spec.md
@@ -1,0 +1,155 @@
+# Phase 3 Spec — messages=[system, user] conversion + per-provider input cap + Gemini-only halved fallback
+
+**Plan:** [docs/plans/2026-05-05-deepseek-second-llm-provider.md](2026-05-05-deepseek-second-llm-provider.md)
+**Branch:** `feat/multi-provider-llm`
+**Status:** Active.
+**Depends on:** Phase 2 (commits `ffd74ff`, `9e821e0`, `9c012d6` — `LLMProvider` Protocol live, `GeminiProvider` extracts done, all 11 call sites routed through `provider.complete(LLMRequest)`).
+
+## Scope
+
+Three changes that only make sense once the provider abstraction is in place:
+
+**3.1** Convert the call sites that today concatenate ``f"{SYSTEM_PROMPT}\n\n---\n\n{USER}"`` and pass it as a single user message to the explicit ``messages=[{"role": "system", ...}, {"role": "user", ...}]`` shape. This makes both providers cache better (Gemini ``system_instruction`` is independently cached; DeepSeek's ``json_object`` mode is most reliable with explicit roles) and is a pre-commitment to Phase 4's DeepSeek wiring. The 6 call sites with a corresponding ``_*_SYSTEM_PROMPT`` constant currently do this — 4 still concatenate (3 unique call sites, plus the halved-input fallback inside extract_source); the other 2 (crossref_pages, synthesize_answer) already use system_instruction and pass through Phase 2's adapter as ``messages=[system, user]``. Phase 3 converts the remaining 4.
+
+**3.2** Add a per-provider input-character cap. Empirical: DeepSeek extracted clean from a 95K-char source where Gemini hits MAX_TOKENS at 50K. Today ``_GEMINI_EXTRACT_INPUT_CAP=50000`` is hardcoded and applied unconditionally. After Phase 4 ships, a session locked to ``deepseek-v4-pro`` should get a 200K cap; Gemini sessions stay at 50K.
+
+**3.3** Gate the halved-input fallback path in ``extract_source`` by the ``gemini-*`` prefix. The fallback's "different prompt path escapes the loop" rationale is Gemini-bug-specific (the 2.5 Flash sampler enters a fixed-point attractor at MAX_TOKENS); Phase 4's DeepSeek doesn't have that pathology, and the empirical 28-call spike showed ``_salvage_extraction`` already covers any rare DeepSeek failure adequately. Halving on DeepSeek would just double cost on a failure path with no benefit.
+
+**In scope:**
+- 4 call sites in ``nlp-service/services/llm_client.py`` switching from concatenated prompt to ``messages=[system, user]``:
+  - ``lint_scan`` (line ~325)
+  - ``extract_source`` first call (line ~495)
+  - ``extract_source`` halved-input fallback (line ~575)
+  - ``disambiguate_entities`` (line ~717)
+  - ``select_pages_for_query`` (line ~1306)
+  - (5 sites total once you count the halved-input fallback as its own conversion)
+- New ``_DEEPSEEK_INPUT_CHAR_CAP = int(os.environ.get("DEEPSEEK_INPUT_CHAR_CAP", "200000"))`` in ``llm_client.py``
+- New helper ``_extract_input_cap_for(model: str) -> int`` that returns the right cap by model prefix
+- Gate the halved-input fallback in ``extract_source`` by ``model.startswith("gemini-")``; DeepSeek path raises ``LLMCompileError`` with the original parse error if salvage fails
+- Tests: assert that 5 call sites pass the explicit ``messages=[system, user]`` shape via the SDK adapter; assert ``_extract_input_cap_for`` mapping; assert Gemini-only halved-fallback gating
+
+**Out of scope:**
+- Triage call site (``triage_page_update``) — its prompt has no module-level system constant; the entire instruction is constructed inline. Phase 3 leaves it as a single user message. Splitting it requires creating a new ``_TRIAGE_SYSTEM_PROMPT`` constant which is a separate concern.
+- ``draft_page``, ``generate_schema``, ``crossref_pages``, ``synthesize_answer`` — Phase 2 already passes ``messages=[system, user]`` for these (they were never concatenated to begin with).
+- ``generate_digest`` — single user message, no separate system prompt; not converted.
+- DeepSeek implementation (Phase 4) — only the prefix gate lands here; the actual provider class stays out.
+- Removing ``_GEMINI_EXTRACT_INPUT_CAP`` — keep both constants; the helper picks the right one based on model.
+
+## Data contracts
+
+### `messages=[system, user]` shape per call site
+
+Pattern (apply 5×):
+```python
+provider = get_provider(model)
+result = provider.complete(LLMRequest(
+    model=model,
+    messages=[
+        {"role": "system", "content": _LINT_SYSTEM_PROMPT},   # the constant
+        {"role": "user",   "content": user_payload},          # the data only
+    ],
+    response_model=...,
+    thinking_budget=_read_thinking_budget('lint_scan'),
+    max_output_tokens=4096,
+    step="lint",
+    extra={"force_json_mime": True},  # or response_model=Schema, depending on call site
+))
+```
+
+Today's GeminiProvider adapter (in ``providers/gemini.py``) already routes ``messages[0].role == "system"`` to the genai SDK's ``system_instruction`` parameter and the user content to ``contents``. So the wire-level outcome is:
+
+- **Before (Phase 2):** ``client.models.generate_content(model=…, contents=f"{SYS}\n\n---\n\n{USER}", config=GenerateContentConfig(response_schema=…, thinking_config=…))``
+- **After (Phase 3):** ``client.models.generate_content(model=…, contents=USER, config=GenerateContentConfig(system_instruction=SYS, response_schema=…, thinking_config=…))``
+
+This **is** a wire-level shape change. Gemini handles ``system_instruction`` as a top-level parameter that is independently cached and prepended to the model's instruction context; concatenated text mixes it in with the user input. In our internal experience the two shapes produce semantically equivalent output for our extraction prompts, but it is not byte-for-byte identical at the model. The verification path is the integration test stage 4 smoke + a baseline JSON diff against a recorded fixture — Phase 3's exit criterion.
+
+### `_DEEPSEEK_INPUT_CHAR_CAP` + `_extract_input_cap_for`
+
+```python
+_DEEPSEEK_INPUT_CHAR_CAP = int(os.environ.get("DEEPSEEK_INPUT_CHAR_CAP", "200000"))
+
+
+def _extract_input_cap_for(model: str) -> int:
+    """Char cap on the source-document input passed to extract_source.
+
+    DeepSeek empirically handles 95K-char inputs clean (28-call spike); Gemini
+    hits MAX_TOKENS at 50K because of the structured-output repetition-loop
+    bug. Each provider gets the cap that matches its real-world capacity.
+    """
+    if model.startswith("deepseek-"):
+        return _DEEPSEEK_INPUT_CHAR_CAP
+    return _GEMINI_EXTRACT_INPUT_CAP
+```
+
+The existing ``markdown = markdown[:_GEMINI_EXTRACT_INPUT_CAP]`` truncation in ``extract_source`` becomes ``markdown = markdown[:_extract_input_cap_for(model)]``.
+
+### Halved-fallback gate
+
+In ``extract_source`` the entire halved-input retry block (the "If MAX_TOKENS, retry once with halved input" path) gets wrapped:
+
+```python
+if not model.startswith("gemini-"):
+    # DeepSeek and any future provider: salvage already failed above; don't
+    # double the cost retrying with halved input on a different upstream bug
+    # we have no evidence exists. Surface the original parse error.
+    raise LLMCompileError(f"extract_llm_parse_failed: {first_err}") from first_err
+
+# Gemini halved-input fallback below — same code as before
+```
+
+## Public API / tool / config changes
+
+None. No new env vars beyond ``DEEPSEEK_INPUT_CHAR_CAP`` (optional, has default). No FastAPI route changes. No DB schema. No settings keys. No docker-compose or n8n changes.
+
+## Success criteria
+
+1. The 5 call sites listed above all build their messages list with explicit ``role: "system"`` + ``role: "user"`` entries; no concatenated ``"\n\n---\n\n"`` prompt strings remain at any of those sites.
+2. ``_DEEPSEEK_INPUT_CHAR_CAP`` and ``_extract_input_cap_for`` exist; ``extract_source`` calls the helper.
+3. Halved-input fallback only runs when ``model.startswith("gemini-")``.
+4. ``pytest nlp-service/tests/ nlp-service/services/providers/`` — all 169 tests stay green.
+5. New tests in ``test_providers.py`` (or test_llm_client.py) cover:
+   - ``_extract_input_cap_for`` returns ``_DEEPSEEK_INPUT_CHAR_CAP`` for ``deepseek-*`` models
+   - ``_extract_input_cap_for`` returns ``_GEMINI_EXTRACT_INPUT_CAP`` for ``gemini-*`` models
+   - Halved-fallback path is taken only on ``gemini-*`` (assert via mocked provider that the fallback is skipped for a hypothetical non-Gemini model)
+6. ``bash scripts/integration-test.sh`` stages 0/1/4 — PASS.
+
+## Out-of-scope items
+
+(See Scope above.) Triage's lack of a module-level system constant is the most notable omission; address as a separate cleanup if/when DeepSeek validation surfaces a regression.
+
+## Safety constraints
+
+- **One commit per logical change.** 3.1 (messages-shape conversion) and 3.2+3.3 (input cap + halved-fallback gate) ship as two commits. Each leaves the suite 169/169 green.
+- **No silent behaviour change.** The wire-level shape change in 3.1 is the riskiest single move in the whole multi-provider effort. The 169-test gate covers all unit paths; the integration stage-4 smoke covers the boot path. A live extraction baseline diff against ``nlp-service/test_corpus/`` is the third gate (Phase 7's full corpus revalidation, deferred).
+- **DeepSeek halved-fallback gate must not be reachable by a Gemini caller.** The condition is ``not model.startswith("gemini-")`` — this is true for any unknown future provider too, which is the safer default (don't run a Gemini-bug-specific mitigation on a provider we haven't validated).
+
+## Test strategy
+
+### Pre-implementation
+- Baseline: 169/169 green (commit ``9c012d6``).
+
+### Per-task
+- **3.1** Convert one call site at a time (or in tight batches), run the relevant pytest selector, confirm green before moving to the next. Existing tests don't pin the messages shape directly, so the bulk verification is "151/151 still green; mocks intercept correctly". Add a smoke assertion in ``test_providers.py`` that mocks ``GeminiProvider.complete`` and verifies one of the converted call sites passes ``messages[0]["role"] == "system"``.
+- **3.2** RED: ``test_extract_input_cap_for_dispatches_by_prefix`` asserts gemini-* → 50000, deepseek-* → 200000.
+- **3.3** RED: ``test_halved_fallback_only_runs_on_gemini`` mocks the provider to return a MAX_TOKENS result + parse failure, asserts the second ``provider.complete`` call is made for ``gemini-2.5-flash`` and is NOT made for ``deepseek-v4-pro``.
+
+### Phase exit
+- ``pytest nlp-service/tests/ nlp-service/services/providers/`` — 169+ green.
+- ``bash scripts/integration-test.sh`` stages 0/1/4 — PASS.
+- ``git diff main..HEAD -- nlp-service/services/llm_client.py`` shows the 5 call-site message-shape edits + the cap helper + the fallback gate; no other behaviour change.
+
+## Decomposition
+
+**Task 3.1** — Convert 5 call sites to ``messages=[system, user]`` shape. One commit (the changes are mechanical and the riskiest single conversion is ``extract_source``, which has the halved-input fallback as a sibling change in the same function — keeping them in one commit gives bisect a clean checkpoint).
+
+**Task 3.2** — Add ``_DEEPSEEK_INPUT_CHAR_CAP`` + ``_extract_input_cap_for`` helper; switch ``extract_source`` to the helper.
+
+**Task 3.3** — Gate the halved-input fallback by ``model.startswith("gemini-")``. Logically tied to 3.2 (both touch ``extract_source``); ship in the same commit.
+
+## References
+
+- Master plan: [2026-05-05-deepseek-second-llm-provider.md](2026-05-05-deepseek-second-llm-provider.md) (Phase 3)
+- Phase 2 commits: ``ffd74ff``, ``9e821e0``, ``9c012d6``
+- Phase 2 spec: [phase_2_spec.md](phase_2_spec.md)
+- ``GeminiProvider.complete`` adapter: [providers/gemini.py](../../nlp-service/services/providers/gemini.py)
+- 5-spike empirical: 28/28 ok, 0 salvage attempts on DeepSeek including 95K-char source — see master plan Context table

--- a/docs/plans/phase_4_spec.md
+++ b/docs/plans/phase_4_spec.md
@@ -1,0 +1,206 @@
+# Phase 4 Spec — DeepSeekProvider implementation
+
+**Plan:** [docs/plans/2026-05-05-deepseek-second-llm-provider.md](2026-05-05-deepseek-second-llm-provider.md)
+**Branch:** `feat/multi-provider-llm`
+**Status:** Active.
+**Depends on:** Phase 3 (commits `385d8c6`, `52fd8de` — messages=[system, user] at 5 call sites; per-provider input cap + Gemini-only halved fallback gate; 174/174 tests green; real-Gemini acid test on `/pipeline/extract-llm` PASS).
+
+## Scope
+
+Implement `DeepSeekProvider` in [nlp-service/services/providers/deepseek.py](../../nlp-service/services/providers/deepseek.py) (new file). Wire it into the factory at [nlp-service/services/providers/__init__.py](../../nlp-service/services/providers/__init__.py) so `get_provider("deepseek-v4-pro")` returns the new class instead of raising `NotImplementedError`. Phase 4 lands the entire DeepSeek backend; no changes to `llm_client.py` or any call site (Phase 3 already canonicalised the `LLMRequest` shape both providers consume).
+
+**In scope:**
+- `nlp-service/services/providers/deepseek.py` (NEW) — `DeepSeekProvider` class implementing the `LLMProvider` Protocol:
+  - Constructor reads `DEEPSEEK_API_KEY` (required at first call), builds `httpx.Client(base_url="https://api.deepseek.com")`
+  - Owns its own pyrate-limiter bucket at `DEEPSEEK_RPM` (default 60)
+  - `complete(req)` posts to `/v1/chat/completions` with `model`, `messages`, `max_tokens`, `temperature`, `response_format={"type":"json_object"}` when `req.response_model is not None`, `reasoning_effort` translated via `translate_thinking_budget` when `req.thinking_budget > 0`
+  - Retry on 408/429/500/502/503/504 with exponential backoff (mirror `_with_retry`)
+  - Usage parsing: read `prompt_tokens`, `completion_tokens`, `prompt_cache_hit_tokens` from response
+  - Logs `[deepseek] step=… finish=… in=… out=… cache_hit=…`
+  - Calls back into `llm_client._check_and_record_cost` via lazy module-attribute lookup (same pattern as Gemini)
+  - Cost computation with discount-window logic
+  - Discount constants:
+    - `DISCOUNT_UNTIL = datetime(2026, 5, 31, 15, 59, 0, tzinfo=timezone.utc)`
+    - `_PRICES_DISCOUNT = {"input": 0.07, "output": 0.27, "cache": 0.014}`
+    - `_PRICES_LIST     = {"input": 0.27, "output": 1.10, "cache": 0.054}`
+  - Env overrides: `DEEPSEEK_INPUT_USD_PER_M`, `DEEPSEEK_OUTPUT_USD_PER_M`, `DEEPSEEK_CACHE_USD_PER_M`
+- Factory update: `get_provider("deepseek-v4-pro")` lazy-imports + caches a `DeepSeekProvider`
+- New tests in `services/providers/test_providers.py`:
+  - JSON-format injection (asserts `response_format={"type":"json_object"}` in the request body when `response_model` is set)
+  - Retry on 429 (one retry then succeeds)
+  - Discount-boundary (one second before `DISCOUNT_UNTIL` returns discount; one second after returns list)
+  - `[deepseek]` log line emitted with `cache_hit=N`
+  - `cost_usd` formula correctness on a known-input usage dict
+- Update the existing `test_get_provider_deepseek_raises_until_phase_4` test → `test_get_provider_dispatches_deepseek_prefix`
+
+**Out of scope:**
+- `_check_and_record_cost` rewrite to take a pre-computed `cost_usd` (Phase 4 keeps the token-shape signature; it builds a Gemini-style usage dict inside DeepSeekProvider's `complete()` and passes the right keys to `_check_and_record_cost`. This is OK because `_check_and_record_cost` now goes through `provider.cost_usd(model, usage)` — the dispatcher doesn't care about the dict's keys, the provider does.)
+- Adding `DEEPSEEK_API_KEY` to `docker-compose.yml` and `/api/health` (Phase 5)
+- Settings UI changes (Phase 6)
+- `_check_and_record_cost`'s docstring still mentions `prompt_tokens`/`cached_tokens`/etc as Gemini-shaped args — leave as-is; the DeepSeekProvider builds a dict with those exact keys before calling `cost_usd`, so the abstraction holds. Phase 4 spec deliberately does not refactor the dispatcher's cost flow.
+- Live smoke call against the real DeepSeek API (gated by key presence; Phase 4 ships the unit tests + mocked HTTP only, with optional smoke tests deferred to operator validation).
+
+## Data contracts
+
+### `DeepSeekProvider.complete(req)` request body
+
+```python
+body = {
+    "model": req.model,                                # "deepseek-v4-pro"
+    "messages": req.messages,                          # passes through, including role=system
+    "max_tokens": req.max_output_tokens,
+    "temperature": req.temperature if req.temperature is not None else 0.0,
+}
+if req.response_model is not None:
+    body["response_format"] = {"type": "json_object"}
+if req.thinking_budget > 0:
+    body["reasoning_effort"] = translate_thinking_budget("deepseek", req.step, req.thinking_budget)
+```
+
+### Response parsing
+
+```python
+# DeepSeek-specific field names (NOT Gemini's)
+choice = data["choices"][0]
+text = choice["message"]["content"]
+finish_reason = choice["finish_reason"]
+usage = {
+    "prompt_tokens":           data["usage"].get("prompt_tokens", 0),
+    "completion_tokens":       data["usage"].get("completion_tokens", 0),
+    "prompt_cache_hit_tokens": data["usage"].get("prompt_cache_hit_tokens", 0),
+}
+```
+
+### `DeepSeekProvider.cost_usd(model, usage)`
+
+```python
+prices = _prices_now()  # discount or list, optionally env-overridden
+fresh   = max(0, usage["prompt_tokens"] - usage["prompt_cache_hit_tokens"])
+cached  = usage["prompt_cache_hit_tokens"]
+output_ = usage["completion_tokens"]
+return (
+    (fresh   / 1_000_000) * prices["input"]
+  + (cached  / 1_000_000) * prices["cache"]
+  + (output_ / 1_000_000) * prices["output"]
+)
+```
+
+### `_prices_now()`
+
+```python
+def _prices_now() -> dict[str, float]:
+    base = _PRICES_DISCOUNT if datetime.now(timezone.utc) < DISCOUNT_UNTIL else _PRICES_LIST
+    return {
+        "input":  float(os.environ.get("DEEPSEEK_INPUT_USD_PER_M",  base["input"])),
+        "output": float(os.environ.get("DEEPSEEK_OUTPUT_USD_PER_M", base["output"])),
+        "cache":  float(os.environ.get("DEEPSEEK_CACHE_USD_PER_M",  base["cache"])),
+    }
+```
+
+### Cost callback into the dispatcher
+
+`DeepSeekProvider.complete()` builds a usage dict with the DeepSeek-native keys (`prompt_tokens`, `completion_tokens`, `prompt_cache_hit_tokens`) and passes the same keys to `_check_and_record_cost`. But `_check_and_record_cost`'s signature is Gemini-shaped (`prompt_tokens, cached_tokens, output_tokens, thought_tokens`). Resolution: the DeepSeek provider maps its native fields to the dispatcher's signature:
+
+```python
+from services import llm_client  # lazy
+llm_client._check_and_record_cost(
+    req.model,
+    usage["prompt_tokens"],            # -> prompt_tokens
+    usage["prompt_cache_hit_tokens"],  # -> cached_tokens
+    usage["completion_tokens"],        # -> output_tokens
+    0,                                  # -> thought_tokens (DeepSeek folds reasoning into completion_tokens)
+)
+```
+
+`_check_and_record_cost` then calls `provider.cost_usd(model, usage_for_provider)` where `usage_for_provider` is rebuilt with Gemini-shape keys. **Each provider's `cost_usd` accepts a Gemini-shape dict**: this is the unified internal interface even though wire-level field names differ. Phase 4's `DeepSeekProvider.cost_usd` translates back to its own field names internally.
+
+Specifically, in `DeepSeekProvider.cost_usd`:
+
+```python
+def cost_usd(self, model: str, usage: dict[str, int]) -> float:
+    # Dispatcher passes the Gemini-shape keys: prompt_token_count,
+    # cached_content_token_count, candidates_token_count, thoughts_token_count.
+    prices = _prices_now()
+    prompt = usage.get("prompt_token_count", 0)
+    cached = usage.get("cached_content_token_count", 0)
+    output_ = usage.get("candidates_token_count", 0) + usage.get("thoughts_token_count", 0)
+    fresh = max(0, prompt - cached)
+    return (
+        (fresh   / 1_000_000) * prices["input"]
+      + (cached  / 1_000_000) * prices["cache"]
+      + (output_ / 1_000_000) * prices["output"]
+    )
+```
+
+(The dispatcher's `_check_and_record_cost` already builds this dict before calling `provider.cost_usd` — see [llm_client.py:227](../../nlp-service/services/llm_client.py#L227).)
+
+## Public API / tool / config changes
+
+None visible to external callers. The factory's behaviour for `deepseek-*` flips from `NotImplementedError` → returning a `DeepSeekProvider` instance. Settings UI dropdown still gates DeepSeek as disabled because `/api/health.provider_keys.deepseek_present` is wired in Phase 5; Phase 4 alone makes the backend ready.
+
+## Success criteria
+
+1. `nlp-service/services/providers/deepseek.py` exists; `DeepSeekProvider.name == "deepseek"`.
+2. `from services.providers import get_provider; isinstance(get_provider("deepseek-v4-pro"), DeepSeekProvider)`.
+3. JSON-format injection test green: a mocked `httpx.Client.post` captures the request body and asserts `response_format={"type":"json_object"}` is present when `response_model` is set on the `LLMRequest`.
+4. Retry test green: mocked `httpx` returns 429 then 200; `complete()` succeeds and the post is called twice.
+5. Discount-boundary test green: mocking `datetime.now()` to return one second before `DISCOUNT_UNTIL` returns discount-rate prices; one second after returns list-rate prices.
+6. `cost_usd(model, usage)` returns the right amount for a known input dict (parameterised test with the formula).
+7. `pytest nlp-service/tests/ nlp-service/services/providers/` — all 174 + new DeepSeek tests green.
+8. The factory's `get_provider("deepseek-v4-pro")` test that previously asserted `NotImplementedError` now asserts the singleton-cached `DeepSeekProvider` instance.
+
+## Out-of-scope items
+
+(See Scope.) Phase 5 wires env, Phase 6 wires UI, Phase 7 runs the full `test_corpus/` revalidation against both providers.
+
+## Safety constraints
+
+- **No live HTTP calls in unit tests.** All DeepSeek tests mock `httpx.Client.post`. A live smoke test gated by `DEEPSEEK_API_KEY` is optional; this spec doesn't require it.
+- **DEEPSEEK_API_KEY not present should not break import.** The constructor reads the env var and raises only on first call (matching Gemini's `RuntimeError("GEMINI_API_KEY not set")` pattern at [providers/gemini.py:120](../../nlp-service/services/providers/gemini.py#L120)).
+- **Rate limiter must use a separate bucket key from Gemini.** `_get_limiter().try_acquire("deepseek")` so Gemini and DeepSeek limiters don't interfere.
+- **`_RETRYABLE_STATUSES` lives per provider.** DeepSeek's set is the same 408/429/5xx; the constant is duplicated in deepseek.py with a comment explaining why (each provider should be free to evolve its retry semantics independently).
+- **Discount window math is UTC-clock-dependent.** Docker containers default to UTC; integration tests that hit DeepSeek must keep that invariant. Operators on non-UTC TZ can override via the env price vars.
+
+## Test strategy
+
+### Pre-implementation
+- Baseline: 174/174 green (commit `52fd8de`).
+
+### Per-test (RED → GREEN)
+
+1. **Factory dispatch flip** — replace `test_get_provider_deepseek_raises_until_phase_4` with `test_get_provider_dispatches_deepseek_prefix`. Initially fails because the factory still raises `NotImplementedError`. Implement the factory branch; passes.
+
+2. **JSON-format injection** — RED test stubs `httpx.Client.post`, captures the body, asserts `response_format={"type":"json_object"}` is present when `response_model` is provided. Initially fails because `DeepSeekProvider` doesn't exist; implement; passes.
+
+3. **No JSON-format when no schema** — same harness, omit `response_model`, assert `response_format` is NOT in the body.
+
+4. **Retry on 429** — RED test stubs `httpx.Client.post` to return a 429 response on the first call and a 200 on the second; mocks `time.sleep`; asserts `complete()` succeeds and the post was called exactly twice.
+
+5. **Retry exhaustion** — three consecutive 429s; asserts a final exception (use the existing `LLMRateLimitedError` from `llm_client.py`, lazy-imported, or `ProviderTransientError` for cleaner separation). Spec: use `LLMRateLimitedError` to match the existing public-facing exception type that callers already catch.
+
+6. **Discount-boundary** — patch `datetime.now()` (via a fixture) to a known instant; assert `_prices_now()["input"]` matches discount or list rate accordingly.
+
+7. **Env override** — set `DEEPSEEK_INPUT_USD_PER_M=0.99`, assert `_prices_now()["input"] == 0.99` regardless of the wall-clock branch.
+
+8. **cost_usd formula** — parameterise over a known usage dict and assert the float result. Catches off-by-N-million errors.
+
+9. **`[deepseek]` log line emitted with cache_hit field** — capsys captures the line; assert format.
+
+### Phase exit
+- `pytest nlp-service/tests/ nlp-service/services/providers/` — all green.
+- (Optional, not required by spec) Live smoke: `curl -X POST http://localhost:8000/pipeline/extract-llm -d '{"compile_model":"deepseek-v4-pro", ...}'` returns a structured response. Operator validates outside CI.
+
+## Decomposition
+
+**Task 4.1** — Create `providers/deepseek.py` with `DeepSeekProvider`, `_prices_now`, `_PRICES_DISCOUNT`/`_PRICES_LIST`, `DISCOUNT_UNTIL`, retry semantics, usage parsing, JSON-format injection. Add the corresponding RED-then-GREEN tests in `test_providers.py`. Update the factory to dispatch `deepseek-*`. One commit.
+
+(Phase 4 is one logical unit; the spec does not subdivide it further. The plan's master file describes 3 sub-tasks (4.1, 4.2, 4.3) but in practice the sub-task split there is mostly about test ordering — the production code lives in one new file. Phase 4 ships as a single commit.)
+
+## References
+
+- Master plan: [2026-05-05-deepseek-second-llm-provider.md](2026-05-05-deepseek-second-llm-provider.md) (Phase 4)
+- Phase 3 commits: `385d8c6`, `52fd8de`
+- Phase 3 spec: [phase_3_spec.md](phase_3_spec.md)
+- DeepSeek API docs (fetched 2026-05-05): `https://api-docs.deepseek.com/api/create-chat-completion` — `response_format`, `reasoning_effort`, `prompt_cache_hit_tokens` field
+- DeepSeek pricing page (fetched 2026-05-05): `https://api-docs.deepseek.com/quick_start/pricing` — discount window through 2026-05-31T15:59:00Z, list rates after
+- Mirror reference: GeminiProvider in [providers/gemini.py](../../nlp-service/services/providers/gemini.py); the DeepSeek class follows the same shape

--- a/docs/plans/phase_5_spec.md
+++ b/docs/plans/phase_5_spec.md
@@ -1,0 +1,145 @@
+# Phase 5 Spec — env wiring + /api/health provider_keys flags
+
+**Plan:** [docs/plans/2026-05-05-deepseek-second-llm-provider.md](2026-05-05-deepseek-second-llm-provider.md)
+**Branch:** `feat/multi-provider-llm`
+**Status:** Active.
+**Depends on:** Phase 4 (commit `6940235` — `DeepSeekProvider` exists; factory dispatches `deepseek-*` correctly; 184/184 tests green).
+
+## Scope
+
+Wire `DEEPSEEK_API_KEY` end-to-end so a real-world deployment can use the Phase 4 provider, and surface key presence to the Next.js front-end so Phase 6's Settings dropdown can gate the DeepSeek option correctly.
+
+**In scope:**
+- `docker-compose.yml`: add `DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}` to both `app.environment` and `nlp-service.environment` blocks adjacent to existing `GEMINI_API_KEY` lines. The `${VAR:-}` empty-default form is required so docker compose doesn't fail on container start when the var is unset.
+- `.env.example`: append `DEEPSEEK_API_KEY=` (empty default) + one-line comment pointing operators to `https://api-docs.deepseek.com` for key issuance.
+- `scripts/integration-test.sh` Stage 1 env-loop: regression-guard `DEEPSEEK_API_KEY` alongside the existing `GEMINI_API_KEY` and `FIRECRAWL_API_KEY` checks. CLAUDE.md's gotcha is "every new `process.env.X` read needs a Stage 1 guard" — this closes that loop.
+- `nlp-service/main.py`:
+  - `startup_check` at [:86](../../nlp-service/main.py#L86): warn if **neither** `GEMINI_API_KEY` nor `DEEPSEEK_API_KEY` is set (today it warns only on missing `GEMINI_API_KEY`). The deprecated `@app.on_event("startup")` decorator stays — switching to FastAPI lifespan is a separate cleanup.
+  - `HealthResponse` model + `/health` handler at [:102](../../nlp-service/main.py#L102): extend with `provider_keys: {gemini: bool, deepseek: bool}`.
+- `app/src/app/api/health/route.ts`: extend the response body with `provider_keys: { gemini_present: !!process.env.GEMINI_API_KEY, deepseek_present: !!process.env.DEEPSEEK_API_KEY }`. Presence-only check; no outbound network probe.
+- New unit test in `nlp-service/tests/test_main.py`: assert `/health` response includes `provider_keys` shape.
+
+**Out of scope:**
+- Settings UI dropdown changes (Phase 6).
+- Live smoke against the real DeepSeek API (requires a paid key in CI; deferred to Phase 7).
+- Renaming `GEMINI_*` env vars to `LLM_*` (operator-facing breaking change, deferred per master plan).
+- Switching `@app.on_event("startup")` to FastAPI's lifespan handler.
+- `nlp-service` lifespan-time validation that the key actually authenticates against the upstream API (presence-only, matches Gemini's existing pattern).
+
+## Data contracts
+
+### `nlp-service/main.py` `/health` response
+
+```python
+class _ProviderKeys(BaseModel):
+    gemini: bool
+    deepseek: bool
+
+class HealthResponse(BaseModel):
+    status: str
+    provider_keys: _ProviderKeys
+
+
+@app.get("/health", response_model=HealthResponse)
+def health() -> HealthResponse:
+    return HealthResponse(
+        status="ok",
+        provider_keys=_ProviderKeys(
+            gemini=bool(os.environ.get("GEMINI_API_KEY", "").strip()),
+            deepseek=bool(os.environ.get("DEEPSEEK_API_KEY", "").strip()),
+        ),
+    )
+```
+
+### `app/src/app/api/health/route.ts` extension
+
+Add to the existing JSON response:
+
+```ts
+provider_keys: {
+  gemini_present: !!process.env.GEMINI_API_KEY,
+  deepseek_present: !!process.env.DEEPSEEK_API_KEY,
+},
+```
+
+The two endpoints intentionally use different field names — nlp-service `gemini`/`deepseek` and Next.js `gemini_present`/`deepseek_present`. Phase 6's Settings UI reads the Next.js endpoint; the nlp-service endpoint is for operator/CI inspection.
+
+### `docker-compose.yml` block
+
+Two adjacent additions:
+
+```yaml
+services:
+  app:
+    environment:
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
+      # ...existing entries
+  nlp-service:
+    environment:
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
+      # ...existing entries
+```
+
+### `scripts/integration-test.sh` Stage 1 env-loop
+
+Stage 1 today loops over `GEMINI_API_KEY` and `FIRECRAWL_API_KEY` checking that the host env var (when set) actually reaches the container. Extend the loop with `DEEPSEEK_API_KEY`. The check is host-side only; absence is accepted (skip), but presence-without-pass-through is a fail.
+
+## Public API / tool / config changes
+
+The `/health` and `/api/health` endpoints gain a new field. Existing clients that don't read `provider_keys` are unaffected. Phase 6 will be the first reader.
+
+## Success criteria
+
+1. `docker compose -f docker-compose.yml config` exits 0; both `GEMINI_API_KEY` and `DEEPSEEK_API_KEY` substituted in both `app` and `nlp-service` environment blocks.
+2. `curl http://localhost:8000/health | jq .provider_keys` returns `{"gemini": <bool>, "deepseek": <bool>}` after the rebuild.
+3. `curl http://localhost:3000/api/health | jq .provider_keys` returns `{"gemini_present": <bool>, "deepseek_present": <bool>}`.
+4. `bash scripts/integration-test.sh` stage 1 passes with `DEEPSEEK_API_KEY` set; loop guards against the regression where a `process.env.DEEPSEEK_API_KEY` read in Node code goes to `undefined` because compose forgot to substitute.
+5. `pytest nlp-service/tests/` + provider tests — all green (target 184+ + new test).
+6. `nlp-service` startup_check warns on stderr when neither `GEMINI_API_KEY` nor `DEEPSEEK_API_KEY` is set.
+
+## Out-of-scope items
+
+(See Scope.) Phase 6 wires the UI; Phase 7 runs corpus revalidation.
+
+## Safety constraints
+
+- **Empty-default for env vars (`${VAR:-}`).** Without it, `docker compose` fails to start the container when `DEEPSEEK_API_KEY` is unset in the host shell — that's the failure mode the CLAUDE.md gotcha explicitly warns about.
+- **Presence-only health check.** No outbound network probe to either provider. Validating the key's actual authentication needs a paid call which we don't want in `/health` (it's polled).
+- **Stage 1 host-side check, not container-side.** Stage 1 verifies the host env reaches the container; a host that lacks the key just skips the check rather than failing. This matches the existing pattern.
+- **No behavior change for sessions that don't use DeepSeek.** Operators who only set `GEMINI_API_KEY` see no functional difference; the `/health` flag just shows `deepseek: false`.
+
+## Test strategy
+
+### Pre-implementation
+- Baseline: 184/184 green (commit `6940235`).
+
+### Per-task
+- **5.1 (compose + .env.example + integration-test):** verification is `docker compose -f docker-compose.yml config` exit 0 and `bash scripts/integration-test.sh` stages 0/1/4 PASS after rebuild.
+- **5.2 (nlp-service /health):** RED test in `nlp-service/tests/test_main.py` asserting `provider_keys` shape; implement; GREEN.
+- **5.3 (Next.js /api/health):** smoke via `curl` after rebuild; the existing route has no unit test surface in the app TypeScript suite.
+
+### Phase exit
+- Full nlp-service test suite green (185+).
+- `docker compose -f docker-compose.yml config` exit 0.
+- Manual `curl` checks for both health endpoints.
+- Integration stages 0/1/4 PASS after rebuild.
+
+## Decomposition
+
+**Task 5.1** — compose + `.env.example` + integration-test stage 1 guard. Single commit; pure config wiring; no Python/TS code changes.
+
+**Task 5.2** — nlp-service `main.py` startup_check + `/health` response. RED→GREEN test. Single commit.
+
+**Task 5.3** — Next.js `/api/health` extension. Single commit.
+
+(Or one bundled commit for all three since the changes are small and sequential. Bundle if total diff is under ~80 LOC.)
+
+## References
+
+- Master plan: [2026-05-05-deepseek-second-llm-provider.md](2026-05-05-deepseek-second-llm-provider.md) (Phase 5)
+- Phase 4 commit: `6940235`
+- Phase 4 spec: [phase_4_spec.md](phase_4_spec.md)
+- CLAUDE.md gotcha: "New `process.env.X` reads need a `docker-compose.yml` `app.environment` entry" — Stage 1 of `scripts/integration-test.sh` regression-guards `GEMINI_API_KEY` + `FIRECRAWL_API_KEY`; extend the loop.
+- DeepSeek API key issuance: `https://api-docs.deepseek.com` (mentioned in `.env.example` comment for operator self-discovery)

--- a/docs/plans/phase_6_spec.md
+++ b/docs/plans/phase_6_spec.md
@@ -1,0 +1,160 @@
+# Phase 6 Spec — Settings UI: optgrouped dropdowns gated by /api/health
+
+**Plan:** [docs/plans/2026-05-05-deepseek-second-llm-provider.md](2026-05-05-deepseek-second-llm-provider.md)
+**Branch:** `feat/multi-provider-llm`
+**Status:** Active.
+**Depends on:** Phase 5 (commit `f876fbb` — `/api/health` exposes `provider_keys: {gemini_present, deepseek_present}`; nlp-service `/health` mirrors with `{gemini, deepseek}`; 188/188 tests green).
+
+## Scope
+
+Light up the Settings dropdown so an operator can pick DeepSeek as the compile or chat model. Phase 4 made `get_provider("deepseek-v4-pro")` work end-to-end; Phase 5 surfaced the key-presence flag; Phase 6 wires the front-end. The per-session lock at [app/src/lib/db.ts:1447](../../app/src/lib/db.ts#L1447) `getEffectiveCompileModel` already accepts arbitrary model strings (the `compile_progress.compile_model` column does too — migration v20). No DB schema work.
+
+**In scope:**
+- `app/src/lib/db.ts` — expand `CHAT_MODELS` const at [:2530-2534](../../app/src/lib/db.ts#L2530) to include `'deepseek-v4-pro'`. `isChatModel` validator at [:2538](../../app/src/lib/db.ts#L2538) automatically picks up the new entry. Add `getProviderForModel(m: string): 'gemini' | 'deepseek'` helper based on prefix.
+- `app/src/app/api/settings/route.ts` — error strings at [:228, :238](../../app/src/app/api/settings/route.ts#L228) list the expanded model set. Validation already routes through `isChatModel`.
+- `app/src/app/settings/page.tsx` — restructure the compile + chat `<select>` blocks ([:1095-1112, :1160-1177](../../app/src/app/settings/page.tsx#L1095)) with grouped `<optgroup label="Gemini">` and `<optgroup label="DeepSeek">`. The DeepSeek option `disabled={!healthData?.provider_keys?.deepseek_present}` + `title=` tooltip directing the operator to set the env var. Update copy ([:1083-1092, :1152-1156](../../app/src/app/settings/page.tsx#L1083)) to drop the word "Gemini" — the descriptions become provider-neutral. Health data fetched via the existing settings page load (no new API call).
+- Manual four-corner matrix walk in the dev server: only-Gemini / only-DeepSeek / both / neither — confirm the dropdown disabled+tooltip states match expectation.
+
+**Out of scope:**
+- Live extraction smoke against DeepSeek through the UI flow (Phase 7).
+- Adding new vitest coverage for the page component (the existing test surface for `settings/page.tsx` is light; Phase 6 verification leans on typecheck + manual matrix).
+- Changing `DEFAULT_COMPILE_MODEL` / `DEFAULT_CHAT_MODEL` away from Gemini ([app/src/lib/db.ts:2536-2562](../../app/src/lib/db.ts#L2536)). Gemini remains the default — operators self-select DeepSeek per session.
+- Onboarding-flow strictness changes (require at least one provider key before finalize). Master plan defers; UI tooltip is sufficient operator self-discovery.
+- Adding extra test coverage for the route handler at `app/src/app/api/settings/route.ts` — the change is a string update, validation already covered.
+
+## Data contracts
+
+### `app/src/lib/db.ts` `CHAT_MODELS` + helper
+
+```ts
+export const CHAT_MODELS = [
+  'gemini-2.5-flash-lite',
+  'gemini-2.5-flash',
+  'gemini-2.5-pro',
+  'deepseek-v4-pro',
+] as const;
+export type ChatModel = typeof CHAT_MODELS[number];
+
+// existing isChatModel at :2538 still works — readonly array contains check.
+
+export function getProviderForModel(m: string): 'gemini' | 'deepseek' {
+  if (m.startsWith('deepseek-')) return 'deepseek';
+  return 'gemini';
+}
+```
+
+### `app/src/app/api/settings/route.ts` validator messages
+
+The existing message strings list valid models verbatim:
+
+```ts
+{ error: 'chat_model must be one of: gemini-2.5-flash-lite, gemini-2.5-flash, gemini-2.5-pro' }
+```
+
+Update to:
+
+```ts
+{ error: 'chat_model must be one of: gemini-2.5-flash-lite, gemini-2.5-flash, gemini-2.5-pro, deepseek-v4-pro' }
+```
+
+(Same change for `compile_model` at [:238](../../app/src/app/api/settings/route.ts#L238).)
+
+The validator predicate `isChatModel` already returns true for `'deepseek-v4-pro'` because it's now in `CHAT_MODELS` — the message string is the only edit.
+
+### `app/src/app/settings/page.tsx` dropdown structure
+
+Both compile + chat selects become:
+
+```tsx
+<select value={compileModel} onChange={…}>
+  <optgroup label="Gemini">
+    <option value="gemini-2.5-flash-lite">Flash Lite (cheapest)</option>
+    <option value="gemini-2.5-flash">Flash (default)</option>
+    <option value="gemini-2.5-pro">Pro (highest quality)</option>
+  </optgroup>
+  <optgroup label="DeepSeek">
+    <option
+      value="deepseek-v4-pro"
+      disabled={!healthData?.provider_keys?.deepseek_present}
+      title={healthData?.provider_keys?.deepseek_present
+        ? undefined
+        : 'Set DEEPSEEK_API_KEY in your environment to enable'}
+    >
+      V4 Pro
+    </option>
+  </optgroup>
+</select>
+```
+
+The `healthData` is already fetched on settings page load (used for the daily-cap display). No new API call added; just one new field read.
+
+### Provider-neutral copy
+
+Today's copy for the compile dropdown describes "the Gemini model that the compile pipeline uses..." — drop "Gemini" so the description fits both providers. Same edit for the chat dropdown copy ([:1152-1156](../../app/src/app/settings/page.tsx#L1152)).
+
+## Public API / tool / config changes
+
+`app/src/app/api/settings/route.ts` POST handler now accepts `'deepseek-v4-pro'` as a valid value for both `chat_model` and `compile_model`. Existing 422 responses for invalid values include the new model in the error message.
+
+The settings persist into the existing `settings` table (which stores arbitrary string values for `chat_model` / `compile_model` keys); migration v20's `compile_progress.compile_model` column also accepts any string. No DB changes.
+
+## Success criteria
+
+1. `cd app && npm run typecheck` exits 0 — the new `'deepseek-v4-pro'` entry types correctly through `ChatModel`, `isChatModel`, `getCompileModel`, `getEffectiveCompileModel`.
+2. Both dropdowns render with `<optgroup label="Gemini">` and `<optgroup label="DeepSeek">`.
+3. DeepSeek option's `disabled` + `title` attributes flip based on `healthData?.provider_keys?.deepseek_present`.
+4. POST `/api/settings` with `{compile_model: "deepseek-v4-pro"}` saves successfully.
+5. POST `/api/settings` with `{compile_model: "invalid-model"}` returns 422 with an error message that includes `'deepseek-v4-pro'` in the valid-list.
+6. Manual four-corner matrix walked end-to-end:
+   - Only `GEMINI_API_KEY`: DeepSeek option appears disabled with tooltip; selecting Gemini saves cleanly
+   - Only `DEEPSEEK_API_KEY`: Gemini options disabled with tooltips; selecting DeepSeek saves
+   - Both keys: both selectable
+   - Neither: both groups disabled
+7. Per-session lock: kicking off a compile after selecting DeepSeek writes `deepseek-v4-pro` to `compile_progress.compile_model` (the lock survives mid-session Settings changes — verified via the existing per-session-lock pattern at [getEffectiveCompileModel](../../app/src/lib/db.ts#L1447)).
+
+## Out-of-scope items
+
+(See Scope.) Phase 7 covers the corpus revalidation; Phase 6 stops at "the operator can pick the option without saving an invalid value."
+
+## Safety constraints
+
+- **Disabled options must be visibly distinct** — tooltip + `disabled` attribute are necessary so an operator on a Gemini-only deployment doesn't get a 422 from the POST after a save attempt that only the back-end will reject.
+- **Per-session lock keeps mid-session model swaps disabled** — the lock has been there since migration v20; this phase doesn't change that. CLAUDE.md gotcha: cancel + restart to switch.
+- **Default stays on Gemini.** `DEFAULT_COMPILE_MODEL = 'gemini-2.5-flash'` / `DEFAULT_CHAT_MODEL = 'gemini-2.5-flash-lite'`. Operators must opt into DeepSeek; no surprise switches.
+- **Gemini-prefix options on a DeepSeek-only deployment must also be disabled.** Symmetry: if an operator has only `DEEPSEEK_API_KEY` set (`gemini_present: false`), the Gemini options are disabled with the same tooltip pattern. Otherwise the operator could save a Gemini selection that the back-end will fail on every call.
+
+## Test strategy
+
+### Pre-implementation
+- Baseline: 188/188 nlp + provider tests green; vitest in `app/` and `cli/` green (CI confirms).
+
+### Per-task
+- **6.1 (db.ts + helper):** typecheck + run any existing vitest that imports `CHAT_MODELS`.
+- **6.2 (settings/route.ts):** run vitest `app/`; existing test surface validates the route handler.
+- **6.3 (settings/page.tsx):** typecheck + manual render in dev server; the Settings page has no automated component-level test today.
+- **6.4 (manual matrix):** four-corner walk recorded in the PR description.
+
+### Phase exit
+- `cd app && npm run typecheck` exit 0.
+- `cd app && npx vitest run` — green (the existing test surface).
+- Four-corner manual matrix recorded.
+- Save + reload: `compile_model = 'deepseek-v4-pro'` round-trips through `/api/settings` GET/POST.
+
+## Decomposition
+
+**Task 6.1** — `app/src/lib/db.ts` `CHAT_MODELS` expansion + `getProviderForModel` helper.
+
+**Task 6.2** — `app/src/app/api/settings/route.ts` error string update (mechanical follow-on).
+
+**Task 6.3** — `app/src/app/settings/page.tsx` optgroup restructure + gating + provider-neutral copy. Largest of the three.
+
+Bundle as one commit: the three files form a single logical change ("expose DeepSeek in Settings dropdown"). Per the master plan's discipline ("one commit per phase task"), Phase 6 ships as one or two commits — bundling makes the diff easier to review.
+
+## References
+
+- Master plan: [2026-05-05-deepseek-second-llm-provider.md](2026-05-05-deepseek-second-llm-provider.md) (Phase 6)
+- Phase 5 spec: [phase_5_spec.md](phase_5_spec.md)
+- Phase 5 commit: `f876fbb`
+- Per-session lock pattern: [app/src/lib/db.ts:1447](../../app/src/lib/db.ts#L1447) `getEffectiveCompileModel`
+- `compile_progress.compile_model` column: migration v20 (already accepts any string)
+- Health endpoint: [app/src/app/api/health/route.ts](../../app/src/app/api/health/route.ts) — `provider_keys: {gemini_present, deepseek_present}` shipped in Phase 5

--- a/nlp-service/main.py
+++ b/nlp-service/main.py
@@ -63,10 +63,20 @@ from routers.vectors import router as vectors_router
 logger = logging.getLogger(__name__)
 
 
+class _ProviderKeys(BaseModel):
+    """Presence-only flags so the Next.js Settings UI can gate dropdown
+    options without an outbound network probe to either provider."""
+    model_config = ConfigDict(extra='forbid')
+
+    gemini: bool
+    deepseek: bool
+
+
 class HealthResponse(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
     status: str
+    provider_keys: _ProviderKeys
 
 
 app = FastAPI(title="kompl-nlp-service", version="0.7.0")
@@ -84,21 +94,31 @@ app.include_router(chat_router)
 
 @app.on_event("startup")
 def startup_check() -> None:
-    """Validate required environment variables at startup.
+    """Validate that at least one LLM provider key is configured.
 
-    Fails loudly if GEMINI_API_KEY is not set — better to crash at startup
-    than to get a 500 on the first compile request 30 seconds later.
+    Phase 4 introduced DeepSeek as a second selectable backend. As long as
+    one of GEMINI_API_KEY / DEEPSEEK_API_KEY is set, the LLM endpoints work
+    for sessions targeting that provider. Both unset is the only loudly-
+    warning state — it means LLM endpoints will hard-fail on first call.
     """
-    gemini_key = os.environ.get("GEMINI_API_KEY", "")
-    if not gemini_key:
+    gemini_key = os.environ.get("GEMINI_API_KEY", "").strip()
+    deepseek_key = os.environ.get("DEEPSEEK_API_KEY", "").strip()
+    if not gemini_key and not deepseek_key:
         logger.warning(
-            "GEMINI_API_KEY is not set. "
+            "Neither GEMINI_API_KEY nor DEEPSEEK_API_KEY is set. "
             "LLM endpoints (/pipeline/extract-llm, /pipeline/draft, "
             "/pipeline/lint-scan, /resolve/disambiguate, /chat/synthesize) "
-            "will fail with 500. Set GEMINI_API_KEY in docker-compose.yml / .env."
+            "will fail with 500 for any session. "
+            "Set at least one in docker-compose.yml / .env."
         )
 
 
 @app.get("/health", response_model=HealthResponse)
 def health() -> HealthResponse:
-    return HealthResponse(status="ok")
+    return HealthResponse(
+        status="ok",
+        provider_keys=_ProviderKeys(
+            gemini=bool(os.environ.get("GEMINI_API_KEY", "").strip()),
+            deepseek=bool(os.environ.get("DEEPSEEK_API_KEY", "").strip()),
+        ),
+    )

--- a/nlp-service/services/llm_client.py
+++ b/nlp-service/services/llm_client.py
@@ -667,7 +667,7 @@ Return JSON with these fields:
 Keep lists focused: 5-15 entities, 3-10 concepts, 3-15 claims, 3-10 relationships.
 Each entity appears once. Stop as soon as the source is covered — do NOT
 repeat names or pad the output.
-"""
+""" + _JSON_TRAILER
 
 
 def extract_source(
@@ -884,7 +884,7 @@ For each pair return:
 
 Be conservative: only return "same" if you are confident. Prefer "ambiguous"
 over a wrong "same" call. Do not hallucinate.
-"""
+""" + _JSON_TRAILER
 
 
 _DISAMBIGUATION_CONCEPT_SYSTEM_PROMPT = """\
@@ -917,7 +917,7 @@ STRICTNESS RULES for this task:
   - When in doubt, prefer "different" over "same". Wrong merges are costly to
     undo and permanently lose the ability to have a page about the narrower
     concept. Duplicate pages self-heal as more sources arrive.
-"""
+""" + _JSON_TRAILER
 
 
 def disambiguate_entities(
@@ -1291,7 +1291,7 @@ Rules:
 - Do NOT modify YAML frontmatter.
 - Do NOT add links to pages that are not in the provided set.
 - Return EVERY page in updated_pages, even if unchanged.
-"""
+""" + _JSON_TRAILER
 
 
 def crossref_pages(pages: list[dict[str, Any]], model: str = _DEFAULT_MODEL) -> CrossrefResponse:
@@ -1534,7 +1534,7 @@ Return JSON with one field:
 
 Only include pages that genuinely help answer the question. If no pages are
 relevant, return an empty list. Do not hallucinate page IDs not in the input.
-"""
+""" + _JSON_TRAILER
 
 
 def select_pages_for_query(
@@ -1650,7 +1650,7 @@ Return JSON with two fields:
   answer     — your full markdown answer (may use headers, bullets, code blocks)
   citations  — list of {page_id, page_title} for every page you cited
                (only pages you actually used in your answer)
-"""
+""" + _JSON_TRAILER
 
 
 def synthesize_answer(

--- a/nlp-service/services/llm_client.py
+++ b/nlp-service/services/llm_client.py
@@ -161,7 +161,7 @@ def _read_thinking_budget(call_site: str) -> int:
 
 
 def _read_daily_cap_usd() -> float:
-    """Read the user-configurable daily Gemini $ cap from /data/llm-config.json.
+    """Read the user-configurable daily LLM $ cap from /data/llm-config.json.
 
     Next.js writes this file whenever setDailyCapUsd() is called in db.ts
     (backed by the 'daily_cap_usd' settings row). We cache the value for 30 s
@@ -210,33 +210,34 @@ def _check_and_record_cost(
     output_tokens: int,
     thought_tokens: int,
 ) -> None:
-    """Check daily cap then record cost. Raises CostCeilingError if exceeded.
+    """Check daily LLM $ cap then record cost. Raises CostCeilingError if exceeded.
 
     Per-call cost is computed by the model's provider (Gemini today; DeepSeek
-    in Phase 4). The dispatcher only enforces the daily LLM $ cap and the
-    on-disk persistence — pricing tables live in the providers.
+    in Phase 4) via ``provider.cost_usd(model, usage_dict)``. The dispatcher
+    enforces the daily LLM $ cap and the on-disk persistence — pricing tables
+    live in the providers.
 
-    Called from inside ``GeminiProvider.complete()`` after every successful
-    Gemini API call. If GEMINI_DAILY_USD_CAP=0 the check is skipped
-    (unlimited mode).
+    The token-count signature is preserved for backward compatibility with
+    the existing test fixture ``mock_cost``; the body translates to a usage
+    dict for the provider.
+
+    Called from inside the provider's ``complete()`` after every successful
+    API call. If GEMINI_DAILY_USD_CAP=0 the check is skipped (unlimited mode).
     """
-    # Lazy import to avoid a circular at module-load time.
-    from .providers.gemini import _get_model_prices
+    provider = get_provider(model)
+    usage = {
+        "prompt_token_count":         prompt_tokens,
+        "cached_content_token_count": cached_tokens,
+        "candidates_token_count":     output_tokens,
+        "thoughts_token_count":       thought_tokens,
+    }
+    cost_usd = provider.cost_usd(model, usage)
 
-    prices = _get_model_prices(model)
-    # prompt_token_count includes cached tokens per Gemini API docs.
-    fresh_input = max(0, prompt_tokens - cached_tokens)
-    cost_usd = (
-        (fresh_input      / 1_000_000) * prices["input"]
-      + (cached_tokens    / 1_000_000) * prices["cache"]
-      + (output_tokens    / 1_000_000) * prices["output"]
-      + (thought_tokens   / 1_000_000) * prices["output"]
-    )
     cap_data = _read_cap()
     daily_cap = _read_daily_cap_usd()
     if daily_cap > 0 and cap_data["total_usd"] + cost_usd > daily_cap:
         raise CostCeilingError(
-            f"Daily Gemini spend limit (${daily_cap:.2f}) reached. "
+            f"Daily LLM spend limit (${daily_cap:.2f}) reached. "
             f"Today's spend: ${cap_data['total_usd']:.4f}. "
             f"Resets at midnight UTC."
         )

--- a/nlp-service/services/llm_client.py
+++ b/nlp-service/services/llm_client.py
@@ -49,6 +49,22 @@ _GEMINI_INPUT_TOKEN_CAP = int(os.environ.get("GEMINI_INPUT_TOKEN_CAP", "128000")
 # over-long input produces a JSON list that exceeds max_output_tokens (32K) and
 # truncates mid-string. Cap extraction inputs tighter. ~50K chars ≈ 12.5K tokens.
 _GEMINI_EXTRACT_INPUT_CAP = int(os.environ.get("GEMINI_EXTRACT_INPUT_CAP", "50000"))
+# DeepSeek extracted clean from a 95K-char source in the spike where Gemini
+# truncates mid-string at 50K. Higher cap gives DeepSeek operators richer
+# extraction on long sources without changing Gemini's tighter limit.
+_DEEPSEEK_INPUT_CHAR_CAP = int(os.environ.get("DEEPSEEK_INPUT_CHAR_CAP", "200000"))
+
+
+def _extract_input_cap_for(model: str) -> int:
+    """Char cap on the source-document input passed to ``extract_source``.
+
+    Gemini hits MAX_TOKENS in structured output around 50K input chars
+    (the 2.5 Flash repetition-loop bug); DeepSeek empirically handles 95K
+    clean. Each provider gets the cap matching its real-world capacity.
+    """
+    if model.startswith("deepseek-"):
+        return _DEEPSEEK_INPUT_CHAR_CAP
+    return _GEMINI_EXTRACT_INPUT_CAP
 # Fallback when /data/llm-config.json is missing (first boot, dev env, test).
 # Runtime cap comes from _read_daily_cap_usd() below; Next.js writes the file
 # whenever the setting is changed in the Settings UI.
@@ -475,8 +491,9 @@ def extract_source(
     """
     import json as _json
 
-    if len(markdown) > _GEMINI_EXTRACT_INPUT_CAP:
-        truncated = markdown[:_GEMINI_EXTRACT_INPUT_CAP]
+    input_cap = _extract_input_cap_for(model)
+    if len(markdown) > input_cap:
+        truncated = markdown[:input_cap]
         last_para = truncated.rfind("\n\n")
         markdown = truncated[:last_para] if last_para > 0 else truncated
 
@@ -543,6 +560,13 @@ def extract_source(
     if result.finish_reason != "MAX_TOKENS":
         # Not a truncation — parse error is something else (schema drift,
         # malformed response). No point retrying with halved input.
+        raise LLMCompileError(f"extract_llm_parse_failed: {first_err}") from first_err
+
+    if not model.startswith("gemini-"):
+        # The halved-input fallback is a Gemini-bug-specific mitigation for
+        # the 2.5 Flash structured-output repetition loop. DeepSeek (and any
+        # other provider) doesn't share the pathology; surface the original
+        # parse error rather than doubling cost on an unvalidated retry path.
         raise LLMCompileError(f"extract_llm_parse_failed: {first_err}") from first_err
 
     print(

--- a/nlp-service/services/llm_client.py
+++ b/nlp-service/services/llm_client.py
@@ -33,33 +33,16 @@ import sys
 import time
 from datetime import date
 from pathlib import Path
-from typing import Any, Callable, TypeVar
+from typing import Any
 
-import httpx
-from google import genai
-from google.genai import types
 from pydantic import BaseModel
-from pyrate_limiter import Duration, InMemoryBucket, Limiter, Rate
 
-# google-genai raises its own error types (ClientError / ServerError / APIError)
-# that generic retry predicates miss — see cookbook issue #1091. We catch the
-# APIError base and filter by status code below. Tolerate SDK layout drift
-# (the class moved between minor releases): a missing module just means the
-# retry loop's `except _APIError` becomes a safe no-op.
-try:
-    from google.genai import errors as _genai_errors
-    _APIError: Any = _genai_errors.APIError
-except (ImportError, AttributeError):  # pragma: no cover
-    _APIError = tuple()
-
-T = TypeVar("T")
+from .providers import LLMRequest, get_provider
 
 # ---------------------------------------------------------------------------
 # Configuration from environment
 # ---------------------------------------------------------------------------
 
-_GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY", "").strip()
-_GEMINI_RPM = int(os.environ.get("GEMINI_RPM", "800"))
 # Rough char budget: 1 token ≈ 4 chars for English. 32,000 tokens → 128,000 chars.
 _GEMINI_INPUT_TOKEN_CAP = int(os.environ.get("GEMINI_INPUT_TOKEN_CAP", "128000"))
 # Extraction output is a structured JSON list of entities/concepts/claims — an
@@ -70,50 +53,6 @@ _GEMINI_EXTRACT_INPUT_CAP = int(os.environ.get("GEMINI_EXTRACT_INPUT_CAP", "5000
 # Runtime cap comes from _read_daily_cap_usd() below; Next.js writes the file
 # whenever the setting is changed in the Settings UI.
 _DAILY_CAP_FALLBACK = float(os.environ.get("GEMINI_DAILY_USD_CAP", "5.00"))
-
-# Gemini 2.5-family pricing ($/M tokens, 2026-04 public rates).
-# Previous env-driven single-price values ($0.075 / $0.300) were stale 1.5-Flash
-# rates and under-counted actual spend by 3-8× depending on model. We now do
-# per-model lookup because each call site knows its model (compile_model or
-# chat_model from the Next.js settings, forwarded as a request field).
-#
-# cost = (prompt_tokens - cached_tokens) * input_rate
-#      + cached_tokens                   * cache_rate    (≈ 0.1x input)
-#      + (candidates_tokens + thoughts_tokens) * output_rate
-#
-# Thinking tokens are billed at the output rate per
-#   https://ai.google.dev/gemini-api/docs/thinking
-# Cached tokens are still counted in prompt_token_count per
-#   https://ai.google.dev/api/generate-content
-# so we subtract explicitly to avoid double-counting.
-_MODEL_PRICES: dict[str, dict[str, float]] = {
-    "gemini-2.5-flash-lite": {"input": 0.10, "output": 0.40, "cache": 0.01},
-    "gemini-2.5-flash":      {"input": 0.30, "output": 2.50, "cache": 0.03},
-    # Pro tiered — ≤200k prompts use the small-context SKU. >200k switches to
-    # $2.50 / $15 / $0.25; we don't auto-detect that boundary here. If Pro is
-    # routinely exercised with >200k prompts, override via env vars below.
-    "gemini-2.5-pro":        {"input": 1.25, "output": 10.00, "cache": 0.125},
-}
-
-# Env overrides — last-resort escape hatch when Gemini changes pricing and
-# the code hasn't been updated yet. Apply to all models.
-_INPUT_PRICE_OVERRIDE  = os.environ.get("GEMINI_INPUT_PRICE_PER_M")
-_OUTPUT_PRICE_OVERRIDE = os.environ.get("GEMINI_OUTPUT_PRICE_PER_M")
-_CACHE_PRICE_OVERRIDE  = os.environ.get("GEMINI_CACHE_PRICE_PER_M")
-
-
-def _get_model_prices(model: str) -> dict[str, float]:
-    """Return {input, output, cache} per-million-token prices for `model`.
-
-    Falls back to gemini-2.5-flash-lite rates for unknown models so an SDK
-    bump to a new model name doesn't silently crash pricing.
-    """
-    base = _MODEL_PRICES.get(model, _MODEL_PRICES["gemini-2.5-flash-lite"])
-    return {
-        "input":  float(_INPUT_PRICE_OVERRIDE)  if _INPUT_PRICE_OVERRIDE  else base["input"],
-        "output": float(_OUTPUT_PRICE_OVERRIDE) if _OUTPUT_PRICE_OVERRIDE else base["output"],
-        "cache":  float(_CACHE_PRICE_OVERRIDE)  if _CACHE_PRICE_OVERRIDE  else base["cache"],
-    }
 
 
 # Default for call sites that haven't been updated to pass `model` — matches
@@ -273,13 +212,17 @@ def _check_and_record_cost(
 ) -> None:
     """Check daily cap then record cost. Raises CostCeilingError if exceeded.
 
-    Per-model pricing via _get_model_prices. Thought tokens billed at the
-    output rate. Cached tokens billed at the cache rate (subtracted from
-    fresh input to avoid double-counting). See module header for formula.
+    Per-call cost is computed by the model's provider (Gemini today; DeepSeek
+    in Phase 4). The dispatcher only enforces the daily LLM $ cap and the
+    on-disk persistence — pricing tables live in the providers.
 
-    Called after every successful Gemini API call. If GEMINI_DAILY_USD_CAP=0
-    the check is skipped (unlimited mode).
+    Called from inside ``GeminiProvider.complete()`` after every successful
+    Gemini API call. If GEMINI_DAILY_USD_CAP=0 the check is skipped
+    (unlimited mode).
     """
+    # Lazy import to avoid a circular at module-load time.
+    from .providers.gemini import _get_model_prices
+
     prices = _get_model_prices(model)
     # prompt_token_count includes cached tokens per Gemini API docs.
     fresh_input = max(0, prompt_tokens - cached_tokens)
@@ -300,155 +243,6 @@ def _check_and_record_cost(
     cap_data["total_usd"] = round(cap_data["total_usd"] + cost_usd, 6)
     cap_data["call_count"] = cap_data.get("call_count", 0) + 1
     _write_cap(cap_data)
-
-
-def _record_usage(step: str, model: str, response: Any) -> None:
-    """Unified wrapper: log one-line usage + record cost. Replaces the 5-line
-    boilerplate that used to live at every call site (_log_usage then manual
-    getattr + _check_and_record_cost).
-
-    Reads from response.usage_metadata:
-      - prompt_token_count   — total effective prompt (INCLUDES cached)
-      - cached_content_token_count — discounted portion
-      - candidates_token_count — output (user-visible response text)
-      - thoughts_token_count   — output (thinking mode, billed)
-
-    Silently skips when usage_metadata is None (rare — error responses,
-    streaming edge cases). Cost recording never fails the caller."""
-    _log_usage(step, response)
-    usage = getattr(response, "usage_metadata", None)
-    if usage is None:
-        return
-    prompt_tok = int(getattr(usage, "prompt_token_count", 0) or 0)
-    cached_tok = int(getattr(usage, "cached_content_token_count", 0) or 0)
-    output_tok = int(getattr(usage, "candidates_token_count", 0) or 0)
-    thought_tok = int(getattr(usage, "thoughts_token_count", 0) or 0)
-    _check_and_record_cost(model, prompt_tok, cached_tok, output_tok, thought_tok)
-
-
-# ---------------------------------------------------------------------------
-# Rate limiter — in-process token bucket, async-safe
-# ---------------------------------------------------------------------------
-
-_limiter: Limiter | None = None
-
-
-def _get_limiter() -> Limiter:
-    global _limiter
-    if _limiter is None:
-        _limiter = Limiter(
-            InMemoryBucket([Rate(_GEMINI_RPM, Duration.MINUTE)]),
-            raise_when_fail=False,
-            max_delay=60_000,  # wait up to 60s before giving up
-        )
-    return _limiter
-
-
-# ---------------------------------------------------------------------------
-# Retry wrapper for transient upstream errors (google-genai 1.12.1 has no
-# built-in retry; HttpRetryOptions was added in ≥1.65 which is a 60-version
-# jump we're not taking mid-debug). Retries on connection-class errors +
-# Gemini APIError with retryable status codes (408/429/5xx). Rate-limiter
-# token is re-acquired per attempt so retries count against the 800 RPM cap.
-# Apply only to read-only analyzers (extract/resolve/match/triage/…) — never
-# wrap draft_page / synthesize / digest, whose outputs commit downstream
-# state and can't be safely re-executed after a partial response.
-# ---------------------------------------------------------------------------
-
-
-_RETRYABLE_STATUSES: frozenset[int] = frozenset({408, 429, 500, 502, 503, 504})
-
-
-def _with_retry(fn: Callable[[], T], step: str, *, max_attempts: int = 3, base_delay: float = 0.5) -> T:
-    limiter = _get_limiter()
-    last_exc: Exception | None = None
-
-    for i in range(max_attempts):
-        if not limiter.try_acquire("gemini"):
-            raise LLMRateLimitedError(f"llm_rate_limited: bucket exhausted on {step}")
-
-        try:
-            return fn()
-        except (
-            httpx.ConnectError,
-            httpx.PoolTimeout,
-            httpx.ReadTimeout,
-            httpx.WriteTimeout,
-            httpx.RemoteProtocolError,
-            httpx.WriteError,
-            httpx.ReadError,
-        ) as e:
-            last_exc = e
-            err_class = type(e).__name__
-        except _APIError as e:
-            code = getattr(e, "code", None) or getattr(e, "status_code", None)
-            if code not in _RETRYABLE_STATUSES:
-                raise
-            last_exc = e
-            err_class = f"APIError{code}"
-
-        if i < max_attempts - 1:
-            delay = base_delay * (2 ** i)
-            print(
-                f"[llm-retry] {step} attempt {i + 1}/{max_attempts} after "
-                f"{err_class}: {str(last_exc)[:200]} — sleeping {delay}s",
-                file=sys.stderr,
-                flush=True,
-            )
-            time.sleep(delay)
-
-    assert last_exc is not None
-    raise last_exc
-
-
-def _log_usage(step: str, response: Any) -> None:
-    """One-line stderr log per Gemini call: finish_reason + token counts.
-
-    Ground truth for distinguishing a MAX_TOKENS truncation from a normal
-    STOP, or an empty response, or a thinking-budget exhaustion. Non-fatal:
-    a broken log must never break the caller, so swallow any exception.
-    """
-    try:
-        candidates = getattr(response, "candidates", None) or []
-        finish = "NONE"
-        if candidates:
-            fr = getattr(candidates[0], "finish_reason", None)
-            finish = str(fr).split(".")[-1] if fr is not None else "NONE"
-        usage = getattr(response, "usage_metadata", None)
-        if usage is not None:
-            ptok = getattr(usage, "prompt_token_count", 0) or 0
-            ctok = getattr(usage, "candidates_token_count", 0) or 0
-            ttok = getattr(usage, "thoughts_token_count", 0) or 0
-            print(
-                f"[gemini] step={step} finish={finish} in={ptok} out={ctok} thinking={ttok}",
-                file=sys.stderr,
-                flush=True,
-            )
-        else:
-            print(f"[gemini] step={step} finish={finish} usage=none", file=sys.stderr, flush=True)
-    except Exception:
-        pass
-
-
-def _was_truncated(response: Any) -> bool:
-    """Check if Gemini hit max_output_tokens (ground truth, not regex).
-
-    Gemini 2.5 Flash has a known repetition-loop bug at temperature=0.0 where
-    the sampler enters a fixed-point attractor and emits the same token until
-    max_output_tokens. finish_reason is the authoritative signal — the text-
-    ending heuristic is unreliable (could false-positive on legitimate
-    trailing quotes, or false-negative on loops that happen to close brackets).
-    """
-    try:
-        candidates = getattr(response, "candidates", None) or []
-        if not candidates:
-            return False
-        fr = getattr(candidates[0], "finish_reason", None)
-        if fr is None:
-            return False
-        return str(fr).endswith("MAX_TOKENS")
-    except Exception:
-        return False
 
 
 def _salvage_extraction(raw_text: str) -> "LLMExtractionResponse | None":
@@ -473,22 +267,6 @@ def _salvage_extraction(raw_text: str) -> "LLMExtractionResponse | None":
         return LLMExtractionResponse.model_validate(repaired)
     except Exception:
         return None
-
-
-# ---------------------------------------------------------------------------
-# Gemini client (lazy init — validated at startup by main.py lifespan)
-# ---------------------------------------------------------------------------
-
-_client: genai.Client | None = None
-
-
-def get_client() -> genai.Client:
-    global _client
-    if _client is None:
-        if not _GEMINI_API_KEY:
-            raise RuntimeError("GEMINI_API_KEY not set")
-        _client = genai.Client(api_key=_GEMINI_API_KEY)
-    return _client
 
 
 # ---------------------------------------------------------------------------
@@ -544,28 +322,23 @@ def lint_scan(pages: list[str], model: str = _DEFAULT_MODEL) -> LintScanResponse
 
     prompt = f"{_LINT_SYSTEM_PROMPT}\n\n---\n\n" + "\n\n".join(pages)
 
-    client = get_client()
+    provider = get_provider(model)
     try:
-        response = _with_retry(
-            lambda: client.models.generate_content(
-                model=model,
-                contents=prompt,
-                config=types.GenerateContentConfig(
-                    response_mime_type="application/json",
-                    thinking_config=types.ThinkingConfig(thinking_budget=_read_thinking_budget('lint_scan')),
-                    max_output_tokens=4096,  # lint responses are short
-                ),
-            ),
+        result = provider.complete(LLMRequest(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            response_model=None,
+            thinking_budget=_read_thinking_budget('lint_scan'),
+            max_output_tokens=4096,  # lint responses are short
             step="lint",
-        )
+            extra={"force_json_mime": True},
+        ))
     except LLMRateLimitedError:
         raise
     except Exception as e:
         raise LLMCompileError(f"lint_scan_failed: {e}") from e
 
-    _record_usage("lint", model, response)
-
-    raw_text = response.text
+    raw_text = result.text
     if not raw_text:
         return LintScanResponse(contradictions=[])
 
@@ -719,131 +492,119 @@ def extract_source(
         f"Source document:\n\n{markdown}"
     )
 
-    client = get_client()
+    provider = get_provider(model)
     try:
-        response = _with_retry(
-            lambda: client.models.generate_content(
-                model=model,
-                contents=prompt,
-                config=types.GenerateContentConfig(
-                    response_mime_type="application/json",
-                    response_schema=LLMExtractionResponse,
-                    thinking_config=types.ThinkingConfig(thinking_budget=_read_thinking_budget('extract_source')),
-                    max_output_tokens=32768,
-                    temperature=0.0,
-                ),
-            ),
+        result = provider.complete(LLMRequest(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            response_model=LLMExtractionResponse,
+            thinking_budget=_read_thinking_budget('extract_source'),
+            max_output_tokens=32768,
+            temperature=0.0,
             step="extract",
-        )
+        ))
     except LLMRateLimitedError:
         raise
     except Exception as e:
         raise LLMCompileError(f"extract_llm_call_failed: {e}") from e
 
-    _record_usage("extract", model, response)
-
-    raw_text = response.text
+    raw_text = result.text
     if not raw_text:
         raise LLMCompileError("extract_llm_error: empty response text")
 
-    try:
-        return LLMExtractionResponse.model_validate_json(raw_text)
-    except Exception as first_err:
-        # Recovery path for the Gemini 2.5 Flash structured-output repetition
-        # loop (upstream bug, see repo issue). Three attempts in order of cost:
-        #
-        # (1) Salvage the truncated prefix via json-repair — zero extra Gemini
-        #     cost, recovers the majority of repetition-loop responses because
-        #     the valid entities came before the stuck "AI","AI","AI",... tail.
-        # (2) If finish_reason=MAX_TOKENS AND salvage failed, retry once with
-        #     halved input — different prompt path usually escapes the loop.
-        # (3) On all-fail, chain both errors so we can see what each attempt hit.
-        salvaged = _salvage_extraction(raw_text)
-        if salvaged is not None:
-            print(
-                f"[extract] salvaged truncated response via json-repair "
-                f"(entities={len(salvaged.entities)}, concepts={len(salvaged.concepts)})",
-                file=sys.stderr,
-                flush=True,
-            )
-            return salvaged
+    if result.parsed is not None:
+        return result.parsed  # type: ignore[return-value]
 
-        if not _was_truncated(response):
-            # Not a truncation — parse error is something else (schema drift,
-            # malformed response). No point retrying with halved input.
-            raise LLMCompileError(f"extract_llm_parse_failed: {first_err}") from first_err
-
+    # Recovery path for the Gemini 2.5 Flash structured-output repetition
+    # loop (upstream bug, see repo issue). Three attempts in order of cost:
+    #
+    # (1) Salvage the truncated prefix via json-repair — zero extra Gemini
+    #     cost, recovers the majority of repetition-loop responses because
+    #     the valid entities came before the stuck "AI","AI","AI",... tail.
+    # (2) If finish_reason=MAX_TOKENS AND salvage failed, retry once with
+    #     halved input — different prompt path usually escapes the loop.
+    # (3) On all-fail, chain both errors so we can see what each attempt hit.
+    first_err = result.parse_error
+    salvaged = _salvage_extraction(raw_text)
+    if salvaged is not None:
         print(
-            f"[extract] MAX_TOKENS truncation + salvage failed — "
-            f"retrying with halved input",
+            f"[extract] salvaged truncated response via json-repair "
+            f"(entities={len(salvaged.entities)}, concepts={len(salvaged.concepts)})",
             file=sys.stderr,
             flush=True,
         )
+        return salvaged
 
-        half_markdown = markdown[: len(markdown) // 2]
-        last_para = half_markdown.rfind("\n\n")
-        if last_para > 0:
-            half_markdown = half_markdown[:last_para]
+    if result.finish_reason != "MAX_TOKENS":
+        # Not a truncation — parse error is something else (schema drift,
+        # malformed response). No point retrying with halved input.
+        raise LLMCompileError(f"extract_llm_parse_failed: {first_err}") from first_err
 
-        fallback_prompt = (
-            f"{_EXTRACTION_SYSTEM_PROMPT}\n\n"
-            f"---\n\n"
-            f"Source ID: {source_id}\n\n"
-            f"NLP extraction results:\n"
-            f"Named entities (spaCy NER):\n{ner_section}\n\n"
-            f"Keyphrases:\n{keyphrase_section}\n\n"
-            f"TF-IDF overlap with existing wiki:\n{tfidf_section}\n\n"
-            f"---\n\n"
-            f"Source document:\n\n{half_markdown}"
+    print(
+        f"[extract] MAX_TOKENS truncation + salvage failed — "
+        f"retrying with halved input",
+        file=sys.stderr,
+        flush=True,
+    )
+
+    half_markdown = markdown[: len(markdown) // 2]
+    last_para = half_markdown.rfind("\n\n")
+    if last_para > 0:
+        half_markdown = half_markdown[:last_para]
+
+    fallback_prompt = (
+        f"{_EXTRACTION_SYSTEM_PROMPT}\n\n"
+        f"---\n\n"
+        f"Source ID: {source_id}\n\n"
+        f"NLP extraction results:\n"
+        f"Named entities (spaCy NER):\n{ner_section}\n\n"
+        f"Keyphrases:\n{keyphrase_section}\n\n"
+        f"TF-IDF overlap with existing wiki:\n{tfidf_section}\n\n"
+        f"---\n\n"
+        f"Source document:\n\n{half_markdown}"
+    )
+
+    try:
+        fallback_result = provider.complete(LLMRequest(
+            model=model,
+            messages=[{"role": "user", "content": fallback_prompt}],
+            response_model=LLMExtractionResponse,
+            thinking_budget=_read_thinking_budget('extract_source'),
+            max_output_tokens=32768,
+            temperature=0.0,
+            step="extract-fallback",
+        ))
+    except LLMRateLimitedError:
+        raise
+    except Exception as fallback_call_err:
+        raise LLMCompileError(
+            f"extract_llm_parse_failed_after_fallback: "
+            f"first={first_err}; fallback_call={fallback_call_err}"
+        ) from first_err
+
+    fallback_raw = fallback_result.text
+    if not fallback_raw:
+        raise LLMCompileError(
+            f"extract_llm_parse_failed_after_fallback: "
+            f"first={first_err}; fallback=empty"
+        ) from first_err
+
+    if fallback_result.parsed is not None:
+        return fallback_result.parsed  # type: ignore[return-value]
+
+    fallback_parse_err = fallback_result.parse_error
+    salvaged_fallback = _salvage_extraction(fallback_raw)
+    if salvaged_fallback is not None:
+        print(
+            f"[extract] salvaged fallback response via json-repair",
+            file=sys.stderr,
+            flush=True,
         )
-
-        try:
-            fallback_response = _with_retry(
-                lambda: client.models.generate_content(
-                    model=model,
-                    contents=fallback_prompt,
-                    config=types.GenerateContentConfig(
-                        response_mime_type="application/json",
-                        response_schema=LLMExtractionResponse,
-                        thinking_config=types.ThinkingConfig(thinking_budget=_read_thinking_budget('extract_source')),
-                        max_output_tokens=32768,
-                        temperature=0.0,
-                    ),
-                ),
-                step="extract-fallback",
-            )
-        except LLMRateLimitedError:
-            raise
-        except Exception as fallback_call_err:
-            raise LLMCompileError(
-                f"extract_llm_parse_failed_after_fallback: "
-                f"first={first_err}; fallback_call={fallback_call_err}"
-            ) from first_err
-
-        _record_usage("extract-fallback", model, fallback_response)
-
-        fallback_raw = fallback_response.text
-        if not fallback_raw:
-            raise LLMCompileError(
-                f"extract_llm_parse_failed_after_fallback: "
-                f"first={first_err}; fallback=empty"
-            ) from first_err
-
-        try:
-            return LLMExtractionResponse.model_validate_json(fallback_raw)
-        except Exception as fallback_parse_err:
-            salvaged_fallback = _salvage_extraction(fallback_raw)
-            if salvaged_fallback is not None:
-                print(
-                    f"[extract] salvaged fallback response via json-repair",
-                    file=sys.stderr,
-                    flush=True,
-                )
-                return salvaged_fallback
-            raise LLMCompileError(
-                f"extract_llm_parse_failed_after_fallback: "
-                f"first={first_err}; second={fallback_parse_err}"
-            ) from first_err
+        return salvaged_fallback
+    raise LLMCompileError(
+        f"extract_llm_parse_failed_after_fallback: "
+        f"first={first_err}; second={fallback_parse_err}"
+    ) from first_err
 
 
 # ---------------------------------------------------------------------------
@@ -954,37 +715,29 @@ def disambiguate_entities(
         f"Pairs to resolve:\n{pairs_json}"
     )
 
-    client = get_client()
+    provider = get_provider(model)
     try:
-        response = _with_retry(
-            lambda: client.models.generate_content(
-                model=model,
-                contents=prompt,
-                config=types.GenerateContentConfig(
-                    response_mime_type="application/json",
-                    response_schema=DisambiguationResponse,
-                    thinking_config=types.ThinkingConfig(thinking_budget=_read_thinking_budget('disambiguate_entities')),
-                    max_output_tokens=2048,
-                    temperature=0.0,
-                ),
-            ),
+        result = provider.complete(LLMRequest(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            response_model=DisambiguationResponse,
+            thinking_budget=_read_thinking_budget('disambiguate_entities'),
+            max_output_tokens=2048,
+            temperature=0.0,
             step="disambiguate",
-        )
+        ))
     except LLMRateLimitedError:
         raise
     except Exception as e:
         raise LLMCompileError(f"disambiguate_llm_call_failed: {e}") from e
 
-    _record_usage("disambiguate", model, response)
-
-    raw_text = response.text
+    raw_text = result.text
     if not raw_text:
         raise LLMCompileError("disambiguate_llm_error: empty response text")
 
-    try:
-        return DisambiguationResponse.model_validate_json(raw_text)
-    except Exception as e:
-        raise LLMCompileError(f"disambiguate_llm_parse_failed: {e}") from e
+    if result.parsed is not None:
+        return result.parsed  # type: ignore[return-value]
+    raise LLMCompileError(f"disambiguate_llm_parse_failed: {result.parse_error}") from result.parse_error
 
 
 # ---------------------------------------------------------------------------
@@ -1204,29 +957,27 @@ def draft_page(
 
     prompt += cat_suffix
 
-    limiter = _get_limiter()
-    acquired = limiter.try_acquire("gemini")
-    if not acquired:
-        raise LLMRateLimitedError("llm_rate_limited: bucket exhausted")
-
-    client = get_client()
+    provider = get_provider(model)
     try:
-        response = client.models.generate_content(
+        result = provider.complete(LLMRequest(
             model=model,
-            contents=prompt,
-            config=types.GenerateContentConfig(
-                system_instruction=system_prompt,
-                thinking_config=types.ThinkingConfig(thinking_budget=_read_thinking_budget('draft_page')),
-                max_output_tokens=16384,
-                temperature=0.3,
-            ),
-        )
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt},
+            ],
+            response_model=None,
+            thinking_budget=_read_thinking_budget('draft_page'),
+            max_output_tokens=16384,
+            temperature=0.3,
+            step="draft_page",
+            extra={"retry": False},
+        ))
+    except LLMRateLimitedError:
+        raise
     except Exception as e:
         raise LLMCompileError(f"draft_page_llm_failed: {e}") from e
 
-    _record_usage("draft_page", model, response)
-
-    raw_text = response.text
+    raw_text = result.text
     if not raw_text:
         raise LLMCompileError(f"draft_page_error: empty response for '{title}'")
 
@@ -1331,31 +1082,26 @@ def crossref_pages(pages: list[dict[str, Any]], model: str = _DEFAULT_MODEL) -> 
     if len(prompt) > _GEMINI_INPUT_TOKEN_CAP:
         prompt = prompt[:_GEMINI_INPUT_TOKEN_CAP]
 
-    client = get_client()
+    provider = get_provider(model)
     try:
-        response = _with_retry(
-            lambda: client.models.generate_content(
-                model=model,
-                contents=prompt,
-                config=types.GenerateContentConfig(
-                    system_instruction=_CROSSREF_SYSTEM_PROMPT,
-                    response_mime_type="application/json",
-                    response_schema=CrossrefResponse,
-                    thinking_config=types.ThinkingConfig(thinking_budget=_read_thinking_budget('crossref_pages')),
-                    max_output_tokens=32768,
-                    temperature=0.0,
-                ),
-            ),
+        result = provider.complete(LLMRequest(
+            model=model,
+            messages=[
+                {"role": "system", "content": _CROSSREF_SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+            response_model=CrossrefResponse,
+            thinking_budget=_read_thinking_budget('crossref_pages'),
+            max_output_tokens=32768,
+            temperature=0.0,
             step="crossref",
-        )
+        ))
     except LLMRateLimitedError:
         raise
     except Exception as e:
         raise LLMCompileError(f"crossref_llm_failed: {e}") from e
 
-    _record_usage("crossref", model, response)
-
-    raw_text = response.text
+    raw_text = result.text
     if not raw_text:
         # Return pages unchanged on empty response rather than failing
         return CrossrefResponse(
@@ -1363,10 +1109,9 @@ def crossref_pages(pages: list[dict[str, Any]], model: str = _DEFAULT_MODEL) -> 
             contradictions_found=[],
         )
 
-    try:
-        return CrossrefResponse.model_validate_json(raw_text)
-    except Exception as e:
-        raise LLMCompileError(f"crossref_parse_failed: {e}") from e
+    if result.parsed is not None:
+        return result.parsed  # type: ignore[return-value]
+    raise LLMCompileError(f"crossref_parse_failed: {result.parse_error}") from result.parse_error
 
 
 # ---------------------------------------------------------------------------
@@ -1429,37 +1174,29 @@ def triage_page_update(
         f'- "skip": source is redundant or only tangentially mentions the topic'
     )
 
-    client = get_client()
+    provider = get_provider(model)
     try:
-        response = _with_retry(
-            lambda: client.models.generate_content(
-                model=model,
-                contents=prompt,
-                config=types.GenerateContentConfig(
-                    response_mime_type="application/json",
-                    response_schema=TriageResponse,
-                    thinking_config=types.ThinkingConfig(thinking_budget=_read_thinking_budget('triage_page_update')),
-                    max_output_tokens=512,
-                    temperature=0.0,
-                ),
-            ),
+        result = provider.complete(LLMRequest(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            response_model=TriageResponse,
+            thinking_budget=_read_thinking_budget('triage_page_update'),
+            max_output_tokens=512,
+            temperature=0.0,
             step="triage",
-        )
+        ))
     except LLMRateLimitedError:
         raise
     except Exception as e:
         raise LLMCompileError(f"triage_llm_call_failed: {e}") from e
 
-    _record_usage("triage", model, response)
-
-    raw_text = response.text
+    raw_text = result.text
     if not raw_text:
         raise LLMCompileError("triage_error: empty response text")
 
-    try:
-        triage = TriageResponse.model_validate_json(raw_text)
-    except Exception as e:
-        raise LLMCompileError(f"triage_json_parse_failed: {e}") from e
+    if result.parsed is None:
+        raise LLMCompileError(f"triage_json_parse_failed: {result.parse_error}") from result.parse_error
+    triage = result.parsed
 
     decision = triage.decision if triage.decision in ("update", "contradiction", "skip") else "skip"
     return {"decision": decision, "reason": triage.reason}
@@ -1485,29 +1222,26 @@ def generate_schema(pages_summary: list[dict[str, Any]], model: str = _DEFAULT_M
         + _json.dumps(pages_summary, ensure_ascii=False, indent=2)
     )
 
-    client = get_client()
+    provider = get_provider(model)
     try:
-        response = _with_retry(
-            lambda: client.models.generate_content(
-                model=model,
-                contents=prompt,
-                config=types.GenerateContentConfig(
-                    system_instruction=_SCHEMA_SYSTEM_PROMPT,
-                    thinking_config=types.ThinkingConfig(thinking_budget=_read_thinking_budget('generate_schema')),
-                    max_output_tokens=8192,
-                    temperature=0.0,
-                ),
-            ),
+        result = provider.complete(LLMRequest(
+            model=model,
+            messages=[
+                {"role": "system", "content": _SCHEMA_SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+            response_model=None,
+            thinking_budget=_read_thinking_budget('generate_schema'),
+            max_output_tokens=8192,
+            temperature=0.0,
             step="schema",
-        )
+        ))
     except LLMRateLimitedError:
         raise
     except Exception as e:
         raise LLMCompileError(f"generate_schema_llm_failed: {e}") from e
 
-    _record_usage("schema", model, response)
-
-    raw_text = response.text
+    raw_text = result.text
     if not raw_text:
         raise LLMCompileError("generate_schema_error: empty response")
 
@@ -1570,38 +1304,29 @@ def select_pages_for_query(
         f"Question: {question}"
     )
 
-    client = get_client()
+    provider = get_provider(model)
     try:
-        response = _with_retry(
-            lambda: client.models.generate_content(
-                model=model,
-                contents=prompt,
-                config=types.GenerateContentConfig(
-                    response_mime_type="application/json",
-                    response_schema=SelectPagesResponse,
-                    thinking_config=types.ThinkingConfig(thinking_budget=_read_thinking_budget('select_pages_for_query')),
-                    max_output_tokens=1024,
-                    temperature=0.0,
-                ),
-            ),
+        result = provider.complete(LLMRequest(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            response_model=SelectPagesResponse,
+            thinking_budget=_read_thinking_budget('select_pages_for_query'),
+            max_output_tokens=1024,
+            temperature=0.0,
             step="select_pages",
-        )
+        ))
     except LLMRateLimitedError:
         raise
     except Exception as e:
         raise LLMCompileError(f"select_pages_llm_failed: {e}") from e
 
-    _record_usage("select_pages", model, response)
-
-    raw_text = response.text
+    raw_text = result.text
     if not raw_text:
         return []
 
-    try:
-        result = SelectPagesResponse.model_validate_json(raw_text)
-        return result.page_ids
-    except Exception as e:
-        raise LLMCompileError(f"select_pages_parse_failed: {e}") from e
+    if result.parsed is None:
+        raise LLMCompileError(f"select_pages_parse_failed: {result.parse_error}") from result.parse_error
+    return result.parsed.page_ids
 
 
 # ---------------------------------------------------------------------------
@@ -1677,11 +1402,6 @@ def synthesize_answer(
     """
     import json as _json
 
-    limiter = _get_limiter()
-    acquired = limiter.try_acquire("gemini")
-    if not acquired:
-        raise LLMRateLimitedError("llm_rate_limited: bucket exhausted")
-
     # Build page context section
     page_sections: list[str] = []
     for p in pages:
@@ -1709,34 +1429,37 @@ def synthesize_answer(
     if len(prompt) > _GEMINI_INPUT_TOKEN_CAP:
         prompt = prompt[:_GEMINI_INPUT_TOKEN_CAP]
 
-    client = get_client()
+    provider = get_provider(chat_model)
     try:
-        response = client.models.generate_content(
+        # synthesize_answer skips retry (output commits to chat history
+        # downstream and can't be safely re-run after a partial response).
+        # Rate-limiting is preserved: provider.complete() acquires the bucket
+        # in its retry=False path.
+        result = provider.complete(LLMRequest(
             model=chat_model,
-            contents=prompt,
-            config=types.GenerateContentConfig(
-                system_instruction=_SYNTHESIZE_SYSTEM_PROMPT,
-                response_mime_type="application/json",
-                response_schema=SynthesizeResponse,
-                thinking_config=types.ThinkingConfig(thinking_budget=_read_thinking_budget('synthesize_answer')),
-                max_output_tokens=4096,
-                temperature=0.2,
-            ),
-        )
+            messages=[
+                {"role": "system", "content": _SYNTHESIZE_SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+            response_model=SynthesizeResponse,
+            thinking_budget=_read_thinking_budget('synthesize_answer'),
+            max_output_tokens=4096,
+            temperature=0.2,
+            step="synthesize",
+            extra={"retry": False},
+        ))
+    except LLMRateLimitedError:
+        raise
     except Exception as e:
         raise LLMCompileError(f"synthesize_llm_failed: {e}") from e
 
-    # chat: model is the user's chat_model setting (stamped per session)
-    _record_usage("synthesize", chat_model, response)
-
-    raw_text = response.text
+    raw_text = result.text
     if not raw_text:
         raise LLMCompileError("synthesize_error: empty response text")
 
-    try:
-        return SynthesizeResponse.model_validate_json(raw_text)
-    except Exception as e:
-        raise LLMCompileError(f"synthesize_parse_failed: {e}") from e
+    if result.parsed is None:
+        raise LLMCompileError(f"synthesize_parse_failed: {result.parse_error}") from result.parse_error
+    return result.parsed
 
 
 # ---------------------------------------------------------------------------
@@ -1759,11 +1482,6 @@ def generate_digest(data: Any, model: str = _DEFAULT_MODEL) -> str:
         CostCeilingError     — daily $ cap exceeded
         LLMCompileError      — empty or failed response
     """
-    limiter = _get_limiter()
-    acquired = limiter.try_acquire("gemini")
-    if not acquired:
-        raise LLMRateLimitedError("llm_rate_limited: bucket exhausted")
-
     new_titles = ", ".join(data.new_page_titles[:10]) if data.new_page_titles else "none"
     updated_titles = ", ".join(data.updated_page_titles[:10]) if data.updated_page_titles else "none"
 
@@ -1779,23 +1497,24 @@ Summarize what grew this week and what's notable. If nothing happened, say so br
 Suggest 1-2 areas that could use more sources based on the page titles.
 Keep it under 150 words. No markdown formatting — plain text with line breaks."""
 
-    client = get_client()
+    provider = get_provider(model)
     try:
-        response = client.models.generate_content(
+        result = provider.complete(LLMRequest(
             model=model,
-            contents=prompt,
-            config=types.GenerateContentConfig(
-                thinking_config=types.ThinkingConfig(thinking_budget=_read_thinking_budget('generate_digest')),
-                max_output_tokens=2048,
-                temperature=0.3,
-            ),
-        )
+            messages=[{"role": "user", "content": prompt}],
+            response_model=None,
+            thinking_budget=_read_thinking_budget('generate_digest'),
+            max_output_tokens=2048,
+            temperature=0.3,
+            step="digest",
+            extra={"retry": False},
+        ))
+    except LLMRateLimitedError:
+        raise
     except Exception as e:
         raise LLMCompileError(f"digest_llm_failed: {e}") from e
 
-    _record_usage("digest", model, response)
-
-    raw_text = response.text
+    raw_text = result.text
     if not raw_text:
         raise LLMCompileError("digest_error: empty response text")
 

--- a/nlp-service/services/llm_client.py
+++ b/nlp-service/services/llm_client.py
@@ -120,6 +120,14 @@ def _get_model_prices(model: str) -> dict[str, float]:
 # the historical hardcode so existing behaviour is preserved as a safety net.
 _DEFAULT_MODEL = "gemini-2.5-flash"
 
+# Appended to every schema-bound system prompt. DeepSeek's json_object response
+# mode silently degrades to free-form text unless the literal word "json" is
+# present in the prompt; Gemini ignores the additional natural-language hint.
+_JSON_TRAILER = (
+    "\n\nReturn the response as a single json object matching the schema "
+    "described above. Do not include any text outside the json."
+)
+
 # ---------------------------------------------------------------------------
 # Errors
 # ---------------------------------------------------------------------------
@@ -504,7 +512,7 @@ Return JSON with one field:
 
 If no contradictions are found, return {"contradictions": []}.
 Do not hallucinate contradictions.
-"""
+""" + _JSON_TRAILER
 
 
 class Contradiction(BaseModel):

--- a/nlp-service/services/llm_client.py
+++ b/nlp-service/services/llm_client.py
@@ -321,13 +321,16 @@ def lint_scan(pages: list[str], model: str = _DEFAULT_MODEL) -> LintScanResponse
     if not pages:
         return LintScanResponse(contradictions=[])
 
-    prompt = f"{_LINT_SYSTEM_PROMPT}\n\n---\n\n" + "\n\n".join(pages)
+    user_payload = "\n\n".join(pages)
 
     provider = get_provider(model)
     try:
         result = provider.complete(LLMRequest(
             model=model,
-            messages=[{"role": "user", "content": prompt}],
+            messages=[
+                {"role": "system", "content": _LINT_SYSTEM_PROMPT},
+                {"role": "user",   "content": user_payload},
+            ],
             response_model=None,
             thinking_budget=_read_thinking_budget('lint_scan'),
             max_output_tokens=4096,  # lint responses are short
@@ -481,9 +484,7 @@ def extract_source(
     keyphrase_section = _json.dumps(keyphrase_output, ensure_ascii=False) if keyphrase_output else "N/A — no keyphrase output"
     tfidf_section = _json.dumps(tfidf_output, ensure_ascii=False) if tfidf_output else "N/A — first compile, no existing wiki pages"
 
-    prompt = (
-        f"{_EXTRACTION_SYSTEM_PROMPT}\n\n"
-        f"---\n\n"
+    user_payload = (
         f"Source ID: {source_id}\n\n"
         f"NLP extraction results:\n"
         f"Named entities (spaCy NER):\n{ner_section}\n\n"
@@ -497,7 +498,10 @@ def extract_source(
     try:
         result = provider.complete(LLMRequest(
             model=model,
-            messages=[{"role": "user", "content": prompt}],
+            messages=[
+                {"role": "system", "content": _EXTRACTION_SYSTEM_PROMPT},
+                {"role": "user",   "content": user_payload},
+            ],
             response_model=LLMExtractionResponse,
             thinking_budget=_read_thinking_budget('extract_source'),
             max_output_tokens=32768,
@@ -553,9 +557,7 @@ def extract_source(
     if last_para > 0:
         half_markdown = half_markdown[:last_para]
 
-    fallback_prompt = (
-        f"{_EXTRACTION_SYSTEM_PROMPT}\n\n"
-        f"---\n\n"
+    fallback_user_payload = (
         f"Source ID: {source_id}\n\n"
         f"NLP extraction results:\n"
         f"Named entities (spaCy NER):\n{ner_section}\n\n"
@@ -568,7 +570,10 @@ def extract_source(
     try:
         fallback_result = provider.complete(LLMRequest(
             model=model,
-            messages=[{"role": "user", "content": fallback_prompt}],
+            messages=[
+                {"role": "system", "content": _EXTRACTION_SYSTEM_PROMPT},
+                {"role": "user",   "content": fallback_user_payload},
+            ],
             response_model=LLMExtractionResponse,
             thinking_budget=_read_thinking_budget('extract_source'),
             max_output_tokens=32768,
@@ -710,17 +715,16 @@ def disambiguate_entities(
         if pair_kind == "concept"
         else _DISAMBIGUATION_SYSTEM_PROMPT
     )
-    prompt = (
-        f"{system_prompt}\n\n"
-        f"---\n\n"
-        f"Pairs to resolve:\n{pairs_json}"
-    )
+    user_payload = f"Pairs to resolve:\n{pairs_json}"
 
     provider = get_provider(model)
     try:
         result = provider.complete(LLMRequest(
             model=model,
-            messages=[{"role": "user", "content": prompt}],
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user",   "content": user_payload},
+            ],
             response_model=DisambiguationResponse,
             thinking_budget=_read_thinking_budget('disambiguate_entities'),
             max_output_tokens=2048,
@@ -1299,8 +1303,7 @@ def select_pages_for_query(
     if len(index_text) > _GEMINI_INPUT_TOKEN_CAP:
         index_text = index_text[:_GEMINI_INPUT_TOKEN_CAP]
 
-    prompt = (
-        f"{_SELECT_PAGES_SYSTEM_PROMPT}\n\n"
+    user_payload = (
         f"Wiki index:\n{index_text}\n\n"
         f"Question: {question}"
     )
@@ -1309,7 +1312,10 @@ def select_pages_for_query(
     try:
         result = provider.complete(LLMRequest(
             model=model,
-            messages=[{"role": "user", "content": prompt}],
+            messages=[
+                {"role": "system", "content": _SELECT_PAGES_SYSTEM_PROMPT},
+                {"role": "user",   "content": user_payload},
+            ],
             response_model=SelectPagesResponse,
             thinking_budget=_read_thinking_budget('select_pages_for_query'),
             max_output_tokens=1024,

--- a/nlp-service/services/providers/__init__.py
+++ b/nlp-service/services/providers/__init__.py
@@ -1,0 +1,77 @@
+"""Provider abstraction for LLM backends (Gemini, DeepSeek, etc.).
+
+Phase 2 ships the Protocol + GeminiProvider; Phase 4 adds DeepSeekProvider.
+The factory dispatches by model-name prefix:
+    gemini-*    -> GeminiProvider
+    deepseek-*  -> DeepSeekProvider (Phase 4 — currently raises NotImplementedError)
+    anything else -> ValueError
+
+This module is the single source of truth for the model -> provider mapping.
+"""
+
+from __future__ import annotations
+
+from .base import (
+    LLMProvider,
+    LLMRequest,
+    LLMResult,
+    ProviderError,
+    ProviderRateLimitedError,
+    ProviderTransientError,
+)
+
+__all__ = [
+    "LLMProvider",
+    "LLMRequest",
+    "LLMResult",
+    "ProviderError",
+    "ProviderRateLimitedError",
+    "ProviderTransientError",
+    "get_provider",
+    "translate_thinking_budget",
+]
+
+
+# Cache one instance per provider name. GeminiProvider is a stateful singleton —
+# it owns the genai client and the in-process pyrate-limiter bucket. Recreating
+# it per call would defeat the limiter.
+_REGISTRY: dict[str, LLMProvider] = {}
+
+
+def get_provider(model: str) -> LLMProvider:
+    """Return the LLMProvider that handles ``model``.
+
+    Dispatch is by model-name prefix; the abstraction is pre-committed to
+    Phase 2 (Anthropic) by the same prefix shape.
+    """
+    if model.startswith("gemini-"):
+        from .gemini import GeminiProvider
+        return _REGISTRY.setdefault("gemini", GeminiProvider())
+    if model.startswith("deepseek-"):
+        raise NotImplementedError(
+            "DeepSeek provider lands in Phase 4 of the multi-provider plan"
+        )
+    raise ValueError(f"unknown provider for model {model!r}")
+
+
+def translate_thinking_budget(provider: str, call_site: str, raw: int) -> object:
+    """Translate the int thinking-budget knob into per-provider shape.
+
+    Gemini takes the int as-is (passthrough). DeepSeek's reasoning_effort is an
+    enum {disabled, low, medium, high, max}; the boundaries below mirror the
+    five Gemini thinking-budget tiers used in our settings UI (0, 1024, 2048,
+    8192, anything higher).
+    """
+    if provider == "gemini":
+        return raw
+    if provider == "deepseek":
+        if raw == 0:
+            return "disabled"
+        if raw <= 1024:
+            return "low"
+        if raw <= 2048:
+            return "medium"
+        if raw <= 8192:
+            return "high"
+        return "max"
+    raise ValueError(f"unknown provider {provider!r}")

--- a/nlp-service/services/providers/__init__.py
+++ b/nlp-service/services/providers/__init__.py
@@ -48,9 +48,8 @@ def get_provider(model: str) -> LLMProvider:
         from .gemini import GeminiProvider
         return _REGISTRY.setdefault("gemini", GeminiProvider())
     if model.startswith("deepseek-"):
-        raise NotImplementedError(
-            "DeepSeek provider lands in Phase 4 of the multi-provider plan"
-        )
+        from .deepseek import DeepSeekProvider
+        return _REGISTRY.setdefault("deepseek", DeepSeekProvider())
     raise ValueError(f"unknown provider for model {model!r}")
 
 

--- a/nlp-service/services/providers/base.py
+++ b/nlp-service/services/providers/base.py
@@ -51,9 +51,10 @@ class LLMRequest:
         (e.g. ``"extract"``, ``"draft_page"``, ``"crossref"``).
     extra
         Provider-agnostic escape hatches:
-          ``"retry": bool`` — when False, skip the retry wrapper. Use for
-              draft_page / synthesize / digest whose outputs commit downstream
-              state and can't be safely re-executed after a partial response.
+          ``"retry": bool`` — when False, skip the retry wrapper but still
+              acquire the rate-limiter bucket. Use for draft_page /
+              synthesize / digest whose outputs commit downstream state
+              and can't be safely re-executed after a partial response.
           ``"force_json_mime": bool`` — request JSON mime-type without a
               Pydantic schema. Used by lint_scan, which json.loads() the
               response manually downstream.

--- a/nlp-service/services/providers/base.py
+++ b/nlp-service/services/providers/base.py
@@ -1,0 +1,139 @@
+"""Provider Protocol + canonical request/result dataclasses.
+
+Every LLM call site in llm_client.py builds an ``LLMRequest`` and passes it to
+``provider.complete()``; the provider returns an ``LLMResult``. The dispatcher
+layer (llm_client.py) stays provider-agnostic — _salvage_extraction(),
+_check_and_record_cost(), and the per-call-site error-translation logic live
+there.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from pydantic import BaseModel
+
+
+# ---------------------------------------------------------------------------
+# Request / Result dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LLMRequest:
+    """Canonical input shape for ``LLMProvider.complete()``.
+
+    Attributes
+    ----------
+    model
+        Full model name including provider prefix ("gemini-2.5-flash",
+        "deepseek-v4-pro"). The factory dispatches on prefix.
+    messages
+        ``[{"role": "system"|"user", "content": str}, ...]``.
+        Phase 2 lets call sites pass a single user message containing the
+        already-concatenated system+user text (today's pattern); Phase 3
+        narrows to explicit ``system`` + ``user`` shape.
+    response_model
+        Pydantic schema enforced server-side (Gemini ``response_schema``,
+        DeepSeek ``response_format=json_object``). ``None`` for free-form text.
+    thinking_budget
+        Raw int budget. Provider translates: Gemini int passthrough, DeepSeek
+        enum (see ``translate_thinking_budget`` in providers/__init__.py).
+    max_output_tokens
+        Hard ceiling on response tokens; the master plan caps Gemini at 32K
+        per the repetition-loop research artifact.
+    temperature
+        ``None`` to leave provider default; explicit ``0.0`` for deterministic
+        structured output, ``0.3`` for creative-text drafts.
+    step
+        Stable label used in usage logs and cost-cap accounting
+        (e.g. ``"extract"``, ``"draft_page"``, ``"crossref"``).
+    extra
+        Provider-agnostic escape hatches:
+          ``"retry": bool`` — when False, skip the retry wrapper. Use for
+              draft_page / synthesize / digest whose outputs commit downstream
+              state and can't be safely re-executed after a partial response.
+          ``"force_json_mime": bool`` — request JSON mime-type without a
+              Pydantic schema. Used by lint_scan, which json.loads() the
+              response manually downstream.
+    """
+
+    model: str
+    messages: list[dict[str, str]]
+    response_model: type[BaseModel] | None = None
+    thinking_budget: int = 0
+    max_output_tokens: int = 2048
+    temperature: float | None = None
+    step: str = ""
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class LLMResult:
+    """Canonical output shape from ``LLMProvider.complete()``.
+
+    Attributes
+    ----------
+    text
+        Raw response text. Empty string for empty responses; never ``None``.
+    parsed
+        ``response_model.model_validate_json(text)`` if a schema was requested
+        AND parsing succeeded; ``None`` otherwise. The dispatcher's salvage
+        path checks ``parsed is None`` then re-attempts parse + json-repair.
+    parse_error
+        The exception raised by the in-provider parse attempt, when
+        ``response_model`` was set but parsing failed. ``None`` if parsing
+        succeeded or if no parse was attempted. Lets the dispatcher chain
+        the error message into LLMCompileError without re-running the parse.
+    usage
+        Provider-native token counts. The dispatcher passes this dict
+        verbatim to ``provider.cost_usd(model, usage)``.
+    finish_reason
+        Provider-native finish reason string. Gemini values include "STOP"
+        and "MAX_TOKENS"; the dispatcher's salvage path checks for the
+        latter to decide whether to run the halved-input fallback.
+    """
+
+    text: str
+    parsed: BaseModel | None
+    parse_error: Exception | None
+    usage: dict[str, int]
+    finish_reason: str
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class ProviderError(Exception):
+    """Base for provider-side errors. Dispatcher wraps as needed."""
+
+
+class ProviderRateLimitedError(ProviderError):
+    """In-process rate-limiter bucket exhausted."""
+
+
+class ProviderTransientError(ProviderError):
+    """Retryable upstream error (408/429/5xx)."""
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+class LLMProvider(Protocol):
+    """Minimal contract every backend must satisfy.
+
+    Implementations are stateful (they own a SDK client + a rate-limiter
+    bucket). The factory in providers/__init__.py caches one instance per
+    provider name.
+    """
+
+    name: str
+
+    def complete(self, req: LLMRequest) -> LLMResult: ...
+
+    def cost_usd(self, model: str, usage: dict[str, int]) -> float: ...

--- a/nlp-service/services/providers/deepseek.py
+++ b/nlp-service/services/providers/deepseek.py
@@ -1,0 +1,292 @@
+"""DeepSeek backend for the LLMProvider Protocol.
+
+Mirrors the shape of GeminiProvider: own httpx client, own pyrate-limiter
+bucket, retry on 408/429/5xx, lazy import of llm_client._check_and_record_cost
+so the test fixture's monkeypatch keeps working.
+
+DeepSeek API specifics (2026-05-05):
+- OpenAI-compatible POST /v1/chat/completions on https://api.deepseek.com.
+- json_object response_format requires the literal word "json" in the prompt
+  (Phase 1 system-prompt trailers cover this for every schema-bound site).
+- Reasoning controlled via ``reasoning_effort`` enum (``disabled``, ``low``,
+  ``medium``, ``high``, ``max``); translated from the int thinking_budget in
+  ``providers.translate_thinking_budget``.
+- Usage fields differ from Gemini: ``prompt_tokens``, ``completion_tokens``,
+  ``prompt_cache_hit_tokens``. The Gemini-shape ``thoughts_token_count`` is
+  absent — DeepSeek folds reasoning into completion_tokens.
+- Discount window through 2026-05-31T15:59:00Z (UTC). After that the wall
+  clock flips to list pricing automatically; operators can override via
+  DEEPSEEK_*_USD_PER_M env vars.
+
+Like gemini.py, this module MUST NOT import services.llm_client at module
+level — gemini.py and deepseek.py are loaded lazily by
+``providers.get_provider()`` AFTER llm_client.py finishes its module-load.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+from pydantic import BaseModel
+from pyrate_limiter import Duration, InMemoryBucket, Limiter, Rate
+
+from .base import LLMRequest, LLMResult
+
+
+# ---------------------------------------------------------------------------
+# Configuration from environment
+# ---------------------------------------------------------------------------
+
+_DEEPSEEK_API_KEY = os.environ.get("DEEPSEEK_API_KEY", "").strip()
+# DeepSeek documents 60 RPM as the per-minute cap for the standard tier.
+# Conservative even at the paid tier; operators can raise via the env var.
+_DEEPSEEK_RPM = int(os.environ.get("DEEPSEEK_RPM", "60"))
+
+
+# ---------------------------------------------------------------------------
+# Pricing (DeepSeek V4 Pro, $/M tokens)
+# ---------------------------------------------------------------------------
+#
+# Discount window through 2026-05-31T15:59:00Z UTC. After that the code path
+# automatically flips to the list-pricing dict (no manual edit at deadline).
+# Each rate is ~4× the discount; still below Gemini Flash on equivalent calls
+# in our 28-call spike.
+
+DISCOUNT_UNTIL = datetime(2026, 5, 31, 15, 59, 0, tzinfo=timezone.utc)
+_PRICES_DISCOUNT = {"input": 0.07, "output": 0.27, "cache": 0.014}
+_PRICES_LIST     = {"input": 0.27, "output": 1.10, "cache": 0.054}
+
+
+def _prices_now() -> dict[str, float]:
+    """Per-million-token prices honoring the discount window + env overrides.
+
+    Wall-clock comparison: assumes the container clock is UTC (Docker default).
+    Operators on non-UTC hosts can pin via DEEPSEEK_*_USD_PER_M.
+    """
+    base = _PRICES_DISCOUNT if datetime.now(timezone.utc) < DISCOUNT_UNTIL else _PRICES_LIST
+    return {
+        "input":  float(os.environ.get("DEEPSEEK_INPUT_USD_PER_M",  base["input"])),
+        "output": float(os.environ.get("DEEPSEEK_OUTPUT_USD_PER_M", base["output"])),
+        "cache":  float(os.environ.get("DEEPSEEK_CACHE_USD_PER_M",  base["cache"])),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Retry semantics — same status codes as Gemini, kept duplicated so the two
+# providers can evolve their retry sets independently if upstream behaviour
+# diverges. DeepSeek docs confirm 408/429/5xx are the right retryable set.
+# ---------------------------------------------------------------------------
+
+_RETRYABLE_STATUSES: frozenset[int] = frozenset({408, 429, 500, 502, 503, 504})
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter — own bucket so Gemini and DeepSeek don't share the cap
+# ---------------------------------------------------------------------------
+
+_limiter: Limiter | None = None
+
+
+def _get_limiter() -> Limiter:
+    global _limiter
+    if _limiter is None:
+        _limiter = Limiter(
+            InMemoryBucket([Rate(_DEEPSEEK_RPM, Duration.MINUTE)]),
+            raise_when_fail=False,
+            max_delay=60_000,  # wait up to 60s before giving up
+        )
+    return _limiter
+
+
+# ---------------------------------------------------------------------------
+# httpx client (lazy init)
+# ---------------------------------------------------------------------------
+
+_client: httpx.Client | None = None
+
+
+def get_client() -> httpx.Client:
+    global _client
+    if _client is None:
+        if not _DEEPSEEK_API_KEY:
+            raise RuntimeError("DEEPSEEK_API_KEY not set")
+        _client = httpx.Client(
+            base_url="https://api.deepseek.com",
+            headers={"Authorization": f"Bearer {_DEEPSEEK_API_KEY}"},
+            timeout=120.0,
+        )
+    return _client
+
+
+# ---------------------------------------------------------------------------
+# Logging helpers
+# ---------------------------------------------------------------------------
+
+
+def _log_usage(step: str, finish: str, usage: dict[str, int]) -> None:
+    try:
+        in_  = usage.get("prompt_tokens", 0)
+        out_ = usage.get("completion_tokens", 0)
+        hit_ = usage.get("prompt_cache_hit_tokens", 0)
+        print(
+            f"[deepseek] step={step} finish={finish} in={in_} out={out_} cache_hit={hit_}",
+            file=sys.stderr,
+            flush=True,
+        )
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# DeepSeekProvider
+# ---------------------------------------------------------------------------
+
+
+class DeepSeekProvider:
+    """LLMProvider implementation backed by DeepSeek's OpenAI-compatible HTTP API.
+
+    Owns a lazily-initialised httpx client and a per-process pyrate-limiter
+    bucket. ``providers.get_provider("deepseek-...")`` caches one instance per
+    process.
+    """
+
+    name = "deepseek"
+
+    def complete(self, req: LLMRequest) -> LLMResult:
+        # Lazy import: keep the public LLMRateLimitedError type at the
+        # dispatcher layer; avoid circular import at module load.
+        from services.llm_client import LLMRateLimitedError
+        from . import translate_thinking_budget
+
+        body: dict[str, Any] = {
+            "model": req.model,
+            "messages": req.messages,
+            "max_tokens": req.max_output_tokens,
+            "temperature": req.temperature if req.temperature is not None else 0.0,
+        }
+        if req.response_model is not None:
+            body["response_format"] = {"type": "json_object"}
+        if req.thinking_budget > 0:
+            body["reasoning_effort"] = translate_thinking_budget(
+                "deepseek", req.step, req.thinking_budget
+            )
+
+        client = get_client()
+        limiter = _get_limiter()
+        last_exc: Exception | None = None
+
+        max_attempts = 3 if req.extra.get("retry", True) else 1
+        for attempt in range(max_attempts):
+            if not limiter.try_acquire("deepseek"):
+                raise LLMRateLimitedError(
+                    f"llm_rate_limited: bucket exhausted on {req.step}"
+                )
+            try:
+                response = client.post("/v1/chat/completions", json=body)
+            except (
+                httpx.ConnectError,
+                httpx.PoolTimeout,
+                httpx.ReadTimeout,
+                httpx.WriteTimeout,
+                httpx.RemoteProtocolError,
+                httpx.WriteError,
+                httpx.ReadError,
+            ) as e:
+                last_exc = e
+                err_class = type(e).__name__
+            else:
+                if response.status_code == 200:
+                    return self._unpack(req, response)
+                if response.status_code not in _RETRYABLE_STATUSES:
+                    raise RuntimeError(
+                        f"deepseek http {response.status_code}: "
+                        f"{response.text[:500]}"
+                    )
+                last_exc = RuntimeError(
+                    f"deepseek http {response.status_code}: {response.text[:200]}"
+                )
+                err_class = f"HTTP{response.status_code}"
+
+            if attempt < max_attempts - 1:
+                delay = 0.5 * (2 ** attempt)
+                print(
+                    f"[llm-retry] deepseek {req.step} attempt {attempt + 1}/"
+                    f"{max_attempts} after {err_class}: "
+                    f"{str(last_exc)[:200]} — sleeping {delay}s",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                time.sleep(delay)
+
+        assert last_exc is not None
+        raise last_exc
+
+    def _unpack(self, req: LLMRequest, response: httpx.Response) -> LLMResult:
+        data = response.json()
+        choice = data["choices"][0]
+        text = choice["message"]["content"] or ""
+        finish_reason = choice.get("finish_reason", "stop")
+        # DeepSeek-native usage shape:
+        usage_native = {
+            "prompt_tokens":           int((data.get("usage") or {}).get("prompt_tokens", 0) or 0),
+            "completion_tokens":       int((data.get("usage") or {}).get("completion_tokens", 0) or 0),
+            "prompt_cache_hit_tokens": int((data.get("usage") or {}).get("prompt_cache_hit_tokens", 0) or 0),
+        }
+        _log_usage(req.step, finish_reason, usage_native)
+
+        # Cost-cap accounting routes through the dispatcher with a Gemini-
+        # shape signature; map DeepSeek fields to that signature. The
+        # dispatcher then calls back into provider.cost_usd(model, usage)
+        # where ``usage`` is the same Gemini-shape dict — see ``cost_usd``
+        # below for how DeepSeek translates back.
+        if usage_native["prompt_tokens"] or usage_native["completion_tokens"]:
+            from services import llm_client  # lazy
+            llm_client._check_and_record_cost(
+                req.model,
+                usage_native["prompt_tokens"],            # -> prompt_tokens
+                usage_native["prompt_cache_hit_tokens"],  # -> cached_tokens
+                usage_native["completion_tokens"],        # -> output_tokens
+                0,                                          # -> thought_tokens (folded into completion_tokens)
+            )
+
+        parsed: BaseModel | None = None
+        parse_error: Exception | None = None
+        if req.response_model is not None and text:
+            try:
+                parsed = req.response_model.model_validate_json(text)
+            except Exception as e:
+                parse_error = e
+
+        # LLMResult.usage stores the DeepSeek-native shape — the dispatcher
+        # never reads it directly (cost goes through cost_usd), so the wire
+        # shape can be provider-native here.
+        return LLMResult(
+            text=text,
+            parsed=parsed,
+            parse_error=parse_error,
+            usage=usage_native,
+            finish_reason=str(finish_reason).upper(),
+        )
+
+    def cost_usd(self, model: str, usage: dict[str, int]) -> float:
+        """Per-call cost. The dispatcher passes a Gemini-shape dict
+        (prompt_token_count, cached_content_token_count, candidates_token_count,
+        thoughts_token_count) — translate to DeepSeek's pricing formula.
+        """
+        prices = _prices_now()
+        prompt = usage.get("prompt_token_count", 0)
+        cached = usage.get("cached_content_token_count", 0)
+        # DeepSeek folds reasoning into completion_tokens; the dispatcher's
+        # thoughts_token_count is always 0 for us, but we sum to be safe.
+        output_ = usage.get("candidates_token_count", 0) + usage.get("thoughts_token_count", 0)
+        fresh = max(0, prompt - cached)
+        return (
+            (fresh   / 1_000_000) * prices["input"]
+          + (cached  / 1_000_000) * prices["cache"]
+          + (output_ / 1_000_000) * prices["output"]
+        )

--- a/nlp-service/services/providers/gemini.py
+++ b/nlp-service/services/providers/gemini.py
@@ -1,0 +1,357 @@
+"""Gemini backend for the LLMProvider Protocol.
+
+Behaviour-preserving extract from llm_client.py: client construction,
+retry wrapper, rate limiter, price table, MAX_TOKENS detection, usage
+logging. The dispatcher (llm_client.py) keeps the salvage path, the
+daily-cap accounting, and the per-call-site error translation —
+those are provider-agnostic.
+
+This module MUST NOT import services.llm_client at module level — gemini.py
+is loaded lazily by ``providers.get_provider()`` AFTER llm_client.py has
+finished its own module-load. Functions that need llm_client.* (the
+``LLMRateLimitedError`` type, the ``_check_and_record_cost`` callback) use
+lazy ``from services import llm_client`` inside the function body. That
+also keeps the test fixture's
+``monkeypatch.setattr(llm_client, "_check_and_record_cost", mock)`` effective
+via attribute lookup at call time.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from typing import Any, Callable, TypeVar
+
+import httpx
+from google import genai
+from google.genai import types
+from pydantic import BaseModel
+from pyrate_limiter import Duration, InMemoryBucket, Limiter, Rate
+
+from .base import LLMRequest, LLMResult
+
+# google-genai raises its own error types (ClientError / ServerError / APIError)
+# that generic retry predicates miss — see cookbook issue #1091. Catch the
+# APIError base and filter by status code below. Tolerate SDK layout drift
+# (the class moved between minor releases): a missing module just means the
+# retry loop's ``except _APIError`` becomes a safe no-op.
+try:
+    from google.genai import errors as _genai_errors
+    _APIError: Any = _genai_errors.APIError
+except (ImportError, AttributeError):  # pragma: no cover
+    _APIError = tuple()
+
+T = TypeVar("T")
+
+
+# ---------------------------------------------------------------------------
+# Configuration from environment
+# ---------------------------------------------------------------------------
+
+_GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY", "").strip()
+_GEMINI_RPM = int(os.environ.get("GEMINI_RPM", "800"))
+
+
+# ---------------------------------------------------------------------------
+# Pricing (Gemini 2.5-family, $/M tokens, 2026-04 public rates)
+# ---------------------------------------------------------------------------
+#
+# cost = (prompt_tokens - cached_tokens) * input_rate
+#      + cached_tokens                   * cache_rate    (≈ 0.1x input)
+#      + (candidates_tokens + thoughts_tokens) * output_rate
+#
+# Thinking tokens billed at the output rate per
+#   https://ai.google.dev/gemini-api/docs/thinking
+# Cached tokens are still counted in prompt_token_count per
+#   https://ai.google.dev/api/generate-content
+# so we subtract explicitly to avoid double-counting.
+
+_MODEL_PRICES: dict[str, dict[str, float]] = {
+    "gemini-2.5-flash-lite": {"input": 0.10, "output": 0.40, "cache": 0.01},
+    "gemini-2.5-flash":      {"input": 0.30, "output": 2.50, "cache": 0.03},
+    # Pro tiered — ≤200k prompts use the small-context SKU. >200k switches to
+    # $2.50 / $15 / $0.25; we don't auto-detect that boundary here. If Pro is
+    # routinely exercised with >200k prompts, override via env vars below.
+    "gemini-2.5-pro":        {"input": 1.25, "output": 10.00, "cache": 0.125},
+}
+
+# Env overrides — last-resort escape hatch when Gemini changes pricing and
+# the code hasn't been updated yet. Apply to all models.
+_INPUT_PRICE_OVERRIDE  = os.environ.get("GEMINI_INPUT_PRICE_PER_M")
+_OUTPUT_PRICE_OVERRIDE = os.environ.get("GEMINI_OUTPUT_PRICE_PER_M")
+_CACHE_PRICE_OVERRIDE  = os.environ.get("GEMINI_CACHE_PRICE_PER_M")
+
+
+def _get_model_prices(model: str) -> dict[str, float]:
+    """Return {input, output, cache} per-million-token prices for ``model``.
+
+    Falls back to gemini-2.5-flash-lite rates for unknown models so an SDK
+    bump to a new model name doesn't silently crash pricing.
+    """
+    base = _MODEL_PRICES.get(model, _MODEL_PRICES["gemini-2.5-flash-lite"])
+    return {
+        "input":  float(_INPUT_PRICE_OVERRIDE)  if _INPUT_PRICE_OVERRIDE  else base["input"],
+        "output": float(_OUTPUT_PRICE_OVERRIDE) if _OUTPUT_PRICE_OVERRIDE else base["output"],
+        "cache":  float(_CACHE_PRICE_OVERRIDE)  if _CACHE_PRICE_OVERRIDE  else base["cache"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter — in-process token bucket, async-safe
+# ---------------------------------------------------------------------------
+
+_limiter: Limiter | None = None
+
+
+def _get_limiter() -> Limiter:
+    global _limiter
+    if _limiter is None:
+        _limiter = Limiter(
+            InMemoryBucket([Rate(_GEMINI_RPM, Duration.MINUTE)]),
+            raise_when_fail=False,
+            max_delay=60_000,  # wait up to 60s before giving up
+        )
+    return _limiter
+
+
+# ---------------------------------------------------------------------------
+# Gemini client (lazy init — validated at startup by main.py lifespan)
+# ---------------------------------------------------------------------------
+
+_client: genai.Client | None = None
+
+
+def get_client() -> genai.Client:
+    global _client
+    if _client is None:
+        if not _GEMINI_API_KEY:
+            raise RuntimeError("GEMINI_API_KEY not set")
+        _client = genai.Client(api_key=_GEMINI_API_KEY)
+    return _client
+
+
+# ---------------------------------------------------------------------------
+# Retry wrapper for transient upstream errors. google-genai 1.12.1 has no
+# built-in retry; HttpRetryOptions was added in ≥1.65 — a 60-version jump
+# we're not taking mid-debug. Retries on connection-class errors + Gemini
+# APIError with retryable status codes (408/429/5xx). The rate-limiter
+# token is re-acquired per attempt so retries count against the 800 RPM cap.
+# Apply only to read-only analyzers (extract/resolve/match/triage/…) —
+# never wrap draft_page / synthesize / digest, whose outputs commit
+# downstream state and can't be safely re-executed after a partial response.
+# ---------------------------------------------------------------------------
+
+_RETRYABLE_STATUSES: frozenset[int] = frozenset({408, 429, 500, 502, 503, 504})
+
+
+def _with_retry(
+    fn: Callable[[], T], step: str, *, max_attempts: int = 3, base_delay: float = 0.5,
+) -> T:
+    # Lazy import: keeps the public LLMRateLimitedError type at the dispatcher
+    # layer, avoids circular import at module load time.
+    from services.llm_client import LLMRateLimitedError
+
+    limiter = _get_limiter()
+    last_exc: Exception | None = None
+
+    for i in range(max_attempts):
+        if not limiter.try_acquire("gemini"):
+            raise LLMRateLimitedError(f"llm_rate_limited: bucket exhausted on {step}")
+
+        try:
+            return fn()
+        except (
+            httpx.ConnectError,
+            httpx.PoolTimeout,
+            httpx.ReadTimeout,
+            httpx.WriteTimeout,
+            httpx.RemoteProtocolError,
+            httpx.WriteError,
+            httpx.ReadError,
+        ) as e:
+            last_exc = e
+            err_class = type(e).__name__
+        except _APIError as e:
+            code = getattr(e, "code", None) or getattr(e, "status_code", None)
+            if code not in _RETRYABLE_STATUSES:
+                raise
+            last_exc = e
+            err_class = f"APIError{code}"
+
+        if i < max_attempts - 1:
+            delay = base_delay * (2 ** i)
+            print(
+                f"[llm-retry] {step} attempt {i + 1}/{max_attempts} after "
+                f"{err_class}: {str(last_exc)[:200]} — sleeping {delay}s",
+                file=sys.stderr,
+                flush=True,
+            )
+            time.sleep(delay)
+
+    assert last_exc is not None
+    raise last_exc
+
+
+# ---------------------------------------------------------------------------
+# Logging / usage helpers
+# ---------------------------------------------------------------------------
+
+
+def _log_usage(step: str, response: Any) -> None:
+    """One-line stderr log per Gemini call: finish_reason + token counts.
+
+    Ground truth for distinguishing a MAX_TOKENS truncation from a normal
+    STOP, an empty response, or a thinking-budget exhaustion. Non-fatal:
+    a broken log must never break the caller, so swallow any exception.
+    """
+    try:
+        candidates = getattr(response, "candidates", None) or []
+        finish = "NONE"
+        if candidates:
+            fr = getattr(candidates[0], "finish_reason", None)
+            finish = str(fr).split(".")[-1] if fr is not None else "NONE"
+        usage = getattr(response, "usage_metadata", None)
+        if usage is not None:
+            ptok = getattr(usage, "prompt_token_count", 0) or 0
+            ctok = getattr(usage, "candidates_token_count", 0) or 0
+            ttok = getattr(usage, "thoughts_token_count", 0) or 0
+            print(
+                f"[gemini] step={step} finish={finish} in={ptok} out={ctok} thinking={ttok}",
+                file=sys.stderr,
+                flush=True,
+            )
+        else:
+            print(f"[gemini] step={step} finish={finish} usage=none", file=sys.stderr, flush=True)
+    except Exception:
+        pass
+
+
+def _read_finish_reason(response: Any) -> str:
+    candidates = getattr(response, "candidates", None) or []
+    if not candidates:
+        return "NONE"
+    fr = getattr(candidates[0], "finish_reason", None)
+    return str(fr).split(".")[-1] if fr is not None else "NONE"
+
+
+def _read_usage_dict(response: Any) -> dict[str, int]:
+    usage = getattr(response, "usage_metadata", None)
+    if usage is None:
+        return {}
+    return {
+        "prompt_token_count":         int(getattr(usage, "prompt_token_count", 0) or 0),
+        "cached_content_token_count": int(getattr(usage, "cached_content_token_count", 0) or 0),
+        "candidates_token_count":     int(getattr(usage, "candidates_token_count", 0) or 0),
+        "thoughts_token_count":       int(getattr(usage, "thoughts_token_count", 0) or 0),
+    }
+
+
+# ---------------------------------------------------------------------------
+# GeminiProvider
+# ---------------------------------------------------------------------------
+
+
+class GeminiProvider:
+    """LLMProvider implementation backed by the google-genai SDK.
+
+    Owns the lazily-initialised genai client and the per-process
+    pyrate-limiter bucket. ``providers.get_provider("gemini-...")`` caches
+    one instance per process.
+    """
+
+    name = "gemini"
+
+    def complete(self, req: LLMRequest) -> LLMResult:
+        # Build genai config from the canonical LLMRequest fields. Today's
+        # call sites always set thinking_config (even when budget=0) — match
+        # that contract verbatim so behaviour is byte-for-byte preserved.
+        config_kwargs: dict[str, Any] = {
+            "max_output_tokens": req.max_output_tokens,
+            "thinking_config": types.ThinkingConfig(thinking_budget=req.thinking_budget),
+        }
+        if req.temperature is not None:
+            config_kwargs["temperature"] = req.temperature
+        if req.response_model is not None:
+            config_kwargs["response_mime_type"] = "application/json"
+            config_kwargs["response_schema"] = req.response_model
+        elif req.extra.get("force_json_mime"):
+            # lint_scan today: response_mime_type=json without a Pydantic schema.
+            config_kwargs["response_mime_type"] = "application/json"
+
+        # Phase 2 dual-shape adapter: a lone user message goes straight to
+        # ``contents`` (today's concatenated pattern); explicit system+user
+        # messages map system to ``system_instruction``. Phase 3 narrows to
+        # always-explicit roles.
+        system_parts = [m["content"] for m in req.messages if m.get("role") == "system"]
+        user_parts   = [m["content"] for m in req.messages if m.get("role") == "user"]
+        if system_parts:
+            config_kwargs["system_instruction"] = "\n\n".join(system_parts)
+        contents = user_parts[0] if len(user_parts) == 1 else "\n\n".join(user_parts)
+
+        config = types.GenerateContentConfig(**config_kwargs)
+        client = get_client()
+
+        def _call() -> Any:
+            return client.models.generate_content(model=req.model, contents=contents, config=config)
+
+        if req.extra.get("retry", True):
+            response = _with_retry(_call, step=req.step)
+        else:
+            # Free-form / state-committing paths (draft_page, synthesize, digest):
+            # acquire the limiter manually and skip retry — semantically
+            # identical to the existing inline rate-limit checks.
+            from services.llm_client import LLMRateLimitedError  # lazy
+            limiter = _get_limiter()
+            if not limiter.try_acquire("gemini"):
+                raise LLMRateLimitedError("llm_rate_limited: bucket exhausted")
+            response = _call()
+
+        # Log + record cost. Lazy import respects test-fixture monkeypatching
+        # of llm_client._check_and_record_cost.
+        _log_usage(req.step, response)
+        usage_dict = _read_usage_dict(response)
+        if usage_dict:
+            from services import llm_client  # lazy
+            llm_client._check_and_record_cost(
+                req.model,
+                usage_dict["prompt_token_count"],
+                usage_dict["cached_content_token_count"],
+                usage_dict["candidates_token_count"],
+                usage_dict["thoughts_token_count"],
+            )
+
+        # Pack result. Parse on demand if a Pydantic schema was requested;
+        # the dispatcher's salvage path (extract_source) checks ``parsed is None``
+        # and re-runs json-repair / halved-input fallback when needed.
+        text = response.text or ""
+        parsed: BaseModel | None = None
+        parse_error: Exception | None = None
+        if req.response_model is not None and text:
+            try:
+                parsed = req.response_model.model_validate_json(text)
+            except Exception as e:
+                parse_error = e
+
+        return LLMResult(
+            text=text,
+            parsed=parsed,
+            parse_error=parse_error,
+            usage=usage_dict,
+            finish_reason=_read_finish_reason(response),
+        )
+
+    def cost_usd(self, model: str, usage: dict[str, int]) -> float:
+        """Per-call cost in USD, computed from Gemini's usage_metadata fields."""
+        prices = _get_model_prices(model)
+        prompt = usage.get("prompt_token_count", 0)
+        cached = usage.get("cached_content_token_count", 0)
+        out_   = usage.get("candidates_token_count", 0)
+        think  = usage.get("thoughts_token_count", 0)
+        fresh = max(0, prompt - cached)
+        return (
+            (fresh   / 1_000_000) * prices["input"]
+          + (cached  / 1_000_000) * prices["cache"]
+          + (out_    / 1_000_000) * prices["output"]
+          + (think   / 1_000_000) * prices["output"]
+        )

--- a/nlp-service/services/providers/test_providers.py
+++ b/nlp-service/services/providers/test_providers.py
@@ -117,6 +117,114 @@ def test_get_provider_unknown_raises_value_error():
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Per-provider extract-input cap (Phase 3 task 3.2)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_input_cap_for_gemini_returns_gemini_cap():
+    from services.llm_client import _extract_input_cap_for, _GEMINI_EXTRACT_INPUT_CAP
+
+    assert _extract_input_cap_for("gemini-2.5-flash") == _GEMINI_EXTRACT_INPUT_CAP
+    assert _extract_input_cap_for("gemini-2.5-pro") == _GEMINI_EXTRACT_INPUT_CAP
+    assert _extract_input_cap_for("gemini-2.5-flash-lite") == _GEMINI_EXTRACT_INPUT_CAP
+
+
+def test_extract_input_cap_for_deepseek_returns_deepseek_cap():
+    from services.llm_client import _extract_input_cap_for, _DEEPSEEK_INPUT_CHAR_CAP
+
+    assert _extract_input_cap_for("deepseek-v4-pro") == _DEEPSEEK_INPUT_CHAR_CAP
+    # Future DeepSeek SKUs would also fall through the prefix branch.
+    assert _extract_input_cap_for("deepseek-v5-something") == _DEEPSEEK_INPUT_CHAR_CAP
+
+
+def test_extract_input_cap_for_unknown_falls_back_to_gemini_cap():
+    """Unknown prefixes default to the tighter Gemini cap. Better to truncate
+    than to ship a bigger input on a provider whose limits we haven't
+    validated yet."""
+    from services.llm_client import _extract_input_cap_for, _GEMINI_EXTRACT_INPUT_CAP
+
+    assert _extract_input_cap_for("anthropic-claude-4-7") == _GEMINI_EXTRACT_INPUT_CAP
+
+
+# ---------------------------------------------------------------------------
+# Halved-input fallback gate (Phase 3 task 3.3)
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_provider(call_log):
+    """Build a stub provider whose ``complete()`` always returns a parse
+    failure with finish_reason='MAX_TOKENS'. Records every call into
+    ``call_log`` so tests can assert how many times it was invoked.
+    """
+    from services.providers.base import LLMResult
+
+    class _FakeProvider:
+        name = "fake"
+
+        def complete(self, req):
+            call_log.append(req.step)
+            return LLMResult(
+                text='{"entities": [{"name": "x"',  # truncated mid-string
+                parsed=None,
+                parse_error=ValueError("truncated"),
+                usage={},
+                finish_reason="MAX_TOKENS",
+            )
+
+        def cost_usd(self, model, usage):
+            return 0.0
+
+    return _FakeProvider()
+
+
+def test_extract_halved_fallback_runs_on_gemini(monkeypatch):
+    """On gemini-* models with finish_reason=MAX_TOKENS and salvage failure,
+    extract_source retries once with halved input — provider.complete is
+    called twice (extract + extract-fallback)."""
+    from services import llm_client
+
+    log: list[str] = []
+    monkeypatch.setattr(llm_client, "get_provider", lambda m: _make_fake_provider(log))
+    monkeypatch.setattr(llm_client, "_salvage_extraction", lambda raw: None)
+
+    with pytest.raises(llm_client.LLMCompileError):
+        llm_client.extract_source(
+            source_id="s1",
+            markdown="x" * 1000,
+            ner_output={},
+            keyphrase_output=None,
+            tfidf_output=None,
+            model="gemini-2.5-flash",
+        )
+
+    assert log == ["extract", "extract-fallback"]
+
+
+def test_extract_halved_fallback_skipped_on_non_gemini(monkeypatch):
+    """For deepseek-* (or any non-gemini prefix), the halved-input fallback
+    must be skipped — only one provider.complete call is made and the
+    LLMCompileError surfaces the original parse error."""
+    from services import llm_client
+
+    log: list[str] = []
+    monkeypatch.setattr(llm_client, "get_provider", lambda m: _make_fake_provider(log))
+    monkeypatch.setattr(llm_client, "_salvage_extraction", lambda raw: None)
+
+    with pytest.raises(llm_client.LLMCompileError) as exc:
+        llm_client.extract_source(
+            source_id="s1",
+            markdown="x" * 1000,
+            ner_output={},
+            keyphrase_output=None,
+            tfidf_output=None,
+            model="deepseek-v4-pro",
+        )
+
+    assert log == ["extract"], "halved-fallback must NOT run on deepseek-*"
+    assert "extract_llm_parse_failed" in str(exc.value)
+
+
 def test_cost_cap_error_message_says_llm_not_gemini(monkeypatch, tmp_path):
     """The cap error message generalises now that DeepSeek is on the way.
 

--- a/nlp-service/services/providers/test_providers.py
+++ b/nlp-service/services/providers/test_providers.py
@@ -78,6 +78,24 @@ def test_llm_result_carries_text_parsed_usage_finish():
 # ---------------------------------------------------------------------------
 
 
+def test_get_provider_dispatches_gemini_prefix(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    # Reset cached singleton so the env override takes effect for this test.
+    from services import providers as P
+    P._REGISTRY.clear()
+
+    from services.providers import get_provider
+    from services.providers.gemini import GeminiProvider
+
+    p = get_provider("gemini-2.5-flash")
+    assert isinstance(p, GeminiProvider)
+    assert p.name == "gemini"
+    # Same instance returned on repeat lookups (singleton cache).
+    assert get_provider("gemini-2.5-pro") is p
+
+    P._REGISTRY.clear()
+
+
 def test_get_provider_deepseek_raises_until_phase_4():
     from services.providers import get_provider
 
@@ -92,6 +110,31 @@ def test_get_provider_unknown_raises_value_error():
         get_provider("anthropic-claude-4-7")
     with pytest.raises(ValueError, match="unknown provider"):
         get_provider("not-a-real-model")
+
+
+# ---------------------------------------------------------------------------
+# Cost-cap message generalisation (Phase 2 task 2.3)
+# ---------------------------------------------------------------------------
+
+
+def test_cost_cap_error_message_says_llm_not_gemini(monkeypatch, tmp_path):
+    """The cap error message generalises now that DeepSeek is on the way.
+
+    Pre-Phase-2.3 the message said "Daily Gemini spend"; Phase 4 will see
+    operators run DeepSeek-only sessions, where "Gemini" would be misleading.
+    """
+    from services import llm_client
+    # Point the cap files at a temp dir + force a small cap.
+    monkeypatch.setattr(llm_client, "_CAP_FILE", tmp_path / "cap.json")
+    monkeypatch.setattr(llm_client, "_CONFIG_FILE", tmp_path / "cfg.json")
+    monkeypatch.setattr(llm_client, "_read_daily_cap_usd", lambda: 0.0001)
+
+    with pytest.raises(llm_client.CostCeilingError) as exc:
+        # Use enough tokens to definitely exceed 0.0001 cap on flash pricing
+        # (input rate 0.30 / M; 1M prompt tokens = $0.30, well over $0.0001).
+        llm_client._check_and_record_cost("gemini-2.5-flash", 1_000_000, 0, 1_000_000, 0)
+    assert "Daily LLM spend" in str(exc.value)
+    assert "Gemini" not in str(exc.value)
 
 
 # ---------------------------------------------------------------------------

--- a/nlp-service/services/providers/test_providers.py
+++ b/nlp-service/services/providers/test_providers.py
@@ -1,0 +1,133 @@
+"""Unit tests for the provider abstraction.
+
+Phase 2 covers: LLMRequest/LLMResult shape, factory dispatch (gemini-* -> ok,
+deepseek-* -> NotImplementedError, anything else -> ValueError),
+translate_thinking_budget mapping. Phase 4 will extend with DeepSeek-specific
+tests (json_object injection, retry on 429, discount-boundary).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+
+# ---------------------------------------------------------------------------
+# LLMRequest / LLMResult shape
+# ---------------------------------------------------------------------------
+
+
+def test_llm_request_minimal_shape():
+    from services.providers.base import LLMRequest
+
+    req = LLMRequest(
+        model="gemini-2.5-flash",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    assert req.model == "gemini-2.5-flash"
+    assert req.messages[0]["role"] == "user"
+    assert req.response_model is None
+    assert req.thinking_budget == 0
+    assert req.temperature is None
+    assert req.extra == {}
+
+
+def test_llm_request_full_shape():
+    from services.providers.base import LLMRequest
+
+    class Out(BaseModel):
+        ok: bool
+
+    req = LLMRequest(
+        model="gemini-2.5-flash",
+        messages=[
+            {"role": "system", "content": "be terse"},
+            {"role": "user", "content": "go"},
+        ],
+        response_model=Out,
+        thinking_budget=1024,
+        max_output_tokens=4096,
+        temperature=0.0,
+        step="test",
+        extra={"retry": False, "force_json_mime": True},
+    )
+    assert req.response_model is Out
+    assert req.thinking_budget == 1024
+    assert req.extra["retry"] is False
+
+
+def test_llm_result_carries_text_parsed_usage_finish():
+    from services.providers.base import LLMResult
+
+    res = LLMResult(
+        text="ok",
+        parsed=None,
+        parse_error=None,
+        usage={"prompt_token_count": 10},
+        finish_reason="STOP",
+    )
+    assert res.text == "ok"
+    assert res.parsed is None
+    assert res.parse_error is None
+    assert res.usage["prompt_token_count"] == 10
+    assert res.finish_reason == "STOP"
+
+
+# ---------------------------------------------------------------------------
+# Factory dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_get_provider_deepseek_raises_until_phase_4():
+    from services.providers import get_provider
+
+    with pytest.raises(NotImplementedError):
+        get_provider("deepseek-v4-pro")
+
+
+def test_get_provider_unknown_raises_value_error():
+    from services.providers import get_provider
+
+    with pytest.raises(ValueError, match="unknown provider"):
+        get_provider("anthropic-claude-4-7")
+    with pytest.raises(ValueError, match="unknown provider"):
+        get_provider("not-a-real-model")
+
+
+# ---------------------------------------------------------------------------
+# translate_thinking_budget mapping
+# ---------------------------------------------------------------------------
+
+
+def test_translate_thinking_budget_gemini_passthrough():
+    from services.providers import translate_thinking_budget
+
+    for raw in [0, 1024, 2048, 8192, 32768, -1]:
+        assert translate_thinking_budget("gemini", "extract", raw) == raw
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (0, "disabled"),
+        (1, "low"),
+        (1024, "low"),
+        (1025, "medium"),
+        (2048, "medium"),
+        (2049, "high"),
+        (8192, "high"),
+        (8193, "max"),
+        (32768, "max"),
+    ],
+)
+def test_translate_thinking_budget_deepseek_enum(raw, expected):
+    from services.providers import translate_thinking_budget
+
+    assert translate_thinking_budget("deepseek", "extract", raw) == expected
+
+
+def test_translate_thinking_budget_unknown_provider_raises():
+    from services.providers import translate_thinking_budget
+
+    with pytest.raises(ValueError, match="unknown provider"):
+        translate_thinking_budget("openai", "extract", 0)

--- a/nlp-service/services/providers/test_providers.py
+++ b/nlp-service/services/providers/test_providers.py
@@ -8,6 +8,8 @@ tests (json_object injection, retry on 429, discount-boundary).
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 from pydantic import BaseModel
 
@@ -96,11 +98,21 @@ def test_get_provider_dispatches_gemini_prefix(monkeypatch):
     P._REGISTRY.clear()
 
 
-def test_get_provider_deepseek_raises_until_phase_4():
-    from services.providers import get_provider
+def test_get_provider_dispatches_deepseek_prefix(monkeypatch):
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+    from services import providers as P
+    P._REGISTRY.clear()
 
-    with pytest.raises(NotImplementedError):
-        get_provider("deepseek-v4-pro")
+    from services.providers import get_provider
+    from services.providers.deepseek import DeepSeekProvider
+
+    p = get_provider("deepseek-v4-pro")
+    assert isinstance(p, DeepSeekProvider)
+    assert p.name == "deepseek"
+    # Singleton cache: same instance on repeat lookup.
+    assert get_provider("deepseek-v5-future") is p
+
+    P._REGISTRY.clear()
 
 
 def test_get_provider_unknown_raises_value_error():
@@ -223,6 +235,285 @@ def test_extract_halved_fallback_skipped_on_non_gemini(monkeypatch):
 
     assert log == ["extract"], "halved-fallback must NOT run on deepseek-*"
     assert "extract_llm_parse_failed" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# DeepSeekProvider.complete() (Phase 4)
+# ---------------------------------------------------------------------------
+
+
+def _stub_deepseek_post(monkeypatch, status_codes, body=None):
+    """Patch httpx.Client.post to walk through ``status_codes`` returning
+    a canned 200 body on a 200 code and a minimal text payload on others.
+
+    Returns the captured-bodies list so tests can assert on the request
+    JSON for each invocation.
+    """
+    captured: list[dict] = []
+    iterator = iter(status_codes)
+    default_body = body or {
+        "choices": [{
+            "message": {"content": '{"ok": true}'},
+            "finish_reason": "stop",
+        }],
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 20,
+            "prompt_cache_hit_tokens": 0,
+        },
+    }
+
+    class _FakeResponse:
+        def __init__(self, status):
+            self.status_code = status
+            self.text = "rate limited" if status != 200 else ""
+        def json(self):
+            return default_body
+
+    def _fake_post(self, url, json=None, **kw):
+        captured.append(json)
+        try:
+            code = next(iterator)
+        except StopIteration:
+            code = 200
+        return _FakeResponse(code)
+
+    monkeypatch.setattr("httpx.Client.post", _fake_post)
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    return captured
+
+
+def _ensure_clean_deepseek_singleton(monkeypatch):
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+    from services import providers as P
+    from services.providers import deepseek as D
+    P._REGISTRY.clear()
+    # Reset any module-level caches the previous test may have populated.
+    D._client = None
+    D._limiter = None
+    # The pyrate-limiter constructor signature differs across versions
+    # (the container's 3.7.1 pin accepts ``raise_when_fail`` as a kwarg, but
+    # other host-local installs do not). Tests don't need a real bucket —
+    # stub _get_limiter to a permissive MagicMock that always grants tokens.
+    fake_limiter = MagicMock()
+    fake_limiter.try_acquire.return_value = True
+    monkeypatch.setattr(D, "_get_limiter", lambda: fake_limiter)
+    return fake_limiter
+
+
+def test_deepseek_complete_injects_json_response_format(monkeypatch):
+    """When response_model is set the request body MUST carry response_format."""
+    _ensure_clean_deepseek_singleton(monkeypatch)
+    from pydantic import BaseModel as _BM
+    from services.providers import get_provider
+    from services.providers.base import LLMRequest
+
+    class _Out(_BM):
+        ok: bool
+
+    captured = _stub_deepseek_post(monkeypatch, [200])
+    p = get_provider("deepseek-v4-pro")
+    req = LLMRequest(
+        model="deepseek-v4-pro",
+        messages=[
+            {"role": "system", "content": "be terse — return json"},
+            {"role": "user",   "content": "go"},
+        ],
+        response_model=_Out,
+        thinking_budget=0,
+        max_output_tokens=512,
+        temperature=0.0,
+        step="t",
+    )
+    result = p.complete(req)
+    assert captured[0]["response_format"] == {"type": "json_object"}
+    assert result.parsed.ok is True
+    assert result.text == '{"ok": true}'
+    assert result.finish_reason == "STOP"
+
+
+def test_deepseek_complete_omits_response_format_when_no_schema(monkeypatch):
+    _ensure_clean_deepseek_singleton(monkeypatch)
+    from services.providers import get_provider
+    from services.providers.base import LLMRequest
+
+    captured = _stub_deepseek_post(monkeypatch, [200])
+    p = get_provider("deepseek-v4-pro")
+    req = LLMRequest(
+        model="deepseek-v4-pro",
+        messages=[{"role": "user", "content": "free-form please"}],
+        response_model=None,
+        thinking_budget=0,
+        max_output_tokens=512,
+        step="t",
+    )
+    p.complete(req)
+    assert "response_format" not in captured[0]
+
+
+def test_deepseek_complete_attaches_reasoning_effort_when_thinking_enabled(monkeypatch):
+    _ensure_clean_deepseek_singleton(monkeypatch)
+    from services.providers import get_provider
+    from services.providers.base import LLMRequest
+
+    captured = _stub_deepseek_post(monkeypatch, [200])
+    p = get_provider("deepseek-v4-pro")
+    req = LLMRequest(
+        model="deepseek-v4-pro",
+        messages=[{"role": "user", "content": "go"}],
+        response_model=None,
+        thinking_budget=2048,  # -> "medium" per translate_thinking_budget
+        max_output_tokens=512,
+        step="extract",
+    )
+    p.complete(req)
+    assert captured[0]["reasoning_effort"] == "medium"
+
+
+def test_deepseek_complete_omits_reasoning_when_budget_zero(monkeypatch):
+    _ensure_clean_deepseek_singleton(monkeypatch)
+    from services.providers import get_provider
+    from services.providers.base import LLMRequest
+
+    captured = _stub_deepseek_post(monkeypatch, [200])
+    p = get_provider("deepseek-v4-pro")
+    p.complete(LLMRequest(
+        model="deepseek-v4-pro",
+        messages=[{"role": "user", "content": "go"}],
+        response_model=None,
+        thinking_budget=0,
+        max_output_tokens=512,
+        step="lint",
+    ))
+    assert "reasoning_effort" not in captured[0]
+
+
+def test_deepseek_retries_on_429_then_succeeds(monkeypatch):
+    _ensure_clean_deepseek_singleton(monkeypatch)
+    from services.providers import get_provider
+    from services.providers.base import LLMRequest
+
+    captured = _stub_deepseek_post(monkeypatch, [429, 200])
+    p = get_provider("deepseek-v4-pro")
+    p.complete(LLMRequest(
+        model="deepseek-v4-pro",
+        messages=[{"role": "user", "content": "x"}],
+        response_model=None,
+        thinking_budget=0,
+        max_output_tokens=128,
+        step="t",
+    ))
+    assert len(captured) == 2, "expected exactly one retry after 429"
+
+
+def test_deepseek_emits_log_line_with_cache_hit(monkeypatch, capsys):
+    _ensure_clean_deepseek_singleton(monkeypatch)
+    from services.providers import get_provider
+    from services.providers.base import LLMRequest
+
+    body = {
+        "choices": [{
+            "message": {"content": "free text"},
+            "finish_reason": "stop",
+        }],
+        "usage": {
+            "prompt_tokens": 1234,
+            "completion_tokens": 56,
+            "prompt_cache_hit_tokens": 78,
+        },
+    }
+    _stub_deepseek_post(monkeypatch, [200], body=body)
+    p = get_provider("deepseek-v4-pro")
+    p.complete(LLMRequest(
+        model="deepseek-v4-pro",
+        messages=[{"role": "user", "content": "x"}],
+        response_model=None,
+        thinking_budget=0,
+        max_output_tokens=128,
+        step="extract",
+    ))
+    captured = capsys.readouterr()
+    assert "[deepseek] step=extract" in captured.err
+    assert "in=1234" in captured.err
+    assert "out=56" in captured.err
+    assert "cache_hit=78" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# DeepSeekProvider pricing (Phase 4)
+# ---------------------------------------------------------------------------
+
+
+def test_deepseek_prices_in_discount_window(monkeypatch):
+    """One second before DISCOUNT_UNTIL: prices use the discount table."""
+    from services.providers import deepseek as D
+    monkeypatch.delenv("DEEPSEEK_INPUT_USD_PER_M", raising=False)
+    monkeypatch.delenv("DEEPSEEK_OUTPUT_USD_PER_M", raising=False)
+    monkeypatch.delenv("DEEPSEEK_CACHE_USD_PER_M", raising=False)
+
+    import datetime as _dt
+    target = D.DISCOUNT_UNTIL - _dt.timedelta(seconds=1)
+
+    class _FakeDateTime(_dt.datetime):
+        @classmethod
+        def now(cls, tz=None): return target
+
+    monkeypatch.setattr(D, "datetime", _FakeDateTime)
+    prices = D._prices_now()
+    assert prices["input"] == D._PRICES_DISCOUNT["input"]
+    assert prices["output"] == D._PRICES_DISCOUNT["output"]
+    assert prices["cache"] == D._PRICES_DISCOUNT["cache"]
+
+
+def test_deepseek_prices_after_discount_window(monkeypatch):
+    """One second after DISCOUNT_UNTIL: prices flip to the list table."""
+    from services.providers import deepseek as D
+    monkeypatch.delenv("DEEPSEEK_INPUT_USD_PER_M", raising=False)
+    monkeypatch.delenv("DEEPSEEK_OUTPUT_USD_PER_M", raising=False)
+    monkeypatch.delenv("DEEPSEEK_CACHE_USD_PER_M", raising=False)
+
+    import datetime as _dt
+    target = D.DISCOUNT_UNTIL + _dt.timedelta(seconds=1)
+
+    class _FakeDateTime(_dt.datetime):
+        @classmethod
+        def now(cls, tz=None): return target
+
+    monkeypatch.setattr(D, "datetime", _FakeDateTime)
+    prices = D._prices_now()
+    assert prices["input"] == D._PRICES_LIST["input"]
+    assert prices["output"] == D._PRICES_LIST["output"]
+    assert prices["cache"] == D._PRICES_LIST["cache"]
+
+
+def test_deepseek_prices_env_override_wins(monkeypatch):
+    monkeypatch.setenv("DEEPSEEK_INPUT_USD_PER_M", "0.99")
+    from services.providers import deepseek as D
+    prices = D._prices_now()
+    assert prices["input"] == 0.99
+
+
+def test_deepseek_cost_usd_formula(monkeypatch):
+    """Sanity-check the cost arithmetic on a known usage dict."""
+    monkeypatch.setenv("DEEPSEEK_INPUT_USD_PER_M",  "1.00")
+    monkeypatch.setenv("DEEPSEEK_OUTPUT_USD_PER_M", "10.00")
+    monkeypatch.setenv("DEEPSEEK_CACHE_USD_PER_M",  "0.10")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+    from services import providers as P
+    P._REGISTRY.clear()
+    from services.providers import get_provider
+
+    p = get_provider("deepseek-v4-pro")
+    # 1M prompt tokens, 100K cached, 500K output (Gemini-shape keys).
+    cost = p.cost_usd("deepseek-v4-pro", {
+        "prompt_token_count":         1_000_000,
+        "cached_content_token_count": 100_000,
+        "candidates_token_count":     500_000,
+        "thoughts_token_count":       0,
+    })
+    # fresh = 900_000 -> 0.9; cached = 100_000 -> 0.01; output = 500_000 -> 5.00
+    assert abs(cost - (0.9 + 0.01 + 5.0)) < 1e-9
+    P._REGISTRY.clear()
 
 
 def test_cost_cap_error_message_says_llm_not_gemini(monkeypatch, tmp_path):

--- a/nlp-service/tests/conftest.py
+++ b/nlp-service/tests/conftest.py
@@ -69,7 +69,12 @@ def client(app):
 
 @pytest.fixture
 def mock_gemini(monkeypatch):
-    """Patch get_client() to return a MagicMock Gemini client."""
+    """Patch the Gemini SDK client to a MagicMock.
+
+    Phase 2 moved get_client() out of llm_client into services.providers.gemini.
+    The provider's complete() method calls module-level ``get_client()`` and
+    ``_get_limiter()``; both are monkeypatched here so tests stay hermetic.
+    """
     mock_client = MagicMock()
     mock_response = MagicMock()
     mock_response.text = "---\ntitle: Test\npage_type: source-summary\n---\n## Content\nBody."
@@ -77,25 +82,33 @@ def mock_gemini(monkeypatch):
     mock_response.usage_metadata.candidates_token_count = 50
     mock_client.models.generate_content.return_value = mock_response
 
-    from services import llm_client  # noqa: PLC0415
-    monkeypatch.setattr(llm_client, "get_client", lambda: mock_client)
+    from services.providers import gemini as gemini_provider  # noqa: PLC0415
+    monkeypatch.setattr(gemini_provider, "get_client", lambda: mock_client)
     return mock_client
 
 
 @pytest.fixture
 def mock_limiter(monkeypatch):
-    """Patch _get_limiter() so try_acquire always succeeds."""
+    """Patch _get_limiter() so try_acquire always succeeds.
+
+    Phase 2 moved the limiter into services.providers.gemini.
+    """
     mock_lim = MagicMock()
     mock_lim.try_acquire.return_value = True
 
-    from services import llm_client  # noqa: PLC0415
-    monkeypatch.setattr(llm_client, "_get_limiter", lambda: mock_lim)
+    from services.providers import gemini as gemini_provider  # noqa: PLC0415
+    monkeypatch.setattr(gemini_provider, "_get_limiter", lambda: mock_lim)
     return mock_lim
 
 
 @pytest.fixture
 def mock_cost(monkeypatch):
-    """Patch _check_and_record_cost to avoid disk I/O."""
+    """Patch _check_and_record_cost to avoid disk I/O.
+
+    The provider's complete() method calls back into ``llm_client._check_and_record_cost``
+    via lazy module-attribute lookup, so this monkeypatch on the llm_client
+    namespace is still effective.
+    """
     from services import llm_client  # noqa: PLC0415
     mock_fn = MagicMock()
     monkeypatch.setattr(llm_client, "_check_and_record_cost", mock_fn)

--- a/nlp-service/tests/conftest.py
+++ b/nlp-service/tests/conftest.py
@@ -24,7 +24,15 @@ sys.modules.setdefault("chromadb", chromadb_stub)
 
 st_stub = types.ModuleType("sentence_transformers")
 st_stub.SentenceTransformer = MagicMock()
+# KeyBERT (loaded indirectly via routers/extraction.py) reads
+# ``sentence_transformers.util``. Provide a permissive submodule stub so the
+# import chain succeeds during tests that touch main.app.
+st_util_stub = types.ModuleType("sentence_transformers.util")
+st_util_stub.cos_sim = MagicMock()
+st_util_stub.semantic_search = MagicMock()
+st_stub.util = st_util_stub
 sys.modules.setdefault("sentence_transformers", st_stub)
+sys.modules.setdefault("sentence_transformers.util", st_util_stub)
 
 spacy_stub = types.ModuleType("spacy")
 spacy_stub.load = MagicMock(return_value=MagicMock())

--- a/nlp-service/tests/test_llm_client.py
+++ b/nlp-service/tests/test_llm_client.py
@@ -103,12 +103,15 @@ def test_draft_page_strips_markdown_code_fences(mock_gemini, mock_limiter, mock_
 
 
 def test_draft_page_raises_rate_limited_when_bucket_full(mock_gemini, mock_cost):
-    """draft_page must raise LLMRateLimitedError when the rate limiter denies."""
+    """draft_page must raise LLMRateLimitedError when the rate limiter denies.
+
+    Phase 2: limiter lives in services.providers.gemini.
+    """
     mock_lim = MagicMock()
     mock_lim.try_acquire.return_value = False
 
-    import services.llm_client as lc  # noqa: PLC0415
-    lc._get_limiter = lambda: mock_lim  # direct patch (no monkeypatch needed here)
+    from services.providers import gemini as gemini_provider  # noqa: PLC0415
+    gemini_provider._get_limiter = lambda: mock_lim  # direct patch (no monkeypatch needed here)
 
     with pytest.raises(llm_client.LLMRateLimitedError):
         llm_client.draft_page(

--- a/nlp-service/tests/test_main.py
+++ b/nlp-service/tests/test_main.py
@@ -1,0 +1,69 @@
+"""Unit tests for nlp-service/main.py.
+
+Phase 5 added a provider_keys flag to /health for the Settings UI to gate
+the dropdown by key presence. The test asserts the JSON shape; the
+heavy ML deps are stubbed via conftest.py the same way every other
+nlp-service test does.
+"""
+
+from __future__ import annotations
+
+
+def _build_app():
+    """Import main inside the test (after conftest stubs heavy deps)."""
+    from main import app  # noqa: PLC0415
+    return app
+
+
+def test_health_returns_provider_keys_shape(monkeypatch):
+    """/health must include {gemini: bool, deepseek: bool} under provider_keys."""
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+
+    from fastapi.testclient import TestClient  # noqa: PLC0415
+    client = TestClient(_build_app())
+    r = client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ok"
+    assert "provider_keys" in body
+    assert body["provider_keys"]["gemini"] is True
+    assert body["provider_keys"]["deepseek"] is True
+
+
+def test_health_provider_keys_reflect_unset_env(monkeypatch):
+    """Both flags should be False when neither env var is set."""
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+
+    from fastapi.testclient import TestClient  # noqa: PLC0415
+    client = TestClient(_build_app())
+    r = client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["provider_keys"]["gemini"] is False
+    assert body["provider_keys"]["deepseek"] is False
+
+
+def test_health_provider_keys_reflect_partial_env(monkeypatch):
+    """One key set → one True one False (the Phase 6 gating use case)."""
+    monkeypatch.setenv("GEMINI_API_KEY", "g")
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+
+    from fastapi.testclient import TestClient  # noqa: PLC0415
+    client = TestClient(_build_app())
+    r = client.get("/health")
+    body = r.json()
+    assert body["provider_keys"]["gemini"] is True
+    assert body["provider_keys"]["deepseek"] is False
+
+
+def test_health_provider_keys_treat_whitespace_as_unset(monkeypatch):
+    """A whitespace-only env var should still register as unset."""
+    monkeypatch.setenv("GEMINI_API_KEY", "   ")
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+
+    from fastapi.testclient import TestClient  # noqa: PLC0415
+    client = TestClient(_build_app())
+    body = client.get("/health").json()
+    assert body["provider_keys"]["gemini"] is False

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -240,7 +240,7 @@ stage_1_migration_schema() {
     # compile. Fixed 2026-04-20 by adding the keys to app.environment.
     # Presence-only check; never compares values (would leak secrets on fail).
     echo "  checking env-var wire (host -> app container)..."
-    for var in GEMINI_API_KEY FIRECRAWL_API_KEY; do
+    for var in GEMINI_API_KEY DEEPSEEK_API_KEY FIRECRAWL_API_KEY; do
         host_val=$(printenv "$var" 2>/dev/null || true)
         if [ -n "$host_val" ]; then
             container_val=$($COMPOSE exec -T app printenv "$var" 2>/dev/null || true)


### PR DESCRIPTION
## Summary

- Adds an `LLMProvider` Protocol so every LLM call site routes through a pluggable backend; `GeminiProvider` extracts the existing logic byte-for-byte; `DeepSeekProvider` lands as a second selectable backend behind a model-name prefix dispatch.
- Wires `DEEPSEEK_API_KEY` end-to-end (docker-compose, .env.example, integration-test stage 1) and exposes `provider_keys` flags on both `/health` endpoints so the Settings UI (Phase 6) can gate the dropdown by key presence without an outbound network probe.
- Supersedes the never-executed streaming-detector mitigation (issue #7, Stage C precision validation failed). The provider abstraction is the durable fix for the Gemini 2.5 sampler-bug class — operators can switch to DeepSeek per session via the model setting once Phase 6 ships.
- Phases 1-5 of [docs/plans/2026-05-05-deepseek-second-llm-provider.md](docs/plans/2026-05-05-deepseek-second-llm-provider.md). Phases 6 (Settings UI dropdown) and 7 (corpus revalidation) deferred to follow-up PRs.

## What's in this PR

| Phase | Commit | Change |
|---|---|---|
| 1.1 | `735c91f` | `_JSON_TRAILER` constant + appended to `_LINT_SYSTEM_PROMPT` |
| 1.2 | `9734f9c` | trailer appended to remaining 6 system prompts |
| 2.1 | `ffd74ff` | `LLMProvider` Protocol + `LLMRequest`/`LLMResult` dataclasses + factory shell |
| 2.2 | `9e821e0` | `GeminiProvider` extract; all 11 call sites rewired through `provider.complete()`; mocks repointed |
| 2.3 | `9c012d6` | cost-cap message generalised to ""Daily LLM spend""; per-call cost via `provider.cost_usd()` |
| 3.1 | `385d8c6` | `messages=[system, user]` shape at 5 schema-bound call sites |
| 3.2/3.3 | `52fd8de` | per-provider input cap (50K Gemini / 200K DeepSeek) + Gemini-only halved-fallback gate |
| 4 | `6940235` | `DeepSeekProvider` (httpx, json_object, reasoning_effort, discount-window pricing) + factory wiring |
| 5 | `f876fbb` | docker-compose + .env.example + integration-test stage 1 env-loop guard + nlp-service `/health` + Next.js `/api/health` `provider_keys` |

## Verification

- 188/188 unit + provider tests green (151 nlp-service + 4 new test_main + 33 provider)
- Phase 3 acid test: `POST /pipeline/extract-llm` against real Gemini returned 4 entities + 4 concepts; `[gemini] step=extract finish=STOP in=590 out=997 thinking=438` log line confirms the provider path end-to-end
- Phase 5 verified: `docker compose -f docker-compose.yml config` exit 0 with both keys substituted in both services; `curl :8000/health` returns `{provider_keys: {gemini: true, deepseek: true}}`; `curl :3000/api/health` returns `{provider_keys: {gemini_present: true, deepseek_present: true}}`
- Integration stages 0/1/4 PASS locally with the rebuilt nlp-service image (stage 1 now also regression-guards `DEEPSEEK_API_KEY` env-wire)
- DeepSeek provider paths covered by mocked HTTP tests only — live smoke validation against the real DeepSeek API deferred to Phase 7

## What's intentionally deferred

- **Phase 6:** `CHAT_MODELS` expansion + Settings UI optgroup (Gemini / DeepSeek) + dropdown gating by `healthData?.provider_keys?.deepseek_present`. Reads the `/api/health` surface that Phase 5 just shipped.
- **Phase 7:** full `nlp-service/test_corpus/` revalidation against both providers (±10% entity-count tolerance vs. the 28-call spike baseline; 0 salvage attempts on DeepSeek).

## Test plan

- [ ] CI green on the 4 jobs (3 unit-tests + integration-test stages 0/1/4/11/12/13/20/21 — none of which hit a real LLM)
- [x] Local: `pytest nlp-service/tests/ nlp-service/services/providers/` — 188/188
- [x] Manual: `POST /pipeline/extract-llm` with `compile_model: gemini-2.5-flash` returns a structured response
- [x] Manual: both `/health` endpoints return `provider_keys` with the expected shape
- [x] Manual: `docker compose -f docker-compose.yml config` exits 0 with both keys substituted in both services
- [ ] Manual: `gitnexus_detect_changes` review of the diff scope before merge