### PR TITLE
feat(llm): DeepSeek prompt-drift hardening — 4-layer contract block + 28 tests

### DIFF
--- a/nlp-service/services/llm_client.py
+++ b/nlp-service/services/llm_client.py
@@ -1670,3 +1670,28 @@ Keep it under 150 words. No markdown formatting — plain text with line breaks.
         raise LLMCompileError("digest_error: empty response text")
 
     return raw_text.strip()
+
+
+# ---------------------------------------------------------------------------
+# Finalize prompts with response-shape contracts
+# ---------------------------------------------------------------------------
+#
+# This block runs at module load. It MUST be after every Pydantic response
+# model is defined — the constants above end with `+ _JSON_TRAILER` and we
+# tack on the model-derived contract block here so the prompts stay readable
+# in their original locations. Do NOT move earlier in the file: forward refs
+# to the response models would crash the import.
+#
+# DeepSeek's json_object mode reads only the prompt text (response_model
+# schema is server-side ignored), so the wrapper-key anchor + filled-in
+# example below is what actually constrains output shape. Two production
+# drift variants ({"pairs":[...]}, bare list [{...}]) both came from the
+# same underspecified disambiguate prompt before this block was added.
+
+_LINT_SYSTEM_PROMPT = _LINT_SYSTEM_PROMPT + _format_response_contract(LintScanResponse)
+_EXTRACTION_SYSTEM_PROMPT = _EXTRACTION_SYSTEM_PROMPT + _format_response_contract(LLMExtractionResponse)
+_DISAMBIGUATION_SYSTEM_PROMPT = _DISAMBIGUATION_SYSTEM_PROMPT + _format_response_contract(DisambiguationResponse)
+_DISAMBIGUATION_CONCEPT_SYSTEM_PROMPT = _DISAMBIGUATION_CONCEPT_SYSTEM_PROMPT + _format_response_contract(DisambiguationResponse)
+_CROSSREF_SYSTEM_PROMPT = _CROSSREF_SYSTEM_PROMPT + _format_response_contract(CrossrefResponse)
+_SELECT_PAGES_SYSTEM_PROMPT = _SELECT_PAGES_SYSTEM_PROMPT + _format_response_contract(SelectPagesResponse)
+_SYNTHESIZE_SYSTEM_PROMPT = _SYNTHESIZE_SYSTEM_PROMPT + _format_response_contract(SynthesizeResponse)

--- a/nlp-service/services/llm_client.py
+++ b/nlp-service/services/llm_client.py
@@ -240,6 +240,49 @@ class LLMCompileError(Exception):
     """Raised when the LLM call succeeds but the response cannot be parsed."""
 
 
+def _parse_failure_tail(
+    step: str,
+    expected_wrapper: str,
+    raw_text: str | None,
+) -> str:
+    """Build the structured tail consumed by /api/compile/progress/events.
+
+    Output shape:
+      parse_failed: step=<step>: expected_wrapper=<key>, got_type=<dict|list|other>,
+      got_keys=[...], raw_excerpt='<first 200 chars>'
+
+    Phase C (progress UI expand-to-reveal) reads this tail to show users
+    the exact wrapper drift inline. Without it, the same information
+    lives only in docker logs.
+    """
+    import json as _json
+
+    got_type = "unknown"
+    got_keys: list[str] = []
+    if raw_text:
+        try:
+            parsed = _json.loads(raw_text)
+            if isinstance(parsed, dict):
+                got_type = "dict"
+                got_keys = list(parsed.keys())[:10]
+            elif isinstance(parsed, list):
+                got_type = "list"
+            elif parsed is None:
+                got_type = "null"
+            else:
+                got_type = type(parsed).__name__
+        except Exception:
+            got_type = "non-json"
+    excerpt = (raw_text or "")[:200].replace("\n", " ")
+    return (
+        f"parse_failed: step={step}: "
+        f"expected_wrapper={expected_wrapper}, "
+        f"got_type={got_type}, "
+        f"got_keys={got_keys!r}, "
+        f"raw_excerpt={excerpt!r}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Pydantic output models (contract 5 shapes)
 # ---------------------------------------------------------------------------
@@ -492,7 +535,12 @@ def lint_scan(pages: list[str], model: str = _DEFAULT_MODEL) -> LintScanResponse
         ]
         return LintScanResponse(contradictions=contras)
     except Exception as e:
