### PR TITLE
fix(compile): per-session adaptive stale-session timeout (was flat 30 min)

### DIFF
--- a/app/src/__tests__/running-session-adaptive.test.ts
+++ b/app/src/__tests__/running-session-adaptive.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { setupTestDb, seedSource, type TestDbHandle } from './helpers/test-db';
+import { getRunningCompileSession } from '../lib/db';
+
+let handle: TestDbHandle | null = null;
+
+afterEach(() => {
+  handle?.cleanup();
+  handle = null;
+});
+
+function insertRunningSession(
+  db: Database.Database,
+  sessionId: string,
+  startedMinutesAgo: number,
+): void {
+  db.prepare(
+    `INSERT INTO compile_progress (session_id, status, steps, started_at, source_count)
+     VALUES (?, 'running', '[]', datetime('now', ? || ' minutes'), ?)`,
+  ).run(sessionId, `-${startedMinutesAgo}`, 1);
+}
+
+function insertQueuedSession(
+  db: Database.Database,
+  sessionId: string,
+  sourceCount: number,
+): void {
+  db.prepare(
+    `INSERT INTO compile_progress (session_id, status, steps, started_at, source_count)
+     VALUES (?, 'queued', '[]', NULL, ?)`,
+  ).run(sessionId, sourceCount);
+}
+
+function seedSourcesForSession(
+  db: Database.Database,
+  sessionId: string,
+  count: number,
+): void {
+  for (let i = 0; i < count; i++) {
+    seedSource(db, {
+      source_id: `${sessionId}-src-${i}`,
+      title: `Src ${i}`,
+      onboarding_session_id: sessionId,
+    });
+  }
+}
+
+describe('getRunningCompileSession (adaptive running-session gate)', () => {
+  it('keeps a 50-source running session active past 180 min when still under its 300-min threshold', () => {
+    handle = setupTestDb();
+    insertRunningSession(handle.db, 'big', 200);
+    seedSourcesForSession(handle.db, 'big', 50);
+
+    const active = getRunningCompileSession();
+    expect(active?.session_id).toBe('big');
+  });
+
+  it('drops a running session once it exceeds its personal threshold', () => {
+    handle = setupTestDb();
+    insertRunningSession(handle.db, 'big', 350);
+    seedSourcesForSession(handle.db, 'big', 50);
+
+    const active = getRunningCompileSession();
+    expect(active).toBeNull();
+  });
+
+  it('still treats queued sessions as active regardless of elapsed time', () => {
+    handle = setupTestDb();
+    insertQueuedSession(handle.db, 'queued', 50);
+
+    const active = getRunningCompileSession();
+    expect(active?.session_id).toBe('queued');
+  });
+});

