### PR TITLE
feat(progress): render detail on done + failed step rows

### DIFF
--- a/app/src/app/onboarding/progress/page.tsx
+++ b/app/src/app/onboarding/progress/page.tsx
@@ -656,24 +656,41 @@ function ProgressPageInner() {
                     </div>
                   </div>
                 ) : (
-                  /* Done / failed / pending — single line */
-                  <div style={{ flex: 1, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                    <span style={{
-                      fontFamily: 'var(--font-heading)', fontWeight: 500,
-                      fontSize: isStepDone ? 16 : 14,
-                      lineHeight: isStepDone ? '24px' : '20px',
-                      color: isStepFailed ? 'var(--danger)' : 'var(--fg)',
-                      opacity: isStepDone ? 0.6 : 1,
-                    }}>
-                      {step.label}
-                    </span>
-                    {isStepDone && (
+                  /* Done / failed / pending — single line + optional detail row */
+                  <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 4 }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                       <span style={{
-                        fontFamily: 'var(--font-mono)', fontSize: 10, lineHeight: '15px',
-                        letterSpacing: '-0.5px', textTransform: 'uppercase', color: 'var(--fg-subtle)',
-                        flexShrink: 0,
+                        fontFamily: 'var(--font-heading)', fontWeight: 500,
+                        fontSize: isStepDone ? 16 : 14,
+                        lineHeight: isStepDone ? '24px' : '20px',
+                        color: isStepFailed ? 'var(--danger)' : 'var(--fg)',
+                        opacity: isStepDone ? 0.6 : 1,
                       }}>
-                        Done
+                        {step.label}
+                      </span>
+                      {isStepDone && (
+                        <span style={{
+                          fontFamily: 'var(--font-mono)', fontSize: 10, lineHeight: '15px',
+                          letterSpacing: '-0.5px', textTransform: 'uppercase', color: 'var(--fg-subtle)',
+                          flexShrink: 0,
+                        }}>
+                          Done
+                        </span>
+                      )}
+                    </div>
+                    {/* Render detail on done/failed rows. Active row already has its own
+                        detail block above; pending rows have nothing to show. */}
+                    {detail && (isStepDone || isStepFailed) && (
+                      <span style={{
+                        fontFamily: 'var(--font-mono)',
+                        fontSize: 11,
+                        lineHeight: '16px',
+                        color: isStepFailed ? 'var(--danger)' : 'var(--fg-subtle)',
+                        whiteSpace: 'pre-wrap',
+                        wordBreak: 'break-word',
+                        opacity: isStepDone ? 0.7 : 1,
+                      }}>
+                        {detail}
                       </span>
                     )}
                   </div>


### PR DESCRIPTION
## Summary

The per-step `detail` field is rendered only for the **active** step row in [progress/page.tsx:641-648](app/src/app/onboarding/progress/page.tsx#L641-L648). Done/failed rows show the step label only. When a session fails, the actual error lives in docker logs and the user sees "Step ❌" with no diagnostic context.

This PR renders `detail` on done + failed step rows: small grey monospace summary on done, red on failed. Same logic, two color paths, one wrapper div change.

## Why this is the smallest unit of progress-UX improvement

Two recent live failures (sessions `7ff0547d` and `33455fe7`) both hit `disambiguate_llm_parse_failed`. The user saw "Resolving entities ❌" and a generic "Compile failed" headline. The actual error message (`disambiguate_llm_parse_failed: results: Field required, input_value=...`) lived only in docker logs.

After this PR, that error renders inline on the failed step row. Combined with PR #64's structured parse-failure tail (`parse_failed: step=disambiguate: expected_wrapper=results, got_type=list, got_keys=[], raw_excerpt='[{...}]'`), the user sees exactly which wrapper drift hit them.

## What changed

- [app/src/app/onboarding/progress/page.tsx:658-680](app/src/app/onboarding/progress/page.tsx#L658-L680): inactive-step branch wrapped in a flex column; new `<span>` renders `detail` when `(isStepDone || isStepFailed) && detail`. `whiteSpace: pre-wrap` so multi-line errors wrap naturally.

## What's NOT in this PR (deliberate scope)

- No data-model change. The `detail` field is already on every StepState.
- No new endpoint, no state, no test fixtures.
- Independent of PR #64 (LLM prompt hardening) and the upcoming PR3+PR4 (activity-log scoping + `/items` + `/events` endpoints).
- Expand-to-reveal toggle (per-step items + activity tail) is a separate, larger PR (PR6 of master plan).

## Test plan

- [x] `cd app && npx tsc --noEmit` → 0 errors
- [x] `cd app && npx vitest run` → 366/366 (no new tests added; the only change is JSX inside an existing render branch with no logic change to assert)
- [ ] Manual: trigger a planted-failure compile; verify failed step row renders the error in red below the step label
- [ ] Manual: verify done rows render their summary (e.g. "13/13 sources extracted") below the label in grey