-        raise LLMCompileError(f"lint_scan_parse_failed: {e}") from e
+        raise LLMCompileError(
+            f"lint_scan_parse_failed: {e}; "
+            + _parse_failure_tail(
+                step="lint", expected_wrapper="contradictions", raw_text=raw_text,
+            )
+        ) from e
 
 
 # ---------------------------------------------------------------------------
@@ -680,14 +728,24 @@ def extract_source(
     if result.finish_reason != "MAX_TOKENS":
         # Not a truncation — parse error is something else (schema drift,
         # malformed response). No point retrying with halved input.
-        raise LLMCompileError(f"extract_llm_parse_failed: {first_err}") from first_err
+        raise LLMCompileError(
+            f"extract_llm_parse_failed: {first_err}; "
+            + _parse_failure_tail(
+                step="extract", expected_wrapper="entities", raw_text=raw_text,
+            )
+        ) from first_err
 
     if not model.startswith("gemini-"):
         # The halved-input fallback is a Gemini-bug-specific mitigation for
         # the 2.5 Flash structured-output repetition loop. DeepSeek (and any
         # other provider) doesn't share the pathology; surface the original
         # parse error rather than doubling cost on an unvalidated retry path.
-        raise LLMCompileError(f"extract_llm_parse_failed: {first_err}") from first_err
+        raise LLMCompileError(
+            f"extract_llm_parse_failed: {first_err}; "
+            + _parse_failure_tail(
+                step="extract", expected_wrapper="entities", raw_text=raw_text,
+            )
+        ) from first_err
 
     print(
         f"[extract] MAX_TOKENS truncation + salvage failed — "
@@ -736,7 +794,10 @@ def extract_source(
     if not fallback_raw:
         raise LLMCompileError(
             f"extract_llm_parse_failed_after_fallback: "
-            f"first={first_err}; fallback=empty"
+            f"first={first_err}; fallback=empty; "
+            + _parse_failure_tail(
+                step="extract-fallback", expected_wrapper="entities", raw_text=fallback_raw,
+            )
         ) from first_err
 
     if fallback_result.parsed is not None:
@@ -753,7 +814,10 @@ def extract_source(
         return salvaged_fallback
     raise LLMCompileError(
         f"extract_llm_parse_failed_after_fallback: "
-        f"first={first_err}; second={fallback_parse_err}"
+        f"first={first_err}; second={fallback_parse_err}; "
+        + _parse_failure_tail(
+            step="extract-fallback", expected_wrapper="entities", raw_text=fallback_raw,
+        )
     ) from first_err
 
 
@@ -886,7 +950,12 @@ def disambiguate_entities(
 
     if result.parsed is not None:
         return result.parsed  # type: ignore[return-value]
-    raise LLMCompileError(f"disambiguate_llm_parse_failed: {result.parse_error}") from result.parse_error
+    raise LLMCompileError(
+        f"disambiguate_llm_parse_failed: {result.parse_error}; "
+        + _parse_failure_tail(
+            step="disambiguate", expected_wrapper="results", raw_text=raw_text,
+        )
+    ) from result.parse_error
 
 
 # ---------------------------------------------------------------------------
@@ -1260,7 +1329,12 @@ def crossref_pages(pages: list[dict[str, Any]], model: str = _DEFAULT_MODEL) -> 
 
     if result.parsed is not None:
         return result.parsed  # type: ignore[return-value]
-    raise LLMCompileError(f"crossref_parse_failed: {result.parse_error}") from result.parse_error
+    raise LLMCompileError(
+        f"crossref_parse_failed: {result.parse_error}; "
+        + _parse_failure_tail(
+            step="crossref", expected_wrapper="updated_pages", raw_text=raw_text,
+        )
+    ) from result.parse_error
 
 
 # ---------------------------------------------------------------------------
@@ -1344,7 +1418,12 @@ def triage_page_update(
         raise LLMCompileError("triage_error: empty response text")
 
     if result.parsed is None:
-        raise LLMCompileError(f"triage_json_parse_failed: {result.parse_error}") from result.parse_error
+        raise LLMCompileError(
+            f"triage_json_parse_failed: {result.parse_error}; "
+            + _parse_failure_tail(
+                step="triage", expected_wrapper="decision", raw_text=raw_text,
+            )
+        ) from result.parse_error
     triage = result.parsed
 
     decision = triage.decision if triage.decision in ("update", "contradiction", "skip") else "skip"
@@ -1476,7 +1555,12 @@ def select_pages_for_query(
         return []
 
     if result.parsed is None:
-        raise LLMCompileError(f"select_pages_parse_failed: {result.parse_error}") from result.parse_error
+        raise LLMCompileError(
+            f"select_pages_parse_failed: {result.parse_error}; "
+            + _parse_failure_tail(
+                step="select_pages", expected_wrapper="page_ids", raw_text=raw_text,
+            )
+        ) from result.parse_error
     return result.parsed.page_ids
 
 
@@ -1609,7 +1693,12 @@ def synthesize_answer(
         raise LLMCompileError("synthesize_error: empty response text")
 
     if result.parsed is None:
-        raise LLMCompileError(f"synthesize_parse_failed: {result.parse_error}") from result.parse_error
+        raise LLMCompileError(
+            f"synthesize_parse_failed: {result.parse_error}; "
+            + _parse_failure_tail(
+                step="synthesize", expected_wrapper="answer", raw_text=raw_text,
+            )
+        ) from result.parse_error
     return result.parsed
 
 

--- a/nlp-service/services/llm_client.py
+++ b/nlp-service/services/llm_client.py
@@ -83,6 +83,146 @@ _JSON_TRAILER = (
     "described above. Do not include any text outside the json."
 )
 
+
+# ---------------------------------------------------------------------------
+# Response-shape contract helper
+# ---------------------------------------------------------------------------
+#
+# Builds a 4-layer JSON-shape contract block from a Pydantic response model:
+#   1. Schema  — literal shape with field names, types, Literal enum lists,
+#                nullability marked
+#   2. Example — one filled-in canonical instance with placeholder values
+#   3. Rules   — explicit "keys MUST match, top-level wrapper MUST be object"
+#   4. Verify  — closing self-verification instruction
+#
+# Convergent industry pattern (BAML schema-aligned parsing, OpenAI structured
+# outputs guide, Promptfoo evaluate-json) — measurably reduces drift on
+# DeepSeek's json_object mode where response_model is server-side ignored.
+#
+# Output is appended AFTER _JSON_TRAILER, never replacing it: DeepSeek requires
+# the literal "json" keyword in the prompt to enable json_object mode.
+
+
+def _resolve_ref(ref: str, defs: dict) -> dict:
+    """Resolve a JSON-Schema $ref like '#/$defs/Foo' to its definition."""
+    name = ref.split("/")[-1]
+    return defs.get(name, {})
+
+
+def _render_schema_shape(node: dict, defs: dict, indent: int = 0) -> str:
+    """Render a JSON Schema node as a literal type-placeholder shape."""
+    if "$ref" in node:
+        return _render_schema_shape(_resolve_ref(node["$ref"], defs), defs, indent)
+
+    # Pydantic surfaces Optional[X] as anyOf with a `null` member.
+    if "anyOf" in node:
+        members = node["anyOf"]
+        is_nullable = any(m.get("type") == "null" for m in members)
+        non_null = [m for m in members if m.get("type") != "null"]
+        if non_null and is_nullable:
+            inner = _render_schema_shape(non_null[0], defs, indent)
+            return f"{inner.rstrip()} or null"
+        return _render_schema_shape(
+            non_null[0] if non_null else members[0], defs, indent
+        )
+
+    t = node.get("type")
+    pad = "  " * indent
+
+    if t == "object":
+        props = node.get("properties", {})
+        if not props:
+            return "{}"
+        lines = ["{"]
+        for key, child in props.items():
+            child_rendered = _render_schema_shape(child, defs, indent + 1)
+            lines.append(f"{pad}  \"{key}\": {child_rendered},")
+        if lines[-1].endswith(","):
+            lines[-1] = lines[-1][:-1]
+        lines.append(f"{pad}}}")
+        return "\n".join(lines)
+
+    if t == "array":
+        items = node.get("items", {})
+        item_rendered = _render_schema_shape(items, defs, indent + 1)
+        return f"[\n{pad}  {item_rendered}\n{pad}]"
+
+    if "enum" in node:
+        opts = " | ".join(repr(v) for v in node["enum"])
+        return f"<one of: {opts}>"
+    if t == "string":
+        return "<string>"
+    if t == "integer":
+        return "<integer>"
+    if t == "number":
+        return "<number>"
+    if t == "boolean":
+        return "<true | false>"
+    if t == "null":
+        return "null"
+    return "<value>"
+
+
+def _render_schema_example(node: dict, defs: dict, depth: int = 0):
+    """Render a canonical example value — concrete placeholders, not types."""
+    if "$ref" in node:
+        return _render_schema_example(_resolve_ref(node["$ref"], defs), defs, depth)
+    if "anyOf" in node:
+        non_null = [m for m in node["anyOf"] if m.get("type") != "null"]
+        return _render_schema_example(
+            non_null[0] if non_null else node["anyOf"][0], defs, depth
+        )
+
+    t = node.get("type")
+    if t == "object":
+        props = node.get("properties", {})
+        return {key: _render_schema_example(child, defs, depth + 1) for key, child in props.items()}
+    if t == "array":
+        # One example item — keep prompts compact.
+        return [_render_schema_example(node.get("items", {}), defs, depth + 1)]
+    if "enum" in node:
+        return node["enum"][0]
+    if t == "string":
+        return "example string"
+    if t == "integer":
+        return 1
+    if t == "number":
+        return 1.0
+    if t == "boolean":
+        return True
+    if t == "null":
+        return None
+    return None
+
+
+def _format_response_contract(model_class) -> str:
+    """Render the 4-layer JSON-shape contract block for a Pydantic model.
+
+    Layers (schema, example, rules, self-verify) are derived mechanically
+    from model.model_json_schema(); no hand-rolled examples per call site.
+    """
+    import json as _json
+
+    schema = model_class.model_json_schema()
+    defs = schema.get("$defs", {})
+    rendered_shape = _render_schema_shape(schema, defs, indent=0)
+    rendered_example = _json.dumps(
+        _render_schema_example(schema, defs, depth=0), indent=2
+    )
+
+    return (
+        "\n\n"
+        "Return JSON shaped exactly like this. Keys MUST match exactly.\n"
+        "Top-level wrapper MUST be a JSON object, not a list.\n"
+        "Do not add, rename, or remove fields.\n\n"
+        "Schema:\n"
+        f"{rendered_shape}\n\n"
+        "Example (use this shape with your real values, not these placeholders):\n"
+        f"{rendered_example}\n\n"
+        "Before returning, verify your output matches the shape above."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Errors
 # ---------------------------------------------------------------------------

--- a/nlp-service/tests/test_llm_contracts.py
+++ b/nlp-service/tests/test_llm_contracts.py
@@ -61,3 +61,197 @@ def test_format_response_contract_marks_nullable_fields():
     # _Item.value is Optional[int] → must show null marker somewhere
     lowered = rendered.lower()
     assert "null" in lowered
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+#  Per-call-site contract tests (Task A.3)
+#
+#  For every response_model in llm_client.py, four assertions:
+#    1. Canonical-shape input parses cleanly.
+#    2. Wrapper-key drift (e.g. "pairs" instead of "results") raises.
+#    3. Bare list (no wrapper) raises.
+#    4. Prompt constant contains the wrapper key as a literal substring.
+#
+#  Negative-shape variants are derived from real production failures:
+#    • Variant A — session 7ff0547d-… (2026-05-06): {"pairs":[...]}
+#    • Variant B — session 33455fe7-… (2026-05-06): bare list [{...}]
+# ──────────────────────────────────────────────────────────────────────────────
+
+from services.llm_client import (
+    LintScanResponse,
+    LLMExtractionResponse,
+    DisambiguationResponse,
+    CrossrefResponse,
+    SelectPagesResponse,
+    SynthesizeResponse,
+    _LINT_SYSTEM_PROMPT,
+    _EXTRACTION_SYSTEM_PROMPT,
+    _DISAMBIGUATION_SYSTEM_PROMPT,
+    _DISAMBIGUATION_CONCEPT_SYSTEM_PROMPT,
+    _CROSSREF_SYSTEM_PROMPT,
+    _SELECT_PAGES_SYSTEM_PROMPT,
+    _SYNTHESIZE_SYSTEM_PROMPT,
+)
+
+
+# ── DisambiguationResponse — wrapper key = "results" ──────────────────────────
+
+def test_disambiguation_canonical():
+    p = DisambiguationResponse.model_validate({
+        "results": [{
+            "entity_a": "OpenAI", "entity_b": "Open AI Inc.",
+            "decision": "same", "canonical": "OpenAI",
+            "reason": "Same legal entity.",
+        }]
+    })
+    assert p.results[0].decision == "same"
+
+
+def test_disambiguation_rejects_pairs_wrapper():
+    # Variant A from session 7ff0547d
+    with pytest.raises(ValidationError):
+        DisambiguationResponse.model_validate({
+            "pairs": [{
+                "entity_a": "OpenAI", "entity_b": "Open AI Inc.",
+                "decision": "same", "canonical": "OpenAI", "reason": "x",
+            }]
+        })
+
+
+def test_disambiguation_rejects_bare_list():
+    # Variant B from session 33455fe7
+    with pytest.raises(ValidationError):
+        DisambiguationResponse.model_validate(
+            [{"entity_a": "OpenAI", "entity_b": "Open AI Inc.",
+              "decision": "same", "canonical": "OpenAI", "reason": "x"}]
+        )
+
+
+def test_disambiguation_prompt_anchors_results():
+    assert "results" in _DISAMBIGUATION_SYSTEM_PROMPT
+    assert "Return JSON" in _DISAMBIGUATION_SYSTEM_PROMPT
+
+
+def test_disambiguation_concept_prompt_anchors_results():
+    assert "results" in _DISAMBIGUATION_CONCEPT_SYSTEM_PROMPT
+    assert "Return JSON" in _DISAMBIGUATION_CONCEPT_SYSTEM_PROMPT
+
+
+# ── LintScanResponse — wrapper key = "contradictions" ─────────────────────────
+
+def test_lint_canonical():
+    p = LintScanResponse.model_validate({"contradictions": []})
+    assert p.contradictions == []
+
+
+def test_lint_rejects_results_wrapper():
+    with pytest.raises(ValidationError):
+        LintScanResponse.model_validate({"results": []})
+
+
+def test_lint_rejects_bare_list():
+    with pytest.raises(ValidationError):
+        LintScanResponse.model_validate([])
+
+
+def test_lint_prompt_anchors_contradictions():
+    assert "contradictions" in _LINT_SYSTEM_PROMPT
+
+
+# ── LLMExtractionResponse — flat 6-key shape ──────────────────────────────────
+
+def test_extraction_canonical():
+    p = LLMExtractionResponse.model_validate({
+        "entities": [], "concepts": [], "claims": [],
+        "relationships": [], "contradictions": [], "summary": "x",
+    })
+    assert p.summary == "x"
+
+
+def test_extraction_rejects_data_wrapper():
+    with pytest.raises(ValidationError):
+        LLMExtractionResponse.model_validate({"data": {
+            "entities": [], "concepts": [], "claims": [],
+            "relationships": [], "contradictions": [], "summary": "x",
+        }})
+
+
+def test_extraction_rejects_bare_list():
+    with pytest.raises(ValidationError):
+        LLMExtractionResponse.model_validate([])
+
+
+def test_extraction_prompt_anchors_keys():
+    for key in ("entities", "concepts", "claims", "relationships", "summary"):
+        assert key in _EXTRACTION_SYSTEM_PROMPT, f"missing wrapper key: {key}"
+
+
+# ── CrossrefResponse — wrapper keys = "updated_pages", "contradictions_found" ─
+
+def test_crossref_canonical():
+    p = CrossrefResponse.model_validate({
+        "updated_pages": [], "contradictions_found": [],
+    })
+    assert p.updated_pages == []
+
+
+def test_crossref_rejects_pages_wrapper():
+    with pytest.raises(ValidationError):
+        CrossrefResponse.model_validate({"pages": [], "contradictions": []})
+
+
+def test_crossref_rejects_bare_list():
+    with pytest.raises(ValidationError):
+        CrossrefResponse.model_validate([])
+
+
+def test_crossref_prompt_anchors_keys():
+    assert "updated_pages" in _CROSSREF_SYSTEM_PROMPT
+    assert "contradictions_found" in _CROSSREF_SYSTEM_PROMPT
+
+
+# ── SelectPagesResponse — wrapper key = "page_ids" ────────────────────────────
+
+def test_select_pages_canonical():
+    p = SelectPagesResponse.model_validate({"page_ids": ["abc", "def"]})
+    assert p.page_ids == ["abc", "def"]
+
+
+def test_select_pages_rejects_results_wrapper():
+    with pytest.raises(ValidationError):
+        SelectPagesResponse.model_validate({"results": ["abc"]})
+
+
+def test_select_pages_rejects_bare_list():
+    with pytest.raises(ValidationError):
+        SelectPagesResponse.model_validate(["abc"])
+
+
+def test_select_pages_prompt_anchors_page_ids():
+    assert "page_ids" in _SELECT_PAGES_SYSTEM_PROMPT
+
+
+# ── SynthesizeResponse — wrapper keys = "answer", "citations" ─────────────────
+
+def test_synthesize_canonical():
+    p = SynthesizeResponse.model_validate({
+        "answer": "The transformer architecture was introduced in 2017.",
+        "citations": [{"page_id": "p1", "page_title": "Transformer"}],
+    })
+    assert p.answer.startswith("The transformer")
+    assert p.citations[0].page_id == "p1"
+
+
+def test_synthesize_rejects_response_wrapper():
+    with pytest.raises(ValidationError):
+        SynthesizeResponse.model_validate({"response": {"answer": "x", "citations": []}})
+
+
+def test_synthesize_rejects_bare_list():
+    with pytest.raises(ValidationError):
+        SynthesizeResponse.model_validate([])
+
+
+def test_synthesize_prompt_anchors_keys():
+    assert "answer" in _SYNTHESIZE_SYSTEM_PROMPT
+    assert "citations" in _SYNTHESIZE_SYSTEM_PROMPT

--- a/nlp-service/tests/test_llm_contracts.py
+++ b/nlp-service/tests/test_llm_contracts.py
@@ -1,0 +1,63 @@
+"""Contract tests for response-model prompts.
+
+Two responsibilities:
+  1. Assert every Pydantic response model parses canonical-shape responses
+     and rejects the two known DeepSeek drift variants (wrong wrapper key
+     and bare list — both observed in production: sessions 7ff0547d and
+     33455fe7 on 2026-05-06).
+  2. Assert every system prompt embeds its wrapper key as a literal
+     substring (no implicit-by-_JSON_TRAILER reliance).
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from services.llm_client import _format_response_contract
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+#  Helper unit tests (Task A.1)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class _Flat(BaseModel):
+    answer: str
+    confidence: Literal["high", "medium", "low"]
+
+
+class _Nested(BaseModel):
+    class _Item(BaseModel):
+        name: str
+        value: int | None = None
+
+    results: list[_Item]
+
+
+def test_format_response_contract_renders_flat_model():
+    rendered = _format_response_contract(_Flat)
+    assert "answer" in rendered
+    assert "confidence" in rendered
+    assert "high" in rendered and "medium" in rendered and "low" in rendered
+    assert "Return JSON" in rendered
+    assert "verify your output" in rendered.lower()
+
+
+def test_format_response_contract_renders_nested_list():
+    rendered = _format_response_contract(_Nested)
+    assert "results" in rendered
+    assert "name" in rendered
+    assert "value" in rendered
+    # Nested $ref must be resolved into the inline shape, not left as a $defs
+    # reference token.
+    assert "$ref" not in rendered
+    assert "$defs" not in rendered
+
+
+def test_format_response_contract_marks_nullable_fields():
+    rendered = _format_response_contract(_Nested)
+    # _Item.value is Optional[int] → must show null marker somewhere
+    lowered = rendered.lower()
+    assert "null" in lowered


### PR DESCRIPTION
## Summary

Two live production failures within 4 hours of each other (sessions `7ff0547d` and `33455fe7`) hit the same class of bug: DeepSeek's `json_object` mode emits the wrong JSON wrapper key, Pydantic raises `ValidationError`, the compile session dies. Two distinct drift variants observed:

- **Variant A** (session `7ff0547d`): `{"pairs":[...]}` instead of `{"results":[...]}` — wrapper-key drift.
- **Variant B** (session `33455fe7`): bare list `[{...}, {...}]` — no wrapper at all. Three disambiguate calls, all three failed identically.

Root cause: `_DISAMBIGUATION_SYSTEM_PROMPT` (and 4 other response_model prompts) describes per-pair fields but never anchors the JSON wrapper. DeepSeek's `json_object` mode is documented to read only the prompt text — `response_model` is server-side ignored. Without an explicit wrapper-key anchor + filled-in example, the model improvises.

This PR systematizes prompt anchoring across **every response_model call site** in `nlp-service/services/llm_client.py` and locks it in with **28 contract tests**.

## What changed

### `_format_response_contract()` helper (Task A.1)
New module-level helper at [nlp-service/services/llm_client.py:86-208](nlp-service/services/llm_client.py#L86) renders a **4-layer prompt contract** from a Pydantic model:

1. **Schema** — literal type-placeholder shape (`<string>`, `<integer or null>`, `<one of: 'high' | 'medium' | 'low'>`)
2. **Example** — one filled-in canonical instance with placeholder values
3. **Rules** — explicit "Keys MUST match exactly. Top-level wrapper MUST be a JSON object, not a list."
4. **Self-verify** — closing line "Before returning, verify your output matches the shape above."

Output is mechanically derived from `model.model_json_schema()` — no hand-rolled examples per call site. Industry pattern (BAML schema-aligned parsing, Promptfoo `evaluate-json`, OpenAI structured outputs guide).

### Applied to 7 prompts (Task A.2)
Finalization block at end of file appends `_format_response_contract(<Model>)` to:
- `_LINT_SYSTEM_PROMPT` → `LintScanResponse`
- `_EXTRACTION_SYSTEM_PROMPT` → `LLMExtractionResponse`
- `_DISAMBIGUATION_SYSTEM_PROMPT` + `_DISAMBIGUATION_CONCEPT_SYSTEM_PROMPT` → `DisambiguationResponse`
- `_CROSSREF_SYSTEM_PROMPT` → `CrossrefResponse`
- `_SELECT_PAGES_SYSTEM_PROMPT` → `SelectPagesResponse`
- `_SYNTHESIZE_SYSTEM_PROMPT` → `SynthesizeResponse`

Output is appended **after** `_JSON_TRAILER`, never replacing it: DeepSeek requires the literal "json" keyword in the prompt to enable `json_object` response_format.

**Untouched** (no `response_model` used): `_DRAFT_PAGE_PROMPTS`, `_SCHEMA_SYSTEM_PROMPT`, `triage_page_update` inline, `generate_digest` inline.

### Contract test suite (Task A.3)
New `nlp-service/tests/test_llm_contracts.py` — **28 tests**:

- 3 helper unit tests (flat model, nested list, nullable fields)
- 4 tests per response model × 6 models = 24 (positive parse + reject wrong wrapper + reject bare list + assert prompt anchors wrapper key) — plus an extra prompt-anchor for the concept variant of disambiguation = 25.

Negative-shape variants are derived from real production failures.

### Structured parse-failure tail (Task A.5)
New `_parse_failure_tail()` helper appends a structured trailer to every `LLMCompileError` parse-failure raise:

```
parse_failed: step=disambiguate: expected_wrapper=results, got_type=list, got_keys=[], raw_excerpt='[{...}]'
```

Wrapped 9 raise sites (lint, extract × 5 paths, disambiguate, crossref, triage, select_pages, synthesize). Phase C of the master plan reads this through `/api/compile/progress/events`. Today the same information lives only in docker logs.

## Test plan

- [x] `cd nlp-service && python -m pytest tests/ services/providers/ -q` → **210 passed** (was 182 baseline + 28 new)
- [x] Smoke: render `_DISAMBIGUATION_SYSTEM_PROMPT` tail — contains literal `"results": [...]` shape + filled-in example
- [x] Smoke: feed both observed live drift shapes (Variant A `{"pairs":[...]}`, Variant B `[{...}]`) to `_parse_failure_tail` — outputs match expected format
- [ ] Manual: trigger fresh DeepSeek compile that reaches `resolve` step — verify session completes without `disambiguate_llm_parse_failed`
- [ ] Follow-up PR: extend corpus revalidation runner to disambiguate / crossref / select_pages / synthesize endpoints (Phase A.4 of master plan, separate branch)

## Out of scope (deliberate)

- Auto-recover salvage layer for wrapper-key drift — plan locked on **fail loud + catch in CI** (no salvage).
- Multi-call corpus runner — separate PR (`chore/multi-call-corpus-runner`).
- Progress UI changes (failed step inline detail, expand-to-reveal) — separate PRs (PR3-PR6 of master plan).

## References

- DeepSeek API JSON Output guide: https://api-docs.deepseek.com/guides/json_mode
- Industry pattern (4-layer prompt): BAML schema-aligned parsing, Promptfoo evaluate-json
- Phase 7 corpus revalidation precedent: `validation/2026-05-05-multi-provider-corpus/REPORT.md`