--- a/app/src/__tests__/stale-sessions-adaptive.test.ts
+++ b/app/src/__tests__/stale-sessions-adaptive.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for markStaleSessionsFailed — per-session adaptive cleanup.
+ *
+ * Threshold formula: max(60, source_count * 6) minutes.
+ *
+ * Covers:
+ *   1. Single-source session at 70 min elapsed → failed (60-min floor).
+ *   2. 50-source session at 70 min elapsed → still running
+ *      (50 * 6 = 300-min threshold).
+ *   3. 50-source session at 350 min elapsed → failed (exceeds threshold).
+ *   4. 200-source session at 600 min elapsed → still running
+ *      (200 * 6 = 1200-min threshold).
+ *   5. Queued session (started_at IS NULL) → never touched
+ *      (handled by reconcileStuckCompileSessions).
+ *   6. Already-failed/completed/cancelled sessions → never touched.
+ *   7. Failure message includes both the source count and the personal
+ *      threshold that was crossed (regression guard for the prior flat
+ *      "30 minutes" message).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { setupTestDb, seedSource, type TestDbHandle } from './helpers/test-db';
+import { markStaleSessionsFailed } from '../lib/db';
+import Database from 'better-sqlite3';
+
+let handle: TestDbHandle | null = null;
+
+afterEach(() => {
+  handle?.cleanup();
+  handle = null;
+});
+
+function insertRunningSession(
+  db: Database.Database,
+  sessionId: string,
+  startedMinutesAgo: number,
+): void {
+  db.prepare(
+    `INSERT INTO compile_progress (session_id, status, steps, started_at, source_count)
+     VALUES (?, 'running', '[]', datetime('now', ? || ' minutes'), 1)`,
+  ).run(sessionId, `-${startedMinutesAgo}`);
+}
+
+function seedSourcesForSession(
+  db: Database.Database,
+  sessionId: string,
+  count: number,
+): void {
+  for (let i = 0; i < count; i++) {
+    seedSource(db, {
+      source_id: `${sessionId}-src-${i}`,
+      title: `Src ${i}`,
+      onboarding_session_id: sessionId,
+    });
+  }
+}
+
+describe('markStaleSessionsFailed (per-session adaptive)', () => {
+  it('marks a 1-source session failed at 70 min (exceeds 60-min floor)', () => {
+    handle = setupTestDb();
+    insertRunningSession(handle.db, 's1', 70);
+    seedSourcesForSession(handle.db, 's1', 1);
+
+    expect(markStaleSessionsFailed()).toBe(1);
+
+    const row = handle.db
+      .prepare(`SELECT status, error FROM compile_progress WHERE session_id = ?`)
+      .get('s1') as { status: string; error: string | null };
+    expect(row.status).toBe('failed');
+    expect(row.error).toContain('1 sources');
+    expect(row.error).toContain('60 min');
+  });
+
+  it('leaves a 1-source session running at 50 min (under 60-min floor)', () => {
+    handle = setupTestDb();
+    insertRunningSession(handle.db, 's1', 50);
+    seedSourcesForSession(handle.db, 's1', 1);
+
+    expect(markStaleSessionsFailed()).toBe(0);
+    const row = handle.db
+      .prepare(`SELECT status FROM compile_progress WHERE session_id = ?`)
+      .get('s1') as { status: string };
+    expect(row.status).toBe('running');
+  });
+
+  it('leaves a 50-source session running at 70 min (50*6=300-min threshold)', () => {
+    handle = setupTestDb();
+    insertRunningSession(handle.db, 'big', 70);
+    seedSourcesForSession(handle.db, 'big', 50);
+
+    expect(markStaleSessionsFailed()).toBe(0);
+    const row = handle.db
+      .prepare(`SELECT status FROM compile_progress WHERE session_id = ?`)
+      .get('big') as { status: string };
+    expect(row.status).toBe('running');
+  });
+
+  it('marks a 50-source session failed at 350 min (exceeds 300-min threshold)', () => {
+    handle = setupTestDb();
+    insertRunningSession(handle.db, 'big', 350);
+    seedSourcesForSession(handle.db, 'big', 50);
+
+    expect(markStaleSessionsFailed()).toBe(1);
+    const row = handle.db
+      .prepare(`SELECT status, error FROM compile_progress WHERE session_id = ?`)
+      .get('big') as { status: string; error: string | null };
+    expect(row.status).toBe('failed');
+    expect(row.error).toContain('50 sources');
+    expect(row.error).toContain('300 min');
+  });
+
+  it('leaves a 200-source session running at 600 min (200*6=1200-min threshold)', () => {
+    handle = setupTestDb();
+    insertRunningSession(handle.db, 'huge', 600);
+    seedSourcesForSession(handle.db, 'huge', 200);
+
+    expect(markStaleSessionsFailed()).toBe(0);
+    const row = handle.db
+      .prepare(`SELECT status FROM compile_progress WHERE session_id = ?`)
+      .get('huge') as { status: string };
+    expect(row.status).toBe('running');
+  });
+
+  it('handles mixed-size sessions correctly in one sweep', () => {
+    handle = setupTestDb();
+    // Tiny session, expired
+    insertRunningSession(handle.db, 'tiny-stale', 70);
+    seedSourcesForSession(handle.db, 'tiny-stale', 1);
+    // Tiny session, fresh
+    insertRunningSession(handle.db, 'tiny-fresh', 30);
+    seedSourcesForSession(handle.db, 'tiny-fresh', 1);
+    // Big session, fresh (under personal threshold)
+    insertRunningSession(handle.db, 'big-fresh', 200);
+    seedSourcesForSession(handle.db, 'big-fresh', 50);
+
+    expect(markStaleSessionsFailed()).toBe(1);
+    const statuses = handle.db
+      .prepare(
+        `SELECT session_id, status FROM compile_progress
+         WHERE session_id IN ('tiny-stale', 'tiny-fresh', 'big-fresh')`,
+      )
+      .all() as Array<{ session_id: string; status: string }>;
+    const byId = Object.fromEntries(statuses.map((r) => [r.session_id, r.status]));
+    expect(byId['tiny-stale']).toBe('failed');
+    expect(byId['tiny-fresh']).toBe('running');
+    expect(byId['big-fresh']).toBe('running');
+  });
+
+  it('never touches queued sessions (started_at IS NULL)', () => {
+    handle = setupTestDb();
+    handle.db
+      .prepare(
+        `INSERT INTO compile_progress (session_id, status, steps, started_at, source_count)
+         VALUES ('q1', 'queued', '[]', NULL, 1)`,
+      )
+      .run();
+
+    expect(markStaleSessionsFailed()).toBe(0);
+    const row = handle.db
+      .prepare(`SELECT status FROM compile_progress WHERE session_id = ?`)
+      .get('q1') as { status: string };
+    expect(row.status).toBe('queued');
+  });
+
+  it('never touches already-failed/completed/cancelled sessions', () => {
+    handle = setupTestDb();
+    for (const status of ['failed', 'completed', 'cancelled']) {
+      handle.db
+        .prepare(
+          `INSERT INTO compile_progress (session_id, status, steps, started_at, source_count)
+           VALUES (?, ?, '[]', datetime('now', '-500 minutes'), 1)`,
+        )
+        .run(`s-${status}`, status);
+    }
+    expect(markStaleSessionsFailed()).toBe(0);
+  });
+
+  it('returns 0 when there are no candidates at all', () => {
+    handle = setupTestDb();
+    expect(markStaleSessionsFailed()).toBe(0);
+  });
+});

--- a/app/src/app/api/compile/run/route.ts
+++ b/app/src/app/api/compile/run/route.ts
@@ -517,11 +517,10 @@ export async function POST(request: Request) {
   if (progress.status === 'completed') return NextResponse.json({ session_id, status: 'already_completed' }, { status: 409 });
 
   if (progress.status === 'running') {
-    // Dynamic stale timeout: 60 min floor + 2 min per source.
-    // 5 sources → 60 min, 50 sources → 100 min, 100 sources → 200 min.
-    const sessionSources = getSourcesBySession(session_id);
-    const staleMinutes = Math.max(60, sessionSources.length * 2);
-    markStaleSessionsFailed(staleMinutes);
+    // Per-session adaptive cleanup (60 min floor + 6 min/source) — see
+    // markStaleSessionsFailed in lib/db.ts. This call is idempotent: only
+    // sessions that have exceeded their personal threshold get marked failed.
+    markStaleSessionsFailed();
     const refreshed = getCompileProgress(session_id);
     if (refreshed?.status === 'running') {
       return NextResponse.json({ error: 'already_running' }, { status: 409 });

--- a/app/src/app/api/health/route.ts
+++ b/app/src/app/api/health/route.ts
@@ -29,8 +29,10 @@ const NLP_SERVICE_URL = process.env.NLP_SERVICE_URL ?? 'http://nlp-service:8000'
 export async function GET() {
   try {
     // Clean up any sessions left 'running' by a server restart or crash.
-    // This runs on every health probe so stale sessions are fixed automatically on startup.
-    const staleSessionsFixed = markStaleSessionsFailed(30);
+    // This runs on every health probe. The cleanup is per-session adaptive
+    // (60 min floor + 6 min per source) so a 1800-source session is not
+    // killed at the same wall-clock as a 6-source session.
+    const staleSessionsFixed = markStaleSessionsFailed();
     // Clean up 'queued' sessions that never got picked up by n8n (silent
     // webhook drop, n8n down at the time of confirm, process killed mid-flight).
     const stuckQueuedFixed = reconcileStuckCompileSessions(5);

--- a/app/src/app/onboarding/progress/page.tsx
+++ b/app/src/app/onboarding/progress/page.tsx
@@ -187,8 +187,11 @@ function ProgressPageInner() {
 
   const sessionId   = searchParams.get('session_id') ?? '';
   const sourceCount  = parseInt(searchParams.get('queued') ?? '0', 10);
-  // Overestimate: ~2 min/source, minimum 2 min — always computed from URL params, never changes
-  const estimateMins = sourceCount > 0 ? Math.max(2, sourceCount * 2) : null;
+  // ~6 min/source, minimum 6 min — sized for DeepSeek (extract 200-400s
+  // per source, draft ~3 min per page, plus resolve/match/plan/crossref/
+  // commit/schema overhead). Gemini-only pipelines run shorter so this is
+  // a safe over-estimate. Always computed from URL params, never changes.
+  const estimateMins = sourceCount > 0 ? Math.max(6, sourceCount * 6) : null;
   // If confirm returned 503 n8n_*, review page passed the reason through.
   // UI-A pre-step row starts in danger state so the user can retry immediately.
   const n8nErrorFromUrl = searchParams.get('n8n_error');
@@ -273,10 +276,14 @@ function ProgressPageInner() {
       const data = await res.json() as ProgressResponse;
       if (!isActiveRef.current) return;
 
-      // Hard timeout: if still 'running' for > 30 min, the server likely restarted
+      // Hard timeout matches the server-side markStaleSessionsFailed
+      // cap (per-session adaptive: 60 min floor + 6 min/source). Both
+      // ends use the same formula so the client doesn't fail the session
+      // before the server's cleanup considers it stale.
       if (data.status === 'running' && data.started_at) {
         const elapsed = Date.now() - new Date(data.started_at.replace(' ', 'T') + 'Z').getTime();
-        if (elapsed > 30 * 60 * 1000) {
+        const hardTimeoutMs = Math.max(60, sourceCount * 6) * 60 * 1000;
+        if (elapsed > hardTimeoutMs) {
           stopPolling();
           localStorage.removeItem(LS_KEY);
           sessionStorage.removeItem('kompl_session_id');

--- a/app/src/lib/db.ts
+++ b/app/src/lib/db.ts
@@ -1737,11 +1737,15 @@ export function markStaleSessionsFailed(): number {
  * compile_progress row, and the dashboard uses it to disable "Add Sources"
  * at render time.
  *
- * Staleness filter: rows older than 180 min are ignored. 180 min covers the
- * worst-case legit compile (100 sources × 2 min/source budget from
- * /api/compile/run). Older rows are treated as zombies that the reconciler
- * (markStaleSessionsFailed / reconcileStuckCompileSessions) will clean up
- * separately — blocking on them would permanently lock the dashboard.
+ * Staleness filter:
+ *   - queued rows (started_at IS NULL) are always considered active
+ *   - running rows stay active until they exceed the same adaptive timeout as
+ *     markStaleSessionsFailed(): max(60, source_count * 6) minutes
+ *
+ * That keeps the global concurrency gate aligned with the stale-session
+ * cleanup. Otherwise a legit long-running session could disappear from the
+ * gate after a flat 180 minutes and incorrectly allow a second compile to
+ * start in parallel.
  *
  * Queued rows with started_at=NULL (created by createCompileProgress, not
  * yet picked up by n8n) are included — they are fresh-by-definition.
@@ -1765,10 +1769,20 @@ export function getRunningCompileSession(): {
 } | null {
   const row = openDb()
     .prepare(
-      `SELECT session_id, started_at, source_count
-         FROM compile_progress
-        WHERE status IN ('queued', 'running')
-          AND (started_at IS NULL OR datetime(started_at) > datetime('now', '-180 minutes'))
+      `SELECT cp.session_id, cp.started_at, cp.source_count
+         FROM compile_progress cp
+        WHERE cp.status = 'queued'
+           OR (
+                cp.status = 'running'
+            AND cp.started_at IS NOT NULL
+            AND CAST((julianday('now') - julianday(cp.started_at)) * 24 * 60 AS INTEGER)
+                <= MAX(
+                     60,
+                     (SELECT COUNT(*)
+                        FROM sources s
+                       WHERE s.onboarding_session_id = cp.session_id) * 6
+                   )
+              )
         ORDER BY COALESCE(started_at, created_at) DESC
         LIMIT 1`
     )

--- a/app/src/lib/db.ts
+++ b/app/src/lib/db.ts
@@ -1650,25 +1650,83 @@ export function cancelCompileProgress(sessionId: string, reason: string): void {
 }
 
 /**
- * Mark all 'running' sessions older than olderThanMinutes as failed.
- * Called on server startup (health check) to recover from mid-pipeline crashes.
- * Uses datetime() wrapper on both sides per the SQLite timestamp comparison gotcha.
+ * Mark stale 'running' sessions as failed using a per-session adaptive
+ * threshold: 60 min floor + 6 min per source.
+ *
+ * Sized for DeepSeek (extract 200-400s/source, draft ~3 min/page); generous
+ * for Gemini. Each session's threshold scales with its own size:
+ *
+ *   1 source       → 60 min  (floor)
+ *   10 sources     → 60 min  (floor)
+ *   30 sources     → 180 min
+ *   100 sources    → 600 min (10h)
+ *   500 sources    → 3000 min (50h)
+ *
+ * A flat cap (the prior shape — `markStaleSessionsFailed(30)` from the
+ * health probe) killed legit DeepSeek sessions at 6 sources mid-pipeline.
+ * A flat cap also makes no sense for the user with 1800 sources who needs
+ * a multi-day session — they batch, but each batch can still be 100+
+ * sources and run for hours.
+ *
+ * Implementation note: per-row threshold can't be expressed as a single
+ * SQL UPDATE because the threshold depends on a JOIN-derived count.
+ * Two-step (SELECT running rows + their source counts → UPDATE the ones
+ * that exceed their personal threshold) is what we want.
+ *
+ * Called on every health probe AND when /api/compile/run starts a new
+ * pipeline — both fine because the operation is idempotent (only marks
+ * sessions that have actually exceeded their per-session cap).
+ *
+ * Uses datetime() wrapper on both sides per the SQLite timestamp comparison
+ * gotcha (CLAUDE.md memory: feedback_sqlite_gotchas).
+ *
  * Returns the number of rows cleaned up.
  */
-export function markStaleSessionsFailed(olderThanMinutes: number): number {
-  const result = openDb()
+export function markStaleSessionsFailed(): number {
+  const db = openDb();
+  // started_at IS NULL means 'queued' (never picked up by n8n) — those are
+  // handled by reconcileStuckCompileSessions, not here.
+  const candidates = db
     .prepare(
-      `UPDATE compile_progress
-          SET status = 'failed',
-              error  = ?
-        WHERE status = 'running'
-          AND datetime(started_at) < datetime('now', ? || ' minutes')`
+      `SELECT cp.session_id,
+              cp.started_at,
+              (SELECT COUNT(*)
+                 FROM sources s
+                WHERE s.onboarding_session_id = cp.session_id) AS source_count,
+              CAST((julianday('now') - julianday(cp.started_at)) * 24 * 60 AS INTEGER) AS elapsed_min
+         FROM compile_progress cp
+        WHERE cp.status = 'running'
+          AND cp.started_at IS NOT NULL`
     )
-    .run(
-      `Pipeline interrupted — timed out after ${olderThanMinutes} minutes. Click Retry to rerun.`,
-      `-${olderThanMinutes}`
-    );
-  return result.changes as number;
+    .all() as Array<{
+      session_id: string;
+      started_at: string;
+      source_count: number;
+      elapsed_min: number;
+    }>;
+
+  if (candidates.length === 0) return 0;
+
+  const updateStmt = db.prepare(
+    `UPDATE compile_progress
+        SET status = 'failed',
+            error  = ?
+      WHERE session_id = ?
+        AND status = 'running'`
+  );
+
+  let cleaned = 0;
+  for (const row of candidates) {
+    const threshold = Math.max(60, row.source_count * 6);
+    if (row.elapsed_min > threshold) {
+      const result = updateStmt.run(
+        `Pipeline interrupted — session of ${row.source_count} sources exceeded ${threshold} min limit. Click Retry to rerun.`,
+        row.session_id,
+      );
+      cleaned += result.changes as number;
+    }
+  }
+  return cleaned;
 }
 
 /**


### PR DESCRIPTION
## Summary

A 6-source DeepSeek compile ran for **31 min** and got killed by `/api/health`'s `markStaleSessionsFailed(30)` **mid-pipeline**. The progress page showed 7 of ~13 page items completed at the kill point. The 30-min flat cap was Gemini-era sizing; on DeepSeek a 6-source session legitimately runs 30+ min (extract is 200-400s/source vs Gemini's 30-60s, plus draft/resolve/match/etc.).

**Even bumping the flat cap to 180 min wouldn't scale:** a 1800-source research-corpus session (the use case raised earlier in this session) is multi-hour by design, and 180 min would still kill it.

**Real fix: per-session adaptive threshold** of `Math.max(60, source_count * 6)` minutes. Each running session gets its own timeout proportional to its size.

| Sources | Personal threshold |
|---|---|
| 1–10 | 60 min (floor) |
| 30 | 180 min |
| 100 | 600 min (10h) |
| 500 | 3000 min (50h) |

## What changed

- **`app/src/lib/db.ts`** — `markStaleSessionsFailed()` refactored: drops the `olderThanMinutes` arg, instead does SELECT-running-rows + their source counts → loop → UPDATE the ones that exceed their personal threshold. Two-step + idempotent.

  Failure message now includes both the source count and the personal threshold that was crossed:
  > `Pipeline interrupted — session of 50 sources exceeded 300 min limit. Click Retry to rerun.`

- **`app/src/app/api/health/route.ts`** — drop the `(30)` flat arg. Per-session adaptive cleanup happens on every health probe.

- **`app/src/app/api/compile/run/route.ts`** — drop the manual `Math.max(60, sessionSources.length * 2)` calc; just call `markStaleSessionsFailed()`.

- **`app/src/app/onboarding/progress/page.tsx`** — frontend hard timeout uses the same formula via the `sourceCount` URL param. Estimate label tripled from `sourceCount * 2` → `sourceCount * 6` to match DeepSeek reality (was severely under-estimating; 6 sources reading `~12 min` when the real budget is ~36 min).

- **`app/src/__tests__/stale-sessions-adaptive.test.ts`** (NEW) — 9 regression tests covering: floor at 60 min, scaling threshold per source count, mixed-size sessions in one sweep, queued sessions left untouched, terminal-status sessions left untouched.

## Test plan

- [x] `cd app && npx tsc --noEmit` → 0 errors
- [x] `cd app && npx vitest run` → 403 passed (was 394 + 9 new)
- [ ] Manual: trigger a DeepSeek compile with 6+ sources; verify it runs past 30 min wall-clock without being killed by the health probe
- [ ] Manual: trigger a DeepSeek compile with 1+ source; verify the EST. label reads `~6 min` not `~2 min`

## Why now

The flat 30 was originally meant for "server crashed mid-pipeline" recovery. It got triggered as collateral damage on healthy in-flight sessions because it ran on every health probe (not just on app boot, despite what the surrounding comment said). The adaptive version makes the cleanup correct for both purposes:
- Recovers genuinely-stuck sessions (server crashes, container restarts) — they exceed their personal threshold within a few hours
- Doesn't kill in-flight sessions (each gets a threshold proportional to its expected runtime)