### PR TITLE
fix(mcp-server): override ip-address to ^10.1.1 (GHSA-v2v4-37r5-5v8g)

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "kompl-mcp",
       "version": "1.0.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
         "zod": "^4.3.6"
@@ -634,9 +635,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -18,6 +18,7 @@
     "@types/node": "^24.9.2"
   },
   "overrides": {
-    "hono": "^4.12.14"
+    "hono": "^4.12.14",
+    "ip-address": "^10.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- Closes Scorecard alert #70 (High) — `ip-address@10.1.0` flagged for GHSA-v2v4-37r5-5v8g (XSS in `Address6.group()`/`.link()`/`parseMessage` HTML rendering, patched in 10.1.1)
- Pulled in transitively via `@modelcontextprotocol/sdk@1.29.0 → express-rate-limit@8.3.2`, which exact-pins `ip-address@10.1.0` (still does as of 8.5.0 published today), so a normal `npm update` cannot lift it
- Added an npm `overrides` entry mirroring the existing `hono` override pattern; resolved install bumped to `10.2.0`

## Exploitability
Not exploitable in this codebase. `express-rate-limit` only uses `ip-address` for IPv6 subnet matching during rate-limit key generation; the vulnerable HTML-emitting methods are never invoked. The advisory itself notes "extremely limited" real-world exposure (zero consumers found across 425 dependents on npm). Fixing anyway because Scorecard fires on the dep graph regardless of how the dep is used, and the fix is a one-line override.

## Test plan
- [ ] CI green (Scorecard re-runs against `main` post-merge and clears alert #70)
- [ ] `npm install` in `mcp-server/` resolves `ip-address` to `^10.1.1` (locally: 10.2.0)