### PR TITLE
fix(mcp-server): bump hono >=4.12.16 (GHSA-69xw-7hcm-h432, GHSA-9vqf-7f2p-gf9v)

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -584,9 +584,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -18,7 +18,7 @@
     "@types/node": "^24.9.2"
   },
   "overrides": {
-    "hono": "^4.12.14",
+    "hono": "^4.12.16",
     "ip-address": "^10.1.1"
   }
 }


### PR DESCRIPTION
## Summary

- Two new advisories on `hono` published 2026-05-06; bump override floor `^4.12.14` → `^4.12.16` so the lockfile picks up the patched line (resolves to 4.12.18).
- `GHSA-69xw-7hcm-h432` (CVE-2026-44455, CVSS 4.7) — hono/jsx tag-name validation bypass.
- `GHSA-9vqf-7f2p-gf9v` (CVE-2026-44456, CVSS 6.5) — `bodyLimit()` bypass on `Transfer-Encoding: chunked` requests.
- Closes Scorecard alert [#70](https://github.com/tuirk/Kompl/security/code-scanning/70); Vulnerabilities check should rebound 8/10 → 10/10 on the next Scorecard run, restoring composite score 6.1 → 6.3.

## Why this is low-risk

- `mcp-server` does not import `hono` directly — it's only present transitively via `@modelcontextprotocol/sdk`. `grep -r "from ['\"]hono"` in `mcp-server/` returns zero matches.
- Neither vulnerable code path is exercised here: no JSX SSR, no `bodyLimit()` middleware usage anywhere in tree.
- 4.12.14 → 4.12.16 is a semver patch bump (backwards-compatible bug fixes only).
- Same pattern as the recent `ip-address` override bump in `cc7f586`.

## Test plan

- [x] `npm install` in `mcp-server/` regenerates lockfile cleanly
- [x] Lockfile resolves `node_modules/hono` to 4.12.18 (≥ 4.12.16)
- [ ] CI green (Tests workflow on push)
- [ ] Next scheduled Scorecard run (or post-merge run on `main`) closes alert #70