### PR TITLE
fix(compile): bump LLM-call timeouts for DeepSeek (was Gemini-only sized)

### DIFF
--- a/app/src/app/api/compile/draft/route.ts
+++ b/app/src/app/api/compile/draft/route.ts
@@ -95,7 +95,7 @@ async function callDraftPage(
       existing_categories: existingCategories ?? [],
       ...(compileModel ? { compile_model: compileModel } : {}),
     }),
-    signal: AbortSignal.timeout(180_000), // 3 min — Gemini thinking can be slow
+    signal: AbortSignal.timeout(600_000), // 10 min — DeepSeek draft can match extract latency on dense sources. Gemini thinking adds margin on top. Same 600s budget as extract/resolve/schema for symmetry.
   });
 
   if (!res.ok) {

--- a/app/src/app/api/compile/extract/route.ts
+++ b/app/src/app/api/compile/extract/route.ts
@@ -136,7 +136,7 @@ async function callExtractLLM(payload: Record<string, unknown>): Promise<any> {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
-    signal: AbortSignal.timeout(300_000), // 5 min — Gemini thinking can be slow
+    signal: AbortSignal.timeout(600_000), // 10 min — DeepSeek extract on a 95K-char source clocks ~290s; Vilnius travel guide hit ~387s in Phase 7. Gemini thinking adds another minute on top of that on its bad days. 600s gives ~55% headroom over the worst observed for either provider.
   });
   if (!res.ok) {
     const detail = await res.text().catch(() => '');

--- a/app/src/app/api/compile/resolve/route.ts
+++ b/app/src/app/api/compile/resolve/route.ts
@@ -149,7 +149,7 @@ async function callDisambiguate(
       pairs,
       ...(compileModel ? { compile_model: compileModel } : {}),
     }),
-    signal: AbortSignal.timeout(120_000), // LLM call — allow 2 min
+    signal: AbortSignal.timeout(600_000), // 10 min — disambiguate batches up to 10 pairs; DeepSeek can run ~200-400s per call on dense pairs. 120s (prior value) was Gemini-only sizing.
   });
   if (!res.ok) {
     const detail = await res.text().catch(() => '');

--- a/app/src/app/api/compile/run/route.ts
+++ b/app/src/app/api/compile/run/route.ts
@@ -96,7 +96,9 @@ async function callExtract(sourceId: string, sessionId: string): Promise<void> {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ source_id: sourceId }),
-    signal: AbortSignal.timeout(180_000),
+    // 660s = inner extract LLM (600s) + 60s margin for NER/keyphrase/handler I/O.
+    // Prior 180s aborted the extract step before the inner 300s LLM ever fired.
+    signal: AbortSignal.timeout(660_000),
   });
   await throwOnError('extract', res, sessionId);
 }
@@ -106,7 +108,8 @@ async function callResolve(sessionId: string): Promise<{ canonical_entities: unk
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ session_id: sessionId }),
-    signal: AbortSignal.timeout(180_000),
+    // 660s = inner disambiguate LLM (600s) + 60s margin. Prior 180s aborted before the inner LLM finished on DeepSeek.
+    signal: AbortSignal.timeout(660_000),
   });
   await throwOnError('resolve', res, sessionId);
   const parsed = await res.json() as { canonical_entities?: unknown[]; canonical_concepts?: unknown[] };
@@ -193,7 +196,8 @@ async function callSchema(sessionId: string): Promise<unknown> {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ session_id: sessionId }),
-    signal: AbortSignal.timeout(120_000),
+    // 660s = inner generate-schema LLM (600s) + 60s margin. Prior 120s aborted before inner LLM finished on DeepSeek.
+    signal: AbortSignal.timeout(660_000),
   });
   await throwOnError('schema', res, sessionId);
   return res.json();

--- a/app/src/app/api/compile/schema/route.ts
+++ b/app/src/app/api/compile/schema/route.ts
@@ -76,7 +76,7 @@ export async function POST(request: Request) {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ pages: pagesSummary, compile_model: getEffectiveCompileModel(session_id) }),
-    signal: AbortSignal.timeout(120_000),
+    signal: AbortSignal.timeout(600_000), // 10 min — generate-schema runs an LLM call; DeepSeek can take 200-400s on the page list. 120s (prior value) was Gemini-only sizing.
   });
 
   if (!genRes.ok) {

--- a/app/src/lib/recompile.ts
+++ b/app/src/lib/recompile.ts
@@ -65,7 +65,7 @@ async function callDraftPage(
       existing_categories: existingCategories,
       compile_model: compileModel,
     }),
-    signal: AbortSignal.timeout(180_000), // 3 min — Gemini thinking can be slow
+    signal: AbortSignal.timeout(600_000), // 10 min — recompile-on-source-delete runs an extract LLM call. DeepSeek can take 200-400s on dense sources. 180s (prior) was Gemini-only sizing.
   });
 
   if (!res.ok) {

--- a/nlp-service/services/providers/deepseek.py
+++ b/nlp-service/services/providers/deepseek.py
@@ -118,7 +118,11 @@ def get_client() -> httpx.Client:
         _client = httpx.Client(
             base_url="https://api.deepseek.com",
             headers={"Authorization": f"Bearer {_DEEPSEEK_API_KEY}"},
-            timeout=120.0,
+            # 600s: empirically DeepSeek extract on a 95K-char source reaches
+            # ~290s; the Vilnius travel guide hit ~387s in the Phase 7 rerun.
+            # 120s (the prior value) timed out before the API responded on any
+            # source >25K chars. Headroom over the worst observed: ~55%.
+            timeout=600.0,
         )
     return _client
 


### PR DESCRIPTION
## Summary
DeepSeek's V4 Pro non-think mode regularly takes 200-400s on content-dense sources (Phase 7 corpus run: Vilnius travel guide 387s, Open Standards 95K-char source 290s). Compile pipeline timeouts were tuned for Gemini's 30-60s typical latency. Sources fail with timeout errors when DeepSeek is the active provider.

Three layers needed bumping:

1. **nlp-service httpx client** ([deepseek.py:121](nlp-service/services/providers/deepseek.py#L121)): 120s → 600s. Load-bearing — this fired first, before any higher-level timeout had a chance.
2. **Inner LLM-call timeouts** (extract:139, draft:98, resolve:152, schema:79, recompile.ts:68): all → 600s, comments updated to provider-neutral rationale.
3. **Outer orchestration wrappers** in [run/route.ts](app/src/app/api/compile/run/route.ts) (callExtract:101, callResolve:112, callSchema:200): → 660s, giving 60s margin over the inner 600s for NER/keyphrase/handler I/O. Prior 180s/120s aborted compile steps before the inner LLM call ever completed.

**Untouched (intentional):**
- callMatch (300s) — triage uses thinking_budget=0, fast on both providers
- callDraft (900s) — already plenty over the new inner 600s
- callCrossref (600s) — crossref no longer LLM-bound
- callCommit (120s) — DB-only
- callPlan (30s) — DB-only

## Test plan
- [x] cd app && npx tsc --noEmit → 0 errors
- [x] cd nlp-service && python -m pytest tests/ services/providers/ -q → 182/182
- [x] cd app && npx vitest run → 366/366
- [x] bash scripts/check-schema-sync.sh → Schema sync OK — v22, 18 tables.
- [ ] Manual: trigger a DeepSeek compile session with a 50K+ char source; verify extract completes without timeout