### PR TITLE
feat(compile): parallelize extract step (concurrency=4) + bump file cap to 100

### DIFF
--- a/app/src/app/api/compile/run/route.ts
+++ b/app/src/app/api/compile/run/route.ts
@@ -311,29 +311,83 @@ async function runCompilePipeline(sessionId: string): Promise<void> {
   } else {
     updateCompileStep(sessionId, 'extract', 'running');
     let extractSucceeded = sources.length - unextracted.length;
-    for (const src of unextracted) {
-      try {
-        await callExtract(src.source_id, sessionId);
-        extractSucceeded++;
-      } catch (err) {
-        logActivity('extraction_failed', {
-          source_id: src.source_id,
-          details: { title: src.title, error: err instanceof Error ? err.message : String(err) },
-        });
+    let extractFailed = 0;
+
+    // Parallel extract: each call is 30-400s on DeepSeek (provider-side
+    // generation latency), and we use <1% of the tier RPM cap. Sequential
+    // for...of made wall-clock = N × 250s; concurrency=4 cuts that 4×.
+    //
+    // Concurrency knob: process.env.EXTRACT_CONCURRENCY (default 4). Higher
+    // = faster wall-clock, more in-flight memory + more risk of the daily $
+    // cap firing in a burst. 4 is conservative — Tier 1 RPM allows 800/min;
+    // 4 concurrent calls × ~0.25 RPS each = 1 RPS, plenty of headroom.
+    //
+    // JS single-threaded ⇒ extractSucceeded/extractFailed/queue.shift()
+    // are race-free without a lock. better-sqlite3 + WAL serializes the
+    // updateCompileStep writes; same for logActivity.
+    const EXTRACT_CONCURRENCY = Math.max(
+      1,
+      parseInt(process.env.EXTRACT_CONCURRENCY ?? '4', 10) || 4,
+    );
+    const queue = [...unextracted];
+    let cancelled = false;
+
+    async function extractWorker(): Promise<void> {
+      while (queue.length > 0 && !cancelled) {
+        const src = queue.shift();
+        if (!src) return;
+        try {
+          // Cancel check inside the worker so an in-flight extract finishes
+          // its current call but no new ones start.
+          assertNotCancelled(sessionId);
+        } catch {
+          cancelled = true;
+          return;
+        }
+        try {
+          await callExtract(src.source_id, sessionId);
+          extractSucceeded++;
+        } catch (err) {
+          extractFailed++;
+          logActivity('extraction_failed', {
+            source_id: src.source_id,
+            details: { title: src.title, error: err instanceof Error ? err.message : String(err) },
+          });
+        }
+        // Progress update after every completion (success or fail). Counter
+        // is JS-int-atomic; concurrent writes to compile_progress.steps land
+        // in WAL serially. Last-write-wins on the detail string is fine —
+        // each writer has the same source-of-truth (succeeded count).
+        updateCompileStep(
+          sessionId,
+          'extract',
+          'running',
+          `${extractSucceeded}/${sources.length} sources extracted`,
+        );
       }
-      updateCompileStep(
-        sessionId,
-        'extract',
-        'running',
-        `${extractSucceeded}/${sources.length} sources extracted`
-      );
+    }
+
+    await Promise.all(
+      Array.from({ length: Math.min(EXTRACT_CONCURRENCY, unextracted.length) }, () =>
+        extractWorker(),
+      ),
+    );
+
+    if (cancelled) {
+      // Cancellation already wrote the cancelled status via cancel route;
+      // bail out without overwriting the step state.
+      assertNotCancelled(sessionId);
     }
     if (extractSucceeded === 0) {
       updateCompileStep(sessionId, 'extract', 'failed', `0/${sources.length} sources extracted`);
       failCompileProgress(sessionId, 'All sources failed extraction');
       return;
     }
-    updateCompileStep(sessionId, 'extract', 'done', `${extractSucceeded}/${sources.length} sources extracted`);
+    const detail =
+      extractFailed > 0
+        ? `${extractSucceeded}/${sources.length} sources extracted (${extractFailed} failed)`
+        : `${extractSucceeded}/${sources.length} sources extracted`;
+    updateCompileStep(sessionId, 'extract', 'done', detail);
   }
   assertNotCancelled(sessionId);
 

--- a/app/src/app/api/onboarding/upload/route.ts
+++ b/app/src/app/api/onboarding/upload/route.ts
@@ -44,7 +44,11 @@ const ALLOWED_EXTENSIONS = new Set([
   '.wav',
 ]);
 
-const MAX_FILES_PER_REQUEST = 20;
+// 100 files × 50 MB each = 5 GB max body. Realistic uploads (1-5 MB
+// avg per PDF/doc) → 100-500 MB per request, which Node + Next.js
+// handle without strain. Bumped from 20 to support batch onboarding
+// for users with large source corpora (research-corpus use case).
+const MAX_FILES_PER_REQUEST = 100;
 const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024; // 50 MB
 
 function sanitizeFilename(name: string): string {

--- a/app/src/app/onboarding/[connector]/page.tsx
+++ b/app/src/app/onboarding/[connector]/page.tsx
@@ -252,7 +252,10 @@ function FileConnector({ sessionId, connectors, connectorIdx, showToast, mode }:
 
   function addFiles(fileList: FileList | null) {
     if (!fileList) return;
-    setSelectedFiles(prev => [...prev, ...Array.from(fileList)].slice(0, 20));
+    // Cap matches the server side (MAX_FILES_PER_REQUEST in
+    // /api/onboarding/upload). If they drift, the user gets a confusing
+    // 422 only on submit instead of an obvious "(max N)" hint here.
+    setSelectedFiles(prev => [...prev, ...Array.from(fileList)].slice(0, 100));
   }
 
   function removeFile(idx: number) {
@@ -441,7 +444,7 @@ function FileConnector({ sessionId, connectors, connectorIdx, showToast, mode }:
                   fontFamily: 'var(--font-mono)', fontSize: 10, letterSpacing: '1px',
                   textTransform: 'uppercase', color: 'var(--accent)', marginTop: 8,
                 }}>
-                  {selectedFiles.length} file{selectedFiles.length !== 1 ? 's' : ''} selected{selectedFiles.length >= 20 ? ' (max 20)' : ''}
+                  {selectedFiles.length} file{selectedFiles.length !== 1 ? 's' : ''} selected{selectedFiles.length >= 100 ? ' (max 100)' : ''}
                 </p>
               )}
             </div>


### PR DESCRIPTION
## Summary

Two throughput wins for batch-onboarding workloads (the research-corpus use case — users compiling 100s–1000s of sources at a time).

### 1. Parallel extract step

The extract loop in [compile/run/route.ts:314-330](app/src/app/api/compile/run/route.ts#L314-L330) is a serial `for…of` with `await callExtract` per source. Each LLM call takes 30–400s on DeepSeek (provider-side generation latency, not Kompl latency). 13 sources × 250s avg = ~55 minutes wall-clock for extract alone.

Tier-1 RPM limit is 1000/min; we use <1% (≈one call every 250s). The bottleneck is wall-clock, not rate-limit headroom.

**Fix:** worker-pool with concurrency=4 (env-tunable `EXTRACT_CONCURRENCY`). Cuts wall-clock ~4× without touching downstream pipeline.

- JS single-thread ⇒ `extractSucceeded` / `extractFailed` counters and `queue.shift()` are race-free without a lock
- better-sqlite3 + WAL serializes the concurrent `updateCompileStep` + `logActivity` writes
- Cancellation: each worker calls `assertNotCancelled` before pulling the next source — in-flight extracts complete, no new ones start
- Failure detail: extract step now reports `"(N failed)"` suffix when some sources errored

### 2. File-upload cap bumped 20 → 100

`/api/onboarding/upload`'s `MAX_FILES_PER_REQUEST` + the matching client cap in `onboarding/[connector]/page.tsx FileConnector` both move from 20 to 100. Realistic uploads at 1-5 MB avg per PDF/doc → 100-500 MB body, comfortable for Node + Next.js.

100 is the practical sweet spot for batch onboarding without stressing memory; users with 1000+ source corpora can now batch into ~10 sessions instead of ~50.

Also closes the /review-flagged regression where the client cap had been removed without updating the server (would have produced a confusing HTTP 422 on submit).

## Test plan

- [x] `cd app && npx tsc --noEmit` → 0 errors
- [x] `cd app && npx vitest run` → 366/366 (no behaviour change to existing tests; extract concurrency exercised by the live compile path, not the test fixtures)
- [ ] Manual: trigger compile with 13+ sources on DeepSeek; watch `[deepseek] step=extract` log lines for up to 4 concurrent in-flight calls
- [ ] Manual: cancel mid-run; verify in-flight calls complete but no new ones start
- [ ] Manual: upload 50 files, verify accept; upload 101, verify UI caps at 100 with "(max 100)" hint

## Out of scope

- Other pipeline steps (resolve, match, draft, crossref) stay serial. Each has different concurrency tradeoffs (resolve already batches via `disambiguate_entities` 10-pair calls; draft is per-page so already parallelizable but more complex). Future plan if extract parallelization shows the pattern works.
- DeepSeek/Gemini batch API (50%-cheaper async) — different shape (24h turnaround); right for 1800-source backlogs, wrong for "I want my wiki tonight". Separate plan.
- Resumable compile past extract — biggest win for very-large-corpus users; separate plan.