### PR TITLE
feat(compile): bump DRAFT_CONCURRENCY 5 → 10

### DIFF
--- a/app/src/app/api/compile/draft/route.ts
+++ b/app/src/app/api/compile/draft/route.ts
@@ -39,7 +39,13 @@ import {
 import { yamlDoubleQuote } from '../../../../lib/yaml-escape';
 
 const NLP_SERVICE_URL = process.env.NLP_SERVICE_URL ?? 'http://nlp-service:8000';
-const DRAFT_CONCURRENCY = 5;
+// 10 concurrent draft calls. Tier-1 RPM is 1000/min and we use <1% of it,
+// so the rate-limit headroom is huge. Per-page memory cost is ~100 KB
+// (source markdown + dossier + schema) → 10 concurrent ≈ 1 MB, fine.
+// Diminishing returns kick in when a layer has fewer plans than the cap;
+// 10 is chosen so a session with 10+ source-summary pages drafts in a
+// single round-trip instead of two staggered batches at 5.
+const DRAFT_CONCURRENCY = 10;
 
 // Same mapping as plan/route.ts — kept local to avoid a shared-lib extraction for 10 lines.
 // Default is 'Uncategorized' (not 'General') — 'General' as a fallback seeds a universal-matching label into existing_categories and the LLM reuses it for every subsequent draft.


### PR DESCRIPTION
## Summary

Draft step is already worker-pool parallelized via `pLimit` ([app/src/app/api/compile/draft/route.ts:716](app/src/app/api/compile/draft/route.ts#L716)), but the concurrency cap was hardcoded at 5. Bumping to 10.

**1-LOC change** (the constant) plus a comment explaining the choice.

## Why 10

- **Rate limits:** tier-1 RPM is 1000/min; we use <1% (each draft takes ~3 min, 10 concurrent = 0.05 RPS). Massive headroom.
- **Memory:** ~100 KB per page (source markdown + dossier + schema). 10 concurrent ≈ 1 MB in flight.
- **Real-world benefit:** layers with 10+ plans (e.g. 10+ source-summary pages when ingesting 10+ sources, or many promoted entity pages on a rich wiki) now draft in one round-trip instead of two staggered batches at 5.

## Where it does NOT help

Layers run **sequentially** (source-summary → entity → concept → comparison → overview) because later layers use already-drafted pages as `relatedPages` context for cross-references. Cross-layer parallelism would weaken cross-references; deliberately not done.

For sessions with ≤5 same-layer plans, behaviour is unchanged.

## Test plan

- [x] `cd app && npx tsc --noEmit` → 0 errors
- [x] `cd app && npx vitest run` → 366/366 (no behaviour change at the existing fixture sizes; the worker-pool semantics are already covered by `pLimit`-using tests)
- [ ] Manual: trigger compile with 12+ sources on DeepSeek; verify nlp-service log shows up to 10 concurrent `[deepseek] step=draft_page` lines, not strictly capped at 5

## Out of scope (deliberate)

- Cross-layer parallelism (weakens relatedPages context)
- DeepSeek batch API (separate plan, 24h turnaround shape — wrong for "I want my wiki tonight")
- Making `DRAFT_CONCURRENCY` env-tunable (adds knob complexity for marginal benefit; the static 10 is fine until evidence says otherwise)