### PR TITLE
feat(compile): retry stranded extract-failures via orchestrator re-plan

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,10 +28,11 @@ GEMINI_DAILY_USD_CAP=5.00
 # DeepSeek V4 Pro as a second selectable backend (Phase 4 multi-provider).
 # Get key at: https://api-docs.deepseek.com
 # Default DEEPSEEK_RPM=60 matches DeepSeek's documented per-minute cap.
-# Discount window: 75% off through 2026-05-31T15:59:00Z UTC; the provider
-# auto-flips to list pricing after the deadline. Override via
-# DEEPSEEK_INPUT_USD_PER_M / OUTPUT / CACHE if you need to pin pricing
-# manually (e.g. after the discount window or for non-UTC deployments).
+# Pricing follows DeepSeek's published list rates; promotional discount
+# windows are ignored on purpose (the cap counter overestimates during a
+# discount, which is the safe side — fires sooner than necessary, never
+# later). Override per-rate via DEEPSEEK_INPUT_USD_PER_M / OUTPUT / CACHE
+# if you need to pin pricing manually (e.g. for a price-list change).
 DEEPSEEK_API_KEY=
 DEEPSEEK_RPM=60
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ This guide is intentionally short. If something here is unclear, open an issue o
 
 ## Looking for something to work on?
 
-- **The "What's next" panel** in the bottom-left footer of the running Kompl app shows what we're planning to build but haven't yet. Examples include Google Drive and Notion connectors, image support via LLM vision, custom LLM provider support, and a Tauri tray app. Pick anything that catches your eye, expand on it, or use it as inspiration for your own idea.
+- **The "What's next" panel** in the bottom-left footer of the running Kompl app shows what we're planning to build but haven't yet. Examples include image support via LLM vision, custom LLM provider support, and a Tauri tray app. Pick anything that catches your eye, expand on it, or use it as inspiration for your own idea.
 - **GitHub issues** — anything labelled `good first issue` is a deliberately scoped entry point.
 - **Bugs you hit yourself** — if you found it, you're already 80% of the way to fixing it.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Knowledge compiler — turns scattered links, files, and bookmarks into a living
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![CI](https://github.com/tuirk/Kompl/actions/workflows/integration-test.yml/badge.svg)](https://github.com/tuirk/Kompl/actions)
 [![Docker](https://img.shields.io/badge/Docker-Compose_Ready-2496ED?logo=docker&logoColor=white)](docker-compose.yml)
-[![LLM](https://img.shields.io/badge/LLM-Gemini_2.5-8E75B2?logo=google&logoColor=white)]()
+[![LLM](https://img.shields.io/badge/LLM-Gemini_%2B_DeepSeek-8E75B2)]()
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/tuirk/Kompl/badge)](https://scorecard.dev/viewer/?uri=github.com/tuirk/Kompl)
 
 ## Why Kompl?
@@ -18,7 +18,7 @@ Most tools save your stuff and forget about it. Kompl reads it, extracts the kno
 
 - One new source can update 10+ wiki pages. Cross-references, contradictions, and synthesis are built at ingest time, not re-discovered on every query.
 - Entity pages, concept pages, comparisons, and source summaries are wikilinked together. The wiki gets richer with every source you add.
-- Runs locally via Docker. Outbound calls are limited to your own API keys (Gemini, Firecrawl) and the URLs you choose to ingest.
+- Runs locally via Docker. Outbound calls are limited to your own API keys (Gemini and/or DeepSeek for compilation, Firecrawl for scraping) and the URLs you choose to ingest.
 
 Built with Next.js, Python NLP, n8n orchestration, and SQLite.
 
@@ -37,6 +37,7 @@ You'll also need two API keys, both free to get:
 | | Get key | Free tier | Notes |
 |---|---|---|---|
 | **Gemini** (wiki compilation) | [aistudio.google.com/apikey](https://aistudio.google.com/apikey) | 1500 req/day | Free works for the demo and your first few sources. **Paid Tier 1 is strongly recommended for real use** — Gemini's free per-minute throttle (~10 RPM) will rate-limit a normal ingest, even though daily quota is plenty. Default rate-limiter assumes Tier 1. |
+| **DeepSeek V4 Pro** (alternative compile backend, optional) | [api-docs.deepseek.com](https://api-docs.deepseek.com) | Pay-as-you-go | Selectable in Settings as an alternative to Gemini — useful for sources past Gemini's input cap or when Gemini hits RECITATION. Set `DEEPSEEK_API_KEY` in `.env`. |
 | **Firecrawl** (URL scraping) | [firecrawl.dev](https://firecrawl.dev) | 500 scrapes/month | Free tier covers normal personal use. |
 
 ## Setup
@@ -172,7 +173,8 @@ If you're not using an MCP client, hit the Next.js routes directly: `/api/pages/
 Your wiki content lives in Docker volumes on your machine. Outbound network calls fall into three buckets:
 
 **You drive these — your content goes to a third party:**
-- **Gemini** (`generativelanguage.googleapis.com`) — wiki compilation. Your source text is sent to Google.
+- **Gemini** (`generativelanguage.googleapis.com`) — wiki compilation when the Gemini backend is selected. Your source text is sent to Google.
+- **DeepSeek** (`api.deepseek.com`) — wiki compilation when the DeepSeek backend is selected. Your source text is sent to DeepSeek. Only outbound if `DEEPSEEK_API_KEY` is configured and selected as the compile model.
 - **Firecrawl** (`api.firecrawl.dev`) — URL scraping fallback. The URL you pasted is sent to Firecrawl.
 - **GitHub public API** (`api.github.com`) — when you paste a GitHub repo URL, Kompl fetches the README + metadata.
 - **YouTube** (`youtube.com`) — when you paste a YouTube URL, transcripts are fetched via the public captions endpoint.
@@ -218,7 +220,7 @@ kompl backup --schedule                               # register a weekly backup
 
 **Known limitations:**
 - Single-tenant only — no user accounts or access control. Don't expose to the public internet without your own auth layer.
-- Gemini is the only LLM provider. Anthropic and OpenAI-compatible providers are planned.
+- Two LLM providers selectable per session: Gemini 2.5 (default) and DeepSeek V4 Pro. Anthropic and OpenAI-compatible providers are planned.
 - **Current connectors:** URLs (YouTube transcripts and GitHub READMEs included), file uploads (PDF, DOCX, PPTX, XLSX, TXT, MD, HTML), browser bookmarks, Twitter JSON export, Upnote, Apple Notes.
 - No mobile app. The web UI works on mobile browsers but isn't optimized for small screens.
 

--- a/app/src/__tests__/compile-timeouts.test.ts
+++ b/app/src/__tests__/compile-timeouts.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Outer-timeout formulas for run/route.ts orchestrator wrappers.
+ *
+ * These tests pin the formula SHAPE (floor + ceil(rate × N × OVERHEAD) +
+ * HEADROOM_MS), not specific milliseconds for arbitrary N — so tuning a
+ * per-item rate updates one constant in compile-timeouts.ts + a couple
+ * of expected values here, not a wide test diff.
+ *
+ * The static AbortSignal constants from PR #71 (commit b7b2d48) were
+ * ticking bombs that fire at some N+1; session 97f58805 hit the
+ * outer-undici headersTimeout at 16m 46s on a 38-plan draft. These
+ * formulas guarantee the ceiling rises linearly with N.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  computeResolveMs,
+  computeMatchMs,
+  computeDraftMs,
+  computeCrossrefMs,
+  computeCommitMs,
+} from '../lib/compile-timeouts';
+
+const OVERHEAD = 1.2;
+const HEADROOM_MS = 180_000;
+
+// Pin the floors to mirror compile-timeouts.ts. If these change there, this
+// test drives the regression boundary.
+const RESOLVE_FLOOR_MS  = 300_000;
+const MATCH_FLOOR_MS    = 120_000;
+const DRAFT_FLOOR_MS    = 600_000;
+const CROSSREF_FLOOR_MS = 120_000;
+const COMMIT_FLOOR_MS   = 120_000;
+
+const RESOLVE_PER_SOURCE_MS = 60_000;
+const MATCH_PER_PAIR_MS     = 60_000;
+const DRAFT_PER_BATCH_MS    = 600_000;
+const CROSSREF_PER_PLAN_MS  = 30_000;
+const COMMIT_PER_PLAN_MS    = 60_000;
+
+const expected = (rawMs: number, floorMs: number): number =>
+  Math.max(floorMs, Math.ceil(rawMs * OVERHEAD) + HEADROOM_MS);
+
+describe('computeResolveMs', () => {
+  it('returns the floor at N=0', () => {
+    expect(computeResolveMs(0)).toBe(RESOLVE_FLOOR_MS);
+  });
+
+  it('returns the floor at N=1 (raw 180s × 1.2 + 180s = 396s, but floor is 300s — wait, raw=180+60=180_000+60_000=180s, *1.2=216s, +180s=396s, max(300s, 396s)=396s)', () => {
+    const raw = 120_000 + 1 * RESOLVE_PER_SOURCE_MS;
+    expect(computeResolveMs(1)).toBe(expected(raw, RESOLVE_FLOOR_MS));
+  });
+
+  it('scales linearly at N=10', () => {
+    const raw = 120_000 + 10 * RESOLVE_PER_SOURCE_MS;
+    expect(computeResolveMs(10)).toBe(expected(raw, RESOLVE_FLOOR_MS));
+  });
+
+  it('scales linearly at N=100', () => {
+    const raw = 120_000 + 100 * RESOLVE_PER_SOURCE_MS;
+    expect(computeResolveMs(100)).toBe(expected(raw, RESOLVE_FLOOR_MS));
+  });
+});
+
+describe('computeMatchMs', () => {
+  it('returns the floor at N=0', () => {
+    expect(computeMatchMs(0)).toBe(MATCH_FLOOR_MS);
+  });
+
+  it('uses default candidatesPerSource=3', () => {
+    const raw = 10 * 3 * MATCH_PER_PAIR_MS;
+    expect(computeMatchMs(10)).toBe(expected(raw, MATCH_FLOOR_MS));
+  });
+
+  it('honors explicit candidatesPerSource', () => {
+    const raw = 10 * 5 * MATCH_PER_PAIR_MS;
+    expect(computeMatchMs(10, 5)).toBe(expected(raw, MATCH_FLOOR_MS));
+  });
+
+  it('scales linearly at N=50', () => {
+    const raw = 50 * 3 * MATCH_PER_PAIR_MS;
+    expect(computeMatchMs(50)).toBe(expected(raw, MATCH_FLOOR_MS));
+  });
+});
+
+describe('computeDraftMs', () => {
+  it('returns the floor at N=0', () => {
+    expect(computeDraftMs(0)).toBe(DRAFT_FLOOR_MS);
+  });
+
+  it('returns the floor at N=1 (1 batch × 600s × 1.2 + 180s = 900s, > 600s floor)', () => {
+    const raw = 1 * DRAFT_PER_BATCH_MS;
+    expect(computeDraftMs(1)).toBe(expected(raw, DRAFT_FLOOR_MS));
+  });
+
+  it('uses default concurrency=10', () => {
+    const raw = Math.ceil(38 / 10) * DRAFT_PER_BATCH_MS; // 4 batches × 600s
+    expect(computeDraftMs(38)).toBe(expected(raw, DRAFT_FLOOR_MS));
+  });
+
+  it('exceeds the static 1.5M ms that fired on session 97f58805 (38 plans)', () => {
+    // The whole point of the refactor: 38 plans needed >1.5M ms but PR #71's
+    // static value was exactly 1.5M ms.
+    expect(computeDraftMs(38)).toBeGreaterThan(1_500_000);
+  });
+
+  it('honors explicit concurrency', () => {
+    const raw = Math.ceil(38 / 5) * DRAFT_PER_BATCH_MS; // 8 batches at concurrency=5
+    expect(computeDraftMs(38, 5)).toBe(expected(raw, DRAFT_FLOOR_MS));
+  });
+
+  it('scales linearly at N=100', () => {
+    const raw = Math.ceil(100 / 10) * DRAFT_PER_BATCH_MS; // 10 batches
+    expect(computeDraftMs(100)).toBe(expected(raw, DRAFT_FLOOR_MS));
+  });
+});
+
+describe('computeCrossrefMs', () => {
+  it('returns the floor at N=0', () => {
+    expect(computeCrossrefMs(0)).toBe(CROSSREF_FLOOR_MS);
+  });
+
+  it('returns the floor at small N (raw < floor)', () => {
+    // 1 plan × 30s × 1.2 + 180s = 216s. Floor is 120s, so 216s wins.
+    const raw = 1 * CROSSREF_PER_PLAN_MS;
+    expect(computeCrossrefMs(1)).toBe(expected(raw, CROSSREF_FLOOR_MS));
+  });
+
+  it('scales linearly at N=38', () => {
+    const raw = 38 * CROSSREF_PER_PLAN_MS;
+    expect(computeCrossrefMs(38)).toBe(expected(raw, CROSSREF_FLOOR_MS));
+  });
+});
+
+describe('computeCommitMs', () => {
+  it('returns the floor at N=0', () => {
+    expect(computeCommitMs(0)).toBe(COMMIT_FLOOR_MS);
+  });
+
+  it('scales linearly at N=10', () => {
+    const raw = 10 * COMMIT_PER_PLAN_MS;
+    expect(computeCommitMs(10)).toBe(expected(raw, COMMIT_FLOOR_MS));
+  });
+
+  it('scales linearly at N=38', () => {
+    const raw = 38 * COMMIT_PER_PLAN_MS;
+    expect(computeCommitMs(38)).toBe(expected(raw, COMMIT_FLOOR_MS));
+  });
+});
+
+describe('floor enforcement (degenerate inputs)', () => {
+  it('every compute*Ms returns its floor at N=0 (no NaN, no zero)', () => {
+    expect(computeResolveMs(0)).toBe(RESOLVE_FLOOR_MS);
+    expect(computeMatchMs(0)).toBe(MATCH_FLOOR_MS);
+    expect(computeDraftMs(0)).toBe(DRAFT_FLOOR_MS);
+    expect(computeCrossrefMs(0)).toBe(CROSSREF_FLOOR_MS);
+    expect(computeCommitMs(0)).toBe(COMMIT_FLOOR_MS);
+  });
+
+  it('every compute*Ms returns a positive integer at any non-negative N', () => {
+    for (const n of [0, 1, 5, 10, 38, 100, 1000]) {
+      for (const fn of [computeResolveMs, computeMatchMs, computeDraftMs, computeCrossrefMs, computeCommitMs]) {
+        const result = fn(n);
+        expect(Number.isInteger(result)).toBe(true);
+        expect(result).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/app/src/__tests__/compile-timeouts.test.ts
+++ b/app/src/__tests__/compile-timeouts.test.ts
@@ -42,11 +42,13 @@ const expected = (rawMs: number, floorMs: number): number =>
   Math.max(floorMs, Math.ceil(rawMs * OVERHEAD) + HEADROOM_MS);
 
 describe('computeResolveMs', () => {
-  it('returns the floor at N=0', () => {
-    expect(computeResolveMs(0)).toBe(RESOLVE_FLOOR_MS);
+  it('returns prelude + headroom at N=0 (floor enforced as a minimum)', () => {
+    const raw = 120_000 + 0 * RESOLVE_PER_SOURCE_MS;
+    expect(computeResolveMs(0)).toBe(expected(raw, RESOLVE_FLOOR_MS));
+    expect(computeResolveMs(0)).toBeGreaterThanOrEqual(RESOLVE_FLOOR_MS);
   });
 
-  it('returns the floor at N=1 (raw 180s × 1.2 + 180s = 396s, but floor is 300s — wait, raw=180+60=180_000+60_000=180s, *1.2=216s, +180s=396s, max(300s, 396s)=396s)', () => {
+  it('scales linearly at N=1', () => {
     const raw = 120_000 + 1 * RESOLVE_PER_SOURCE_MS;
     expect(computeResolveMs(1)).toBe(expected(raw, RESOLVE_FLOOR_MS));
   });
@@ -63,8 +65,9 @@ describe('computeResolveMs', () => {
 });
 
 describe('computeMatchMs', () => {
-  it('returns the floor at N=0', () => {
-    expect(computeMatchMs(0)).toBe(MATCH_FLOOR_MS);
+  it('returns headroom at N=0 (floor is below headroom; headroom wins)', () => {
+    expect(computeMatchMs(0)).toBe(expected(0, MATCH_FLOOR_MS));
+    expect(computeMatchMs(0)).toBeGreaterThanOrEqual(MATCH_FLOOR_MS);
   });
 
   it('uses default candidatesPerSource=3', () => {
@@ -84,11 +87,14 @@ describe('computeMatchMs', () => {
 });
 
 describe('computeDraftMs', () => {
-  it('returns the floor at N=0', () => {
-    expect(computeDraftMs(0)).toBe(DRAFT_FLOOR_MS);
+  it('returns 1-batch-worth at N=0 (Math.max(1, ...) keeps a single-batch budget)', () => {
+    // batches floor at 1 even when planCount=0; raw = 1 × 600_000
+    const raw = 1 * DRAFT_PER_BATCH_MS;
+    expect(computeDraftMs(0)).toBe(expected(raw, DRAFT_FLOOR_MS));
+    expect(computeDraftMs(0)).toBeGreaterThanOrEqual(DRAFT_FLOOR_MS);
   });
 
-  it('returns the floor at N=1 (1 batch × 600s × 1.2 + 180s = 900s, > 600s floor)', () => {
+  it('returns the same as N=0 at N=1 (1 batch × 600s × 1.2 + 180s = 900s, > 600s floor)', () => {
     const raw = 1 * DRAFT_PER_BATCH_MS;
     expect(computeDraftMs(1)).toBe(expected(raw, DRAFT_FLOOR_MS));
   });
@@ -116,8 +122,9 @@ describe('computeDraftMs', () => {
 });
 
 describe('computeCrossrefMs', () => {
-  it('returns the floor at N=0', () => {
-    expect(computeCrossrefMs(0)).toBe(CROSSREF_FLOOR_MS);
+  it('returns headroom at N=0 (floor is below headroom; headroom wins)', () => {
+    expect(computeCrossrefMs(0)).toBe(expected(0, CROSSREF_FLOOR_MS));
+    expect(computeCrossrefMs(0)).toBeGreaterThanOrEqual(CROSSREF_FLOOR_MS);
   });
 
   it('returns the floor at small N (raw < floor)', () => {
@@ -133,8 +140,9 @@ describe('computeCrossrefMs', () => {
 });
 
 describe('computeCommitMs', () => {
-  it('returns the floor at N=0', () => {
-    expect(computeCommitMs(0)).toBe(COMMIT_FLOOR_MS);
+  it('returns headroom at N=0 (floor is below headroom; headroom wins)', () => {
+    expect(computeCommitMs(0)).toBe(expected(0, COMMIT_FLOOR_MS));
+    expect(computeCommitMs(0)).toBeGreaterThanOrEqual(COMMIT_FLOOR_MS);
   });
 
   it('scales linearly at N=10', () => {
@@ -149,12 +157,12 @@ describe('computeCommitMs', () => {
 });
 
 describe('floor enforcement (degenerate inputs)', () => {
-  it('every compute*Ms returns its floor at N=0 (no NaN, no zero)', () => {
-    expect(computeResolveMs(0)).toBe(RESOLVE_FLOOR_MS);
-    expect(computeMatchMs(0)).toBe(MATCH_FLOOR_MS);
-    expect(computeDraftMs(0)).toBe(DRAFT_FLOOR_MS);
-    expect(computeCrossrefMs(0)).toBe(CROSSREF_FLOOR_MS);
-    expect(computeCommitMs(0)).toBe(COMMIT_FLOOR_MS);
+  it('every compute*Ms returns at least its floor at N=0 (no NaN, no zero, no sub-floor)', () => {
+    expect(computeResolveMs(0)).toBeGreaterThanOrEqual(RESOLVE_FLOOR_MS);
+    expect(computeMatchMs(0)).toBeGreaterThanOrEqual(MATCH_FLOOR_MS);
+    expect(computeDraftMs(0)).toBeGreaterThanOrEqual(DRAFT_FLOOR_MS);
+    expect(computeCrossrefMs(0)).toBeGreaterThanOrEqual(CROSSREF_FLOOR_MS);
+    expect(computeCommitMs(0)).toBeGreaterThanOrEqual(COMMIT_FLOOR_MS);
   });
 
   it('every compute*Ms returns a positive integer at any non-negative N', () => {

--- a/app/src/__tests__/helpers/schema.sql
+++ b/app/src/__tests__/helpers/schema.sql
@@ -102,6 +102,7 @@ CREATE TABLE page_plans (
   related_plan_ids JSON,
   draft_content TEXT,
   draft_status TEXT DEFAULT 'planned',
+  draft_error TEXT,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -222,4 +223,4 @@ CREATE INDEX idx_relationship_mentions_source ON relationship_mentions(source_id
 CREATE INDEX idx_collect_staging_session ON collect_staging(session_id);
 CREATE INDEX idx_collect_staging_session_status ON collect_staging(session_id, status);
 
-INSERT INTO settings (key, value) VALUES ('schema_version', '23');
+INSERT INTO settings (key, value) VALUES ('schema_version', '24');

--- a/app/src/__tests__/retry-failed-items.test.ts
+++ b/app/src/__tests__/retry-failed-items.test.ts
@@ -17,14 +17,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { randomUUID } from 'node:crypto';
 import {
+  countFailedDraftPlansBySession,
+  countUnextractedSourcesBySession,
   createCompileProgress,
   getCompileProgress,
   getIngestFailures,
   getStagingBySession,
   insertCollectStaging,
+  insertExtraction,
   insertIngestFailure,
+  insertPagePlan,
+  insertSource,
   markStagingFailed,
   markStagingIngested,
+  updatePlanStatus,
   getDb,
 } from '../lib/db';
 import { COMPILE_STEP_KEYS } from '../lib/compile-steps';
@@ -226,6 +232,105 @@ describe('POST /api/compile/retry-failed', () => {
     expect(triggerSessionCompile).not.toHaveBeenCalled();
   });
 
+  it('retries failed page_plans on a completed session with no failed staging rows', async () => {
+    // Seed scenario: completed session, all staging ingested, but
+    // page_plans contains a mix of drafted + failed rows. This is the
+    // "Writing pages — 0 drafts generated, 10 failed" path: draft step
+    // wrote step.status='done' regardless of per-item failures so commit
+    // could run on what succeeded, leaving the session at status=completed
+    // with no session-level retry path. The button must surface here.
+    createCompileProgress(sessionId, 1);
+    getDb()
+      .prepare(
+        `UPDATE compile_progress
+            SET status='completed',
+                started_at='2026-04-20 10:00:00',
+                completed_at='2026-04-20 10:05:00',
+                steps=?
+          WHERE session_id=?`
+      )
+      .run(
+        JSON.stringify(
+          Object.fromEntries(COMPILE_STEP_KEYS.map((k) => [k, { status: 'done' }]))
+        ),
+        sessionId
+      );
+    // 1 ingested staging row (no failed staging — draft retry should still proceed)
+    const okStageId = randomUUID();
+    insertCollectStaging({
+      stage_id: okStageId,
+      session_id: sessionId,
+      connector: 'url',
+      payload: { url: 'https://ok.example.com', display: { hostname: 'ok.example.com' } },
+    });
+    markStagingIngested(okStageId, `src-${okStageId.slice(0, 8)}`);
+    // 1 drafted plan (success, must stay untouched) + 2 failed plans
+    const draftedPlanId = randomUUID();
+    insertPagePlan({
+      plan_id: draftedPlanId,
+      session_id: sessionId,
+      title: 'Drafted Page',
+      page_type: 'concept',
+      action: 'create',
+      source_ids: [`src-${okStageId.slice(0, 8)}`],
+    });
+    updatePlanStatus(draftedPlanId, 'drafted');
+
+    const failedPlanA = randomUUID();
+    insertPagePlan({
+      plan_id: failedPlanA,
+      session_id: sessionId,
+      title: 'Failed Page A',
+      page_type: 'concept',
+      action: 'create',
+      source_ids: [`src-${okStageId.slice(0, 8)}`],
+    });
+    updatePlanStatus(failedPlanA, 'failed');
+
+    const failedPlanB = randomUUID();
+    insertPagePlan({
+      plan_id: failedPlanB,
+      session_id: sessionId,
+      title: 'Failed Page B',
+      page_type: 'concept',
+      action: 'create',
+      source_ids: [`src-${okStageId.slice(0, 8)}`],
+    });
+    updatePlanStatus(failedPlanB, 'failed');
+
+    expect(countFailedDraftPlansBySession(sessionId)).toBe(2);
+
+    const res = await POST(post({ session_id: sessionId }));
+    const body = (await res.json()) as { retried: number; status: string };
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ retried: 2, status: 'retrying' });
+
+    // Failed plans stay 'failed' — orchestrator's draft step re-attempts
+    // them (pendingDraftCount > 0 branch in run/route.ts). retry-failed
+    // doesn't flip plan rows because the draft step itself reads them.
+    const stillFailed = getDb()
+      .prepare(`SELECT plan_id FROM page_plans WHERE session_id=? AND draft_status='failed'`)
+      .all(sessionId) as { plan_id: string }[];
+    expect(stillFailed).toHaveLength(2);
+
+    // Drafted plan untouched
+    const stillDrafted = getDb()
+      .prepare(`SELECT plan_id FROM page_plans WHERE session_id=? AND draft_status='drafted'`)
+      .all(sessionId) as { plan_id: string }[];
+    expect(stillDrafted).toHaveLength(1);
+
+    // compile_progress reset so orchestrator re-enters
+    const cp = getCompileProgress(sessionId)!;
+    expect(cp.status).toBe('queued');
+    expect(cp.completed_at).toBeNull();
+    expect(cp.started_at).toBe('2026-04-20 10:00:00');
+
+    // n8n triggered exactly once
+    expect(triggerSessionCompile).toHaveBeenCalledTimes(1);
+    expect(triggerSessionCompile).toHaveBeenCalledWith(sessionId);
+  });
+
   it('maps n8n trigger failure to 502/504', async () => {
     seedScenario();
     vi.mocked(triggerSessionCompile).mockResolvedValueOnce({
@@ -237,5 +342,223 @@ describe('POST /api/compile/retry-failed', () => {
     expect(res.status).toBe(504);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe('n8n_timeout');
+  });
+
+  it('unextracted source on completed session triggers retry', async () => {
+    // Seed scenario: completed session, all step statuses 'done', 2 source
+    // rows where only 1 has a matching `extractions` row, 1 committed
+    // page_plan referencing the extracted source. The unextracted source
+    // mirrors the per-source extract-failure shape (orchestrator tolerates
+    // partial failures, only fails the session if EVERY source fails).
+    // The committed plan must survive the retry (regression guard — earlier
+    // draft of the plan wanted to clear plans here, which would clobber
+    // the failed-draft retry path).
+    createCompileProgress(sessionId, 1);
+    getDb()
+      .prepare(
+        `UPDATE compile_progress
+            SET status='completed',
+                started_at='2026-04-20 10:00:00',
+                completed_at='2026-04-20 10:05:00',
+                steps=?
+          WHERE session_id=?`
+      )
+      .run(
+        JSON.stringify(
+          Object.fromEntries(COMPILE_STEP_KEYS.map((k) => [k, { status: 'done' }]))
+        ),
+        sessionId
+      );
+
+    const extractedSrcId = `src-extracted-${randomUUID().slice(0, 8)}`;
+    const unextractedSrcId = `src-unextracted-${randomUUID().slice(0, 8)}`;
+
+    insertSource({
+      source_id: extractedSrcId,
+      title: 'Extracted source',
+      source_type: 'url',
+      source_url: 'https://ok.example.com',
+      content_hash: 'hash-ok',
+      file_path: `data/sources/${extractedSrcId}.md`,
+      metadata: null,
+      onboarding_session_id: sessionId,
+    });
+    insertSource({
+      source_id: unextractedSrcId,
+      title: 'Unextracted source',
+      source_type: 'url',
+      source_url: 'https://fail.example.com',
+      content_hash: 'hash-fail',
+      file_path: `data/sources/${unextractedSrcId}.md`,
+      metadata: null,
+      onboarding_session_id: sessionId,
+    });
+    // Only the first source gets an extractions row.
+    insertExtraction({
+      source_id: extractedSrcId,
+      ner_output: { entities: [] },
+      profile: 'plain',
+      keyphrase_output: null,
+      tfidf_output: null,
+      llm_output: { summary: '' },
+    });
+
+    // 1 committed page_plan referencing the extracted source.
+    const committedPlanId = randomUUID();
+    insertPagePlan({
+      plan_id: committedPlanId,
+      session_id: sessionId,
+      title: 'Committed Page',
+      page_type: 'concept',
+      action: 'create',
+      source_ids: [extractedSrcId],
+    });
+    updatePlanStatus(committedPlanId, 'committed');
+
+    expect(countUnextractedSourcesBySession(sessionId)).toBe(1);
+
+    const res = await POST(post({ session_id: sessionId }));
+    const body = (await res.json()) as { retried: number; status: string };
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ retried: 1, status: 'retrying' });
+
+    // Committed plan survives — endpoint MUST NOT touch page_plans (the
+    // orchestrator's hasNewSources check decides re-plan, not this route).
+    const survivingPlans = getDb()
+      .prepare(`SELECT plan_id, draft_status FROM page_plans WHERE session_id=?`)
+      .all(sessionId) as { plan_id: string; draft_status: string }[];
+    expect(survivingPlans).toHaveLength(1);
+    expect(survivingPlans[0].plan_id).toBe(committedPlanId);
+    expect(survivingPlans[0].draft_status).toBe('committed');
+
+    // compile_progress reset so orchestrator re-enters
+    const cp = getCompileProgress(sessionId)!;
+    expect(cp.status).toBe('queued');
+    expect(cp.completed_at).toBeNull();
+    expect(cp.started_at).toBe('2026-04-20 10:00:00');
+
+    // n8n triggered exactly once
+    expect(triggerSessionCompile).toHaveBeenCalledTimes(1);
+    expect(triggerSessionCompile).toHaveBeenCalledWith(sessionId);
+  });
+
+  it('unextracted + failed-draft mix retries both without clobbering failed plans', async () => {
+    // Same shape as above plus 2 page_plans with draft_status='failed'.
+    // Total retried = 1 unextracted + 2 failed-drafts = 3. All three plan
+    // rows (committed + 2 failed) must survive — clearing plans here would
+    // break the failed-draft retry path (the orchestrator's draft step
+    // re-attempts those failed plans on the next run).
+    createCompileProgress(sessionId, 1);
+    getDb()
+      .prepare(
+        `UPDATE compile_progress
+            SET status='completed',
+                started_at='2026-04-20 10:00:00',
+                completed_at='2026-04-20 10:05:00',
+                steps=?
+          WHERE session_id=?`
+      )
+      .run(
+        JSON.stringify(
+          Object.fromEntries(COMPILE_STEP_KEYS.map((k) => [k, { status: 'done' }]))
+        ),
+        sessionId
+      );
+
+    const extractedSrcId = `src-extracted-${randomUUID().slice(0, 8)}`;
+    const unextractedSrcId = `src-unextracted-${randomUUID().slice(0, 8)}`;
+
+    insertSource({
+      source_id: extractedSrcId,
+      title: 'Extracted source',
+      source_type: 'url',
+      source_url: 'https://ok.example.com',
+      content_hash: 'hash-ok',
+      file_path: `data/sources/${extractedSrcId}.md`,
+      metadata: null,
+      onboarding_session_id: sessionId,
+    });
+    insertSource({
+      source_id: unextractedSrcId,
+      title: 'Unextracted source',
+      source_type: 'url',
+      source_url: 'https://fail.example.com',
+      content_hash: 'hash-fail',
+      file_path: `data/sources/${unextractedSrcId}.md`,
+      metadata: null,
+      onboarding_session_id: sessionId,
+    });
+    insertExtraction({
+      source_id: extractedSrcId,
+      ner_output: { entities: [] },
+      profile: 'plain',
+      keyphrase_output: null,
+      tfidf_output: null,
+      llm_output: { summary: '' },
+    });
+
+    const committedPlanId = randomUUID();
+    insertPagePlan({
+      plan_id: committedPlanId,
+      session_id: sessionId,
+      title: 'Committed Page',
+      page_type: 'concept',
+      action: 'create',
+      source_ids: [extractedSrcId],
+    });
+    updatePlanStatus(committedPlanId, 'committed');
+
+    const failedPlanA = randomUUID();
+    insertPagePlan({
+      plan_id: failedPlanA,
+      session_id: sessionId,
+      title: 'Failed Page A',
+      page_type: 'concept',
+      action: 'create',
+      source_ids: [extractedSrcId],
+    });
+    updatePlanStatus(failedPlanA, 'failed');
+
+    const failedPlanB = randomUUID();
+    insertPagePlan({
+      plan_id: failedPlanB,
+      session_id: sessionId,
+      title: 'Failed Page B',
+      page_type: 'concept',
+      action: 'create',
+      source_ids: [extractedSrcId],
+    });
+    updatePlanStatus(failedPlanB, 'failed');
+
+    expect(countUnextractedSourcesBySession(sessionId)).toBe(1);
+    expect(countFailedDraftPlansBySession(sessionId)).toBe(2);
+
+    const res = await POST(post({ session_id: sessionId }));
+    const body = (await res.json()) as { retried: number; status: string };
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ retried: 3, status: 'retrying' });
+
+    // All three plans survive — committed + 2 failed.
+    const survivingPlans = getDb()
+      .prepare(`SELECT plan_id, draft_status FROM page_plans WHERE session_id=? ORDER BY plan_id`)
+      .all(sessionId) as { plan_id: string; draft_status: string }[];
+    expect(survivingPlans).toHaveLength(3);
+    const byStatus = survivingPlans.reduce<Record<string, number>>((acc, p) => {
+      acc[p.draft_status] = (acc[p.draft_status] ?? 0) + 1;
+      return acc;
+    }, {});
+    expect(byStatus.committed).toBe(1);
+    expect(byStatus.failed).toBe(2);
+
+    // compile_progress reset
+    const cp = getCompileProgress(sessionId)!;
+    expect(cp.status).toBe('queued');
+    expect(cp.completed_at).toBeNull();
+    expect(cp.started_at).toBe('2026-04-20 10:00:00');
+
+    expect(triggerSessionCompile).toHaveBeenCalledTimes(1);
+    expect(triggerSessionCompile).toHaveBeenCalledWith(sessionId);
   });
 });

--- a/app/src/app/api/compile/commit/route.ts
+++ b/app/src/app/api/compile/commit/route.ts
@@ -40,6 +40,7 @@ import {
   getPagePlansByStatus,
   getPageTitleMap,
   updatePlanStatus,
+  updatePlanFailed,
   getCurrentPageHash,
   incrementPageSourceCount,
   setPendingContent,
@@ -147,7 +148,7 @@ async function commitSession(session_id: string): Promise<Response> {
       } catch (txErr) {
         const txMsg = txErr instanceof Error ? txErr.message : String(txErr);
         console.error(JSON.stringify({ ts: new Date().toISOString(), event: 'db_transaction_error', context: 'provenance_only_commit', plan_id: plan.plan_id, session_id, error: txMsg }));
-        updatePlanStatus(plan.plan_id, 'failed');
+        updatePlanFailed(plan.plan_id, `db_transaction_error (provenance_only_commit): ${txMsg}`);
         failed++;
       }
       continue;
@@ -155,7 +156,7 @@ async function commitSession(session_id: string): Promise<Response> {
 
     const markdown = plan.draft_content;
     if (!markdown) {
-      updatePlanStatus(plan.plan_id, 'failed');
+      updatePlanFailed(plan.plan_id, 'missing draft_content (commit ran on a plan with no drafted markdown)');
       failed++;
       continue;
     }
@@ -300,7 +301,7 @@ async function commitSession(session_id: string): Promise<Response> {
     } catch (txErr) {
       const txMsg = txErr instanceof Error ? txErr.message : String(txErr);
       console.error(JSON.stringify({ ts: new Date().toISOString(), event: 'db_transaction_error', context: 'session_commit', plan_id: plan.plan_id, page_id, session_id, error: txMsg }));
-      updatePlanStatus(plan.plan_id, 'failed');
+      updatePlanFailed(plan.plan_id, `db_transaction_error (session_commit): ${txMsg}`);
       failed++;
       continue;
     }

--- a/app/src/app/api/compile/draft/route.ts
+++ b/app/src/app/api/compile/draft/route.ts
@@ -34,6 +34,7 @@ import {
   readRawMarkdown,
   updatePlanDraft,
   updatePlanFailed,
+  updateCompileStep,
   getDb,
 } from '../../../../lib/db';
 import { yamlDoubleQuote } from '../../../../lib/yaml-escape';
@@ -748,6 +749,18 @@ export async function POST(request: Request) {
           if (newCat && newCat !== 'Uncategorized' && newCat !== 'General') sessionCategorySet.add(newCat);
         }
       }
+      // Live progress detail for the UI's "Writing pages" tracker. Without
+      // this, the draft step shows just "PROCESSING" with no count while
+      // earlier steps show "8/8 sources extracted" etc. Mirrors the per-
+      // completion update pattern used by the extract worker pool.
+      updateCompileStep(
+        session_id,
+        'draft',
+        'running',
+        failed > 0
+          ? `${drafted}/${plans.length} pages drafted, ${failed} failed`
+          : `${drafted}/${plans.length} pages drafted`,
+      );
     }
   }
 

--- a/app/src/app/api/compile/draft/route.ts
+++ b/app/src/app/api/compile/draft/route.ts
@@ -33,10 +33,11 @@ import {
   readPageMarkdown,
   readRawMarkdown,
   updatePlanDraft,
-  updatePlanStatus,
+  updatePlanFailed,
   getDb,
 } from '../../../../lib/db';
 import { yamlDoubleQuote } from '../../../../lib/yaml-escape';
+import { LONG_HTTP_AGENT } from '../../../../lib/long-http-agent';
 
 const NLP_SERVICE_URL = process.env.NLP_SERVICE_URL ?? 'http://nlp-service:8000';
 // 10 concurrent draft calls. Tier-1 RPM is 1000/min and we use <1% of it,
@@ -102,6 +103,12 @@ async function callDraftPage(
       ...(compileModel ? { compile_model: compileModel } : {}),
     }),
     signal: AbortSignal.timeout(600_000), // 10 min — DeepSeek draft can match extract latency on dense sources. Gemini thinking adds margin on top. Same 600s budget as extract/resolve/schema for symmetry.
+    // LONG_HTTP_AGENT: undici default headersTimeout=300s would fire before
+    // our 600s AbortSignal on dense source-summary drafts. Session 29be62eb
+    // hit silent HeadersTimeoutError on 15/18 source-summaries (NLP server
+    // returned 200 OK after the client had already given up).
+    // @ts-expect-error — dispatcher is an undici-specific fetch option not in the DOM RequestInit type
+    dispatcher: LONG_HTTP_AGENT,
   });
 
   if (!res.ok) {
@@ -725,7 +732,12 @@ export async function POST(request: Request) {
       const r = results[i];
       if (r instanceof Error) {
         failed++;
-        updatePlanStatus(layerPlans[i].plan_id, 'failed');
+        // Capture the actual error message in the page_plans row + log to
+        // app stdout. Before this, every per-task failure was swallowed —
+        // operators had no clue why a draft died. Session 29be62eb (15
+        // source-summary HeadersTimeoutErrors) wasted 30+ min of debugging.
+        console.error('[draft] plan_id=%s title=%s err=%s', layerPlans[i].plan_id, layerPlans[i].title, r.message);
+        updatePlanFailed(layerPlans[i].plan_id, r.message);
       } else {
         drafted++;
         byType[r.pageType] = (byType[r.pageType] ?? 0) + 1;

--- a/app/src/app/api/compile/extract/route.ts
+++ b/app/src/app/api/compile/extract/route.ts
@@ -43,8 +43,36 @@ import {
   insertRelationshipMentions,
   markSourceExtracted,
   readRawMarkdown,
+  updateSourceTitle,
 } from '../../../../lib/db';
 import { LONG_HTTP_AGENT } from '../../../../lib/long-http-agent';
+
+// "Garbage" source titles — what we get when MarkItDown can't pull a title
+// from PDF metadata and the cascade falls through to the filename stub.
+// When the current title matches, prefer the LLM-derived title instead
+// (the extract LLM is now prompted to return the document's real title).
+//   - arxiv IDs:        2307.08768v4, 1201.6655, 2602.00133v1
+//   - digit prefixes:   12800_Vaughan-Williams, 294907447-MIT, 0611
+//   - pure digits:      0611
+const _GARBAGE_TITLE_PATTERNS: RegExp[] = [
+  /^\d{4}\.\d{4,5}(v\d+)?$/,
+  /^\d{3,}([_-].+)?$/,
+  /^\d+$/,
+];
+
+function isGarbageTitle(s: string): boolean {
+  const trimmed = (s ?? '').trim();
+  if (!trimmed) return true;
+  if (_GARBAGE_TITLE_PATTERNS.some((p) => p.test(trimmed))) return true;
+  // Spaceless filename stubs ≥ 8 chars dominated by digits/punct
+  // (e.g. "DOC-12345-FINAL", "report_v2_final"). Keep regular CamelCase
+  // identifiers alone since those have lots of letters.
+  if (!trimmed.includes(' ') && trimmed.length >= 8) {
+    const punctOrDigit = trimmed.replace(/[A-Za-z]/g, '').length;
+    if (punctOrDigit / trimmed.length >= 0.5) return true;
+  }
+  return false;
+}
 
 const NLP_SERVICE_URL = process.env.NLP_SERVICE_URL ?? 'http://nlp-service:8000';
 
@@ -275,6 +303,18 @@ export async function POST(request: Request) {
       llm_output: llmOutput,
     });
     markSourceExtracted(source_id);
+
+    // Step 7a: title rescue. MarkItDown's PDF path doesn't extract a title
+    // (it's `absent for PDFs (MarkItDown 0.1.5 never sets it)`), so the
+    // ingest cascade falls through to the filename stub — leaving wiki
+    // pages titled `0611`, `2307.08768v4`, `12800_Vaughan-Williams`, etc.
+    // The extract LLM is now prompted to derive the document's real title;
+    // if it did, replace the filename stub with it. Source-summary pages
+    // (Rule 1 in plan/route.ts) then use the rescued title automatically.
+    const llmTitle = (llmOutput?.title ?? '').toString().trim();
+    if (llmTitle && isGarbageTitle(source.title) && !isGarbageTitle(llmTitle)) {
+      updateSourceTitle(source_id, llmTitle);
+    }
 
     // Step 7b: record entity/concept mentions for wiki-wide threshold counting.
     // Alias-pin against the HISTORICAL aliases table so variants discovered in

--- a/app/src/app/api/compile/extract/route.ts
+++ b/app/src/app/api/compile/extract/route.ts
@@ -44,6 +44,7 @@ import {
   markSourceExtracted,
   readRawMarkdown,
 } from '../../../../lib/db';
+import { LONG_HTTP_AGENT } from '../../../../lib/long-http-agent';
 
 const NLP_SERVICE_URL = process.env.NLP_SERVICE_URL ?? 'http://nlp-service:8000';
 
@@ -61,7 +62,9 @@ async function callNer(sourceId: string, text: string): Promise<NerResponse> {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ source_id: sourceId, text }),
-    signal: AbortSignal.timeout(60_000),
+    signal: AbortSignal.timeout(360_000), // 6 min — spaCy NER on dense academic PDFs (50K+ chars) busts the prior 60s wall regardless of concurrency; the 1-source ed7f8def session also timed out at 60s.
+    // @ts-expect-error — dispatcher is an undici-specific fetch option not in the DOM RequestInit type
+    dispatcher: LONG_HTTP_AGENT, // 360s AbortSignal > undici 300s default headersTimeout
   });
   if (!res.ok) throw new Error(`ner_failed: ${res.status} ${await res.text().catch(() => '')}`);
   return res.json() as Promise<NerResponse>;
@@ -105,7 +108,9 @@ async function callMethod(method: string, text: string): Promise<KeyphraseRespon
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ text, top_n: 20 }),
-    signal: AbortSignal.timeout(60_000),
+    signal: AbortSignal.timeout(360_000), // 6 min — keyphrase extractors (yake/rake/keybert/textrank) on dense academic text bust 60s; matched to callNer ceiling.
+    // @ts-expect-error — dispatcher is an undici-specific fetch option not in the DOM RequestInit type
+    dispatcher: LONG_HTTP_AGENT, // 360s AbortSignal > undici 300s default headersTimeout
   });
   if (!res.ok) throw new Error(`${method}_failed: ${res.status}`);
   return res.json() as Promise<KeyphraseResponse>;
@@ -124,7 +129,9 @@ async function callTfidfOverlap(
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ source_text: sourceText, corpus_page_ids: corpusPageIds }),
-    signal: AbortSignal.timeout(60_000),
+    signal: AbortSignal.timeout(360_000), // 6 min — TF-IDF overlap against full wiki corpus on dense source text busts 60s; matched to callNer ceiling.
+    // @ts-expect-error — dispatcher is an undici-specific fetch option not in the DOM RequestInit type
+    dispatcher: LONG_HTTP_AGENT, // 360s AbortSignal > undici 300s default headersTimeout
   });
   if (!res.ok) throw new Error(`tfidf_overlap_failed: ${res.status}`);
   return res.json() as Promise<TfidfResponse>;
@@ -137,6 +144,8 @@ async function callExtractLLM(payload: Record<string, unknown>): Promise<any> {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
     signal: AbortSignal.timeout(600_000), // 10 min — DeepSeek extract on a 95K-char source clocks ~290s; Vilnius travel guide hit ~387s in Phase 7. Gemini thinking adds another minute on top of that on its bad days. 600s gives ~55% headroom over the worst observed for either provider.
+    // @ts-expect-error — dispatcher is an undici-specific fetch option not in the DOM RequestInit type
+    dispatcher: LONG_HTTP_AGENT, // 600s AbortSignal > undici 300s default headersTimeout
   });
   if (!res.ok) {
     const detail = await res.text().catch(() => '');

--- a/app/src/app/api/compile/match/route.ts
+++ b/app/src/app/api/compile/match/route.ts
@@ -147,9 +147,17 @@ export async function POST(request: Request) {
       continue;
     }
 
-    // Take top 3 with score > 0.3
+    // 0.15 calibrated against the actual cosine-similarity distribution for
+    // long-form sources (~50K chars) vs short wiki pages (~2K chars). On
+    // 2026-05-08 a paper titled "EXPLAINING THE FAVORITE-LONGSHOT BIAS"
+    // (58K chars) compared against a 20-page prediction-markets corpus
+    // produced top similarities at 0.208 / 0.185 / 0.137 / 0.118; the
+    // correct match (Favourite-longshot bias page) and a coauthor entity
+    // (Justin Wolfers) were both below the prior 0.3 cap. The triage LLM
+    // is the precision filter (and the existing slice(0, 3) per source
+    // caps cost at sourceCount × 3 triage calls per session).
     const topCandidates = tfidfResult.top_matches
-      .filter((m) => m.similarity > 0.3)
+      .filter((m) => m.similarity > 0.15)
       .slice(0, 3);
 
     totalCandidates += topCandidates.length;

--- a/app/src/app/api/compile/plan/route.ts
+++ b/app/src/app/api/compile/plan/route.ts
@@ -261,6 +261,13 @@ export async function POST(request: Request) {
     const canonicalKey = concept.canonical.toLowerCase();
     // Within-session dedup: same canonical name seen again → skip.
     if (conceptPlansByCanonical.has(canonicalKey)) continue;
+    // Cross-bucket dedup: if Rule 2 already emitted an entity plan for this
+    // canonical name (because some sources tagged it as PRODUCT/ORG/etc.),
+    // don't ALSO emit a concept plan for it. Without this, "S&P 500" landed
+    // in page_plans twice on session 29be62eb (once entity, once concept,
+    // identical source_ids) — see resolve/route.ts partition logic. Entity
+    // is the more specific bucket, so it wins.
+    if (entityPlansByCanonical.has(canonicalKey)) continue;
 
     const existing = getPageByTitle(concept.canonical);
     const plan_id = randomUUID();

--- a/app/src/app/api/compile/progress/items/route.ts
+++ b/app/src/app/api/compile/progress/items/route.ts
@@ -150,6 +150,10 @@ export async function GET(request: Request): Promise<NextResponse> {
         id: p.plan_id,
         label: p.title,
         status: mapDraftStatus(p.draft_status, step),
+        // page_plans.draft_error is populated by updatePlanFailed (schema v24).
+        // Surface it on the draft step so the UI's expand-to-reveal panel
+        // shows WHY a plan failed (was silent before; users had to grep app logs).
+        ...(step === 'draft' && p.draft_error ? { error: p.draft_error } : {}),
       }));
       break;
     }

--- a/app/src/app/api/compile/progress/route.ts
+++ b/app/src/app/api/compile/progress/route.ts
@@ -9,16 +9,26 @@
  *
  * Response shape:
  *   { session_id, status, current_step, steps, error, started_at,
- *     completed_at, failed_stage_count }
- *   where steps is an object: { extract: { status, detail? }, resolve: {...}, ... }
- *   and failed_stage_count is the count of collect_staging rows with
- *   status='failed' + included=1 for this session — powers the
- *   "Retry N failed items" button (Phase 4).
+ *     completed_at, failed_stage_count, failed_draft_count, failed_extract_count }
+ *   where steps is an object: { extract: { status, detail? }, resolve: {...}, ... }.
+ *   failed_stage_count counts collect_staging rows with status='failed' +
+ *   included=1 (intake-stage failures). failed_draft_count counts page_plans
+ *   rows with draft_status='failed' (per-page LLM failures after planning).
+ *   failed_extract_count counts `sources` rows with no matching `extractions`
+ *   row (per-source extract-failure shape — orchestrator tolerates partial
+ *   extract failures, leaving the session 'completed' with stranded sources).
+ *   Any of the three being > 0 surfaces the "Retry N failed" button on the
+ *   progress page; the combined sum is what's shown in the label.
  *
  * Returns 404 { status: 'not_found' } if session_id not found.
  */
 import { NextResponse } from 'next/server';
-import { countFailedStagingBySession, getCompileProgress } from '@/lib/db';
+import {
+  countFailedDraftPlansBySession,
+  countFailedStagingBySession,
+  countUnextractedSourcesBySession,
+  getCompileProgress,
+} from '@/lib/db';
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -39,5 +49,7 @@ export async function GET(request: Request) {
     started_at: row.started_at,
     completed_at: row.completed_at,
     failed_stage_count: countFailedStagingBySession(sessionId),
+    failed_draft_count: countFailedDraftPlansBySession(sessionId),
+    failed_extract_count: countUnextractedSourcesBySession(sessionId),
   });
 }

--- a/app/src/app/api/compile/resolve/route.ts
+++ b/app/src/app/api/compile/resolve/route.ts
@@ -41,6 +41,7 @@ import {
   logActivity,
   normalizeSessionMentionsToCanonical,
 } from '../../../../lib/db';
+import { LONG_HTTP_AGENT } from '../../../../lib/long-http-agent';
 
 const NLP_SERVICE_URL = process.env.NLP_SERVICE_URL ?? 'http://nlp-service:8000';
 
@@ -150,6 +151,8 @@ async function callDisambiguate(
       ...(compileModel ? { compile_model: compileModel } : {}),
     }),
     signal: AbortSignal.timeout(600_000), // 10 min — disambiguate batches up to 10 pairs; DeepSeek can run ~200-400s per call on dense pairs. 120s (prior value) was Gemini-only sizing.
+    // @ts-expect-error — dispatcher is an undici-specific fetch option not in the DOM RequestInit type
+    dispatcher: LONG_HTTP_AGENT, // 600s AbortSignal > undici 300s default headersTimeout
   });
   if (!res.ok) {
     const detail = await res.text().catch(() => '');

--- a/app/src/app/api/compile/retry-failed/route.ts
+++ b/app/src/app/api/compile/retry-failed/route.ts
@@ -4,13 +4,32 @@
  * Phase 4 — per-item retry. Different shape from `/api/compile/retry`:
  *   - /retry resumes a session-level failure from the first non-done step.
  *     It's a no-op when compile_progress.status='completed'.
- *   - /retry-failed targets a session that LOOKS completed but has
- *     collect_staging.status='failed' rows (individual items that were
- *     skipped inside ingest_urls/files/texts). Flips those rows back to
- *     'pending', resets compile_progress so the orchestrator runs again,
- *     and re-fires n8n. The prelude gate in runCompilePipeline naturally
- *     picks up only the flipped rows; already-ingested items stay
- *     status='ingested' and are ignored.
+ *   - /retry-failed targets a session that LOOKS completed but has any of
+ *     (a) collect_staging.status='failed' rows — items skipped inside
+ *     ingest_urls/files/texts; (b) page_plans.draft_status='failed' rows —
+ *     wiki pages whose LLM draft attempt errored after planning; or
+ *     (c) `sources` rows with no matching `extractions` row — sources whose
+ *     extract step failed (orchestrator tolerates partial extract failures,
+ *     marks the step done if at least one source extracted, leaving the
+ *     session 'completed' with stranded sources).
+ *
+ *     The draft step writes step.status='done' regardless of per-item
+ *     failures (so commit can run on what succeeded), and the extract step
+ *     does the same for partial failures, so neither failure shape trips
+ *     the session-level retry path — this endpoint is the way back in.
+ *     Flips staging rows to 'pending', resets compile_progress so the
+ *     orchestrator runs again, and re-fires n8n. The prelude gate picks
+ *     up flipped staging rows; the plan/draft branch in runCompilePipeline
+ *     picks up failed page_plans (pendingDraftCount > 0 → re-draft only
+ *     those); and the orchestrator's hasNewSources check (run/route.ts)
+ *     re-plans when extracted sources extend beyond the existing plan set —
+ *     which is what unstrand the partial-extract sources after they get
+ *     re-extracted on the next pipeline pass.
+ *
+ *     This endpoint deliberately does NOT touch page_plans. Clearing them
+ *     here would break (b) — failed plans need to survive so the
+ *     orchestrator's draft step can re-attempt them. Plan re-runs are
+ *     decided in runCompilePipeline via hasNewSources, not here.
  *
  * Ghost-row fix: for URL-connector retryable rows, matching
  *   ingest_failures rows (session_id + source_url) are deleted in the
@@ -20,7 +39,7 @@
  *
  * Body: { session_id: string }
  * Response:
- *   200 { retried: N, status: 'retrying' }    — n8n triggered
+ *   200 { retried: N, status: 'retrying' }    — n8n triggered (N = staging + draft + extract)
  *   200 { retried: 0, status: 'noop' }         — nothing to retry
  *   400 { error: 'invalid_json' | 'session_id required' }
  *   404 { error: 'no_progress_record' }
@@ -32,6 +51,8 @@ import {
   COMPILE_STEP_KEYS,
 } from '@/lib/compile-steps';
 import {
+  countFailedDraftPlansBySession,
+  countUnextractedSourcesBySession,
   deleteIngestFailuresBySourceUrls,
   getCompileProgress,
   getDb,
@@ -92,7 +113,10 @@ export async function POST(request: Request) {
     )
     .all(session_id) as StagingMini[];
 
-  if (failedRows.length === 0) {
+  const failedDraftCount = countFailedDraftPlansBySession(session_id);
+  const unextractedCount = countUnextractedSourcesBySession(session_id);
+
+  if (failedRows.length === 0 && failedDraftCount === 0 && unextractedCount === 0) {
     return NextResponse.json({ retried: 0, status: 'noop' });
   }
 
@@ -155,5 +179,8 @@ export async function POST(request: Request) {
     );
   }
 
-  return NextResponse.json({ retried: failedRows.length, status: 'retrying' });
+  return NextResponse.json({
+    retried: failedRows.length + failedDraftCount + unextractedCount,
+    status: 'retrying',
+  });
 }

--- a/app/src/app/api/compile/run/route.ts
+++ b/app/src/app/api/compile/run/route.ts
@@ -35,6 +35,7 @@ import {
   getExtractionsBySession,
   getStagingBySession,
   countPagePlansByStatus,
+  getDb,
   logActivity,
   markStaleSessionsFailed,
 } from '@/lib/db';
@@ -431,14 +432,42 @@ async function runCompilePipeline(sessionId: string): Promise<void> {
   //
   // plan calls clearStagedPagePlans() which deletes all non-committed rows
   // (including 'drafted'/'crossreffed'). So plan must NOT re-run once plans
-  // exist. Once plans exist, draft is responsible for picking up any rows
-  // still in 'planned' or 'failed' (see /api/compile/draft filter).
+  // exist — EXCEPT when extracted sources extend beyond the existing plan set
+  // (hasNewSources below). The /retry-failed path can land new extractions on
+  // a session whose prior plan run only saw a smaller extraction set; in that
+  // case we MUST re-run plan so the newly-extracted sources get pages, even
+  // though committed plans already exist. clearStagedPagePlans only deletes
+  // non-committed plans, so the prior committed pages are preserved.
+  // Once plans exist (and no new sources), draft is responsible for picking
+  // up any rows still in 'planned' or 'failed' (see /api/compile/draft filter).
   const planCounts = countPagePlansByStatus(sessionId);
   const planExists =
     Object.values(planCounts).reduce((sum, c) => sum + c, 0) > 0;
   const pendingDraftCount = (planCounts.planned ?? 0) + (planCounts.failed ?? 0);
 
-  if (!planExists) {
+  // hasNewSources: extractions exist that no plan references. Triggers
+  // re-plan even when committed plans are present — the partial-extract
+  // retry path lands new extractions on a session whose prior plan run
+  // happened against a smaller extraction set, and we need plan to
+  // rebuild over the full set so the new sources produce pages.
+  // Cheap query: page_plans.source_ids is JSON, parsed once per row.
+  const allExtractedIds = new Set(
+    getExtractionsBySession(sessionId).map((e) => e.source_id),
+  );
+  const planSourceIds = new Set<string>();
+  for (const r of getDb()
+    .prepare('SELECT source_ids FROM page_plans WHERE session_id = ?')
+    .all(sessionId) as Array<{ source_ids: string }>) {
+    try {
+      (JSON.parse(r.source_ids) as string[]).forEach((id) => planSourceIds.add(id));
+    } catch {
+      // malformed source_ids — the malformed plan will fail downstream;
+      // skip it for this coverage check
+    }
+  }
+  const hasNewSources = [...allExtractedIds].some((id) => !planSourceIds.has(id));
+
+  if (!planExists || hasNewSources) {
     // Fresh run: plan then draft.
     updateCompileStep(sessionId, 'plan', 'running');
     const planResult = await timed(sessionId, 'plan', () =>

--- a/app/src/app/api/compile/run/route.ts
+++ b/app/src/app/api/compile/run/route.ts
@@ -93,10 +93,13 @@ async function callResolve(sessionId: string): Promise<{ canonical_entities: unk
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ session_id: sessionId }),
-    // 660s = inner disambiguate LLM (600s) + 60s margin. Prior 180s aborted before the inner LLM finished on DeepSeek.
-    signal: AbortSignal.timeout(660_000),
+    // 900s = callFuzzy 60s + callEmbedding 60s + callDisambiguate 600s + 180s
+    // headroom. Prior 660s was 60s short of the worst-case sequential sum once
+    // every sub-call hit its individual ceiling. In practice fuzzy+embedding
+    // finish in seconds, but the AbortSignal needs to fit the math.
+    signal: AbortSignal.timeout(900_000),
     // @ts-expect-error — dispatcher is an undici-specific fetch option not in the DOM RequestInit type
-    dispatcher: LONG_HTTP_AGENT, // 660s AbortSignal > undici 300s default headersTimeout
+    dispatcher: LONG_HTTP_AGENT, // 900s AbortSignal > undici 300s default headersTimeout
   });
   await throwOnError('resolve', res, sessionId);
   const parsed = await res.json() as { canonical_entities?: unknown[]; canonical_concepts?: unknown[] };
@@ -114,7 +117,13 @@ async function callMatch(
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ session_id: sessionId, canonical_entities: canonicalEntities }),
-    signal: AbortSignal.timeout(300_000), // triage calls can stack up
+    // 1200s = sequential `for source` at match/route.ts:137 × (callTfidfOverlap
+    // 30s + callTriage 30s) per candidate page. The 300s budget never matched
+    // the actual N×M call cost (N sources × M candidate pages); for N=19
+    // sources × 3 candidates × 30s worst-case AbortSignal = 2280s. 1200s
+    // defensively covers the realistic case (triage usually <5s) and matches
+    // commit/draft scale.
+    signal: AbortSignal.timeout(1_200_000),
   });
   await throwOnError('match', res, sessionId);
   return res.json() as Promise<{ skipped: boolean; matches: unknown[]; stats: Record<string, number> }>;
@@ -146,7 +155,12 @@ async function callDraft(sessionId: string): Promise<{ drafted: number; failed: 
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ session_id: sessionId }),
-    signal: AbortSignal.timeout(900_000),
+    // 1500s = pLimit(N plans, DRAFT_CONCURRENCY=10) × inner callDraftPage 600s.
+    // For N=19 plans (~2 batches × ~600s = ~1200s) plus headroom. Prior 900s
+    // fired at 14m 59.9s on session d28d7644 even though all 19 drafts had
+    // succeeded server-side; outer killed the fetch before the inner JSON
+    // response landed. Matches callExtract's outer for symmetry.
+    signal: AbortSignal.timeout(1_500_000),
     // @ts-expect-error — dispatcher is an undici-specific fetch option not in the DOM RequestInit type
     dispatcher: LONG_HTTP_AGENT,
   });
@@ -172,7 +186,12 @@ async function callCommit(sessionId: string): Promise<{ committed: number; thin_
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ session_id: sessionId }),
-    signal: AbortSignal.timeout(120_000),
+    // 1200s = sequential `for plan` at commit/route.ts:124 × (DB tx + write-page
+    // 30s + vector-upsert 30s) per plan. Prior 120s fit only the trivial case
+    // (~3 plans); for N=19 plans worst case sums to ~20 min. 1200s defensively
+    // covers cases where any plan's file or vector call slows down — realistic
+    // case finishes in <2s/plan.
+    signal: AbortSignal.timeout(1_200_000),
   });
   await throwOnError('commit', res, sessionId);
   return res.json() as Promise<{ committed: number; thin_drafts_skipped: number; sources_activated: number }>;
@@ -183,10 +202,13 @@ async function callSchema(sessionId: string): Promise<unknown> {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ session_id: sessionId }),
-    // 660s = inner generate-schema LLM (600s) + 60s margin. Prior 120s aborted before inner LLM finished on DeepSeek.
-    signal: AbortSignal.timeout(660_000),
+    // 720s = file-exists 10s + generate-schema LLM 600s + write-file 10s +
+    // 100s headroom. Prior 660s gave only 40s margin once both file-IO sub-
+    // calls bracketing the LLM were accounted for; on a slow disk + max LLM
+    // run that would have fired before the response landed.
+    signal: AbortSignal.timeout(720_000),
     // @ts-expect-error — dispatcher is an undici-specific fetch option not in the DOM RequestInit type
-    dispatcher: LONG_HTTP_AGENT, // 660s AbortSignal > undici 300s default headersTimeout
+    dispatcher: LONG_HTTP_AGENT, // 720s AbortSignal > undici 300s default headersTimeout
   });
   await throwOnError('schema', res, sessionId);
   return res.json();

--- a/app/src/app/api/compile/run/route.ts
+++ b/app/src/app/api/compile/run/route.ts
@@ -43,7 +43,14 @@ import { runIngestFilesStep } from '@/lib/compile/steps/ingest-files';
 import { runIngestUrlsStep } from '@/lib/compile/steps/ingest-urls';
 import { runIngestTextsStep } from '@/lib/compile/steps/ingest-texts';
 import { sanitizeLogValue } from '@/lib/log-safe';
-import { LONG_HTTP_AGENT } from '@/lib/long-http-agent';
+import { LONG_HTTP_AGENT, makeDispatcher } from '@/lib/long-http-agent';
+import {
+  computeResolveMs,
+  computeMatchMs,
+  computeDraftMs,
+  computeCrossrefMs,
+  computeCommitMs,
+} from '@/lib/compile-timeouts';
 
 const APP_URL = process.env.APP_URL ?? 'http://app:3000';
 
@@ -88,18 +95,18 @@ async function callExtract(sourceId: string, sessionId: string): Promise<void> {
   await throwOnError('extract', res, sessionId);
 }
 
-async function callResolve(sessionId: string): Promise<{ canonical_entities: unknown[]; canonical_concepts: unknown[] }> {
+async function callResolve(sessionId: string, sourceCount: number): Promise<{ canonical_entities: unknown[]; canonical_concepts: unknown[] }> {
+  // Dynamic timeout sized to sourceCount (proxy for disambiguate-batch count).
+  // See lib/compile-timeouts.ts:computeResolveMs for the formula. Replaces the
+  // static 900s constant from PR #71 — that was a ticking bomb at N+1.
+  const timeoutMs = computeResolveMs(sourceCount);
   const res = await fetch(`${APP_URL}/api/compile/resolve`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ session_id: sessionId }),
-    // 900s = callFuzzy 60s + callEmbedding 60s + callDisambiguate 600s + 180s
-    // headroom. Prior 660s was 60s short of the worst-case sequential sum once
-    // every sub-call hit its individual ceiling. In practice fuzzy+embedding
-    // finish in seconds, but the AbortSignal needs to fit the math.
-    signal: AbortSignal.timeout(900_000),
+    signal: AbortSignal.timeout(timeoutMs),
     // @ts-expect-error — dispatcher is an undici-specific fetch option not in the DOM RequestInit type
-    dispatcher: LONG_HTTP_AGENT, // 900s AbortSignal > undici 300s default headersTimeout
+    dispatcher: makeDispatcher(timeoutMs),
   });
   await throwOnError('resolve', res, sessionId);
   const parsed = await res.json() as { canonical_entities?: unknown[]; canonical_concepts?: unknown[] };
@@ -111,19 +118,19 @@ async function callResolve(sessionId: string): Promise<{ canonical_entities: unk
 
 async function callMatch(
   sessionId: string,
-  canonicalEntities: unknown[]
+  canonicalEntities: unknown[],
+  sourceCount: number,
 ): Promise<{ skipped: boolean; matches: unknown[]; stats: Record<string, number> }> {
+  // Dynamic timeout sized to sourceCount × candidatesPerSource (default 3, the
+  // slice(0,3) cap in match/route.ts). See compile-timeouts.ts:computeMatchMs.
+  const timeoutMs = computeMatchMs(sourceCount);
   const res = await fetch(`${APP_URL}/api/compile/match`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ session_id: sessionId, canonical_entities: canonicalEntities }),
-    // 1200s = sequential `for source` at match/route.ts:137 × (callTfidfOverlap
-    // 30s + callTriage 30s) per candidate page. The 300s budget never matched
-    // the actual N×M call cost (N sources × M candidate pages); for N=19
-    // sources × 3 candidates × 30s worst-case AbortSignal = 2280s. 1200s
-    // defensively covers the realistic case (triage usually <5s) and matches
-    // commit/draft scale.
-    signal: AbortSignal.timeout(1_200_000),
+    signal: AbortSignal.timeout(timeoutMs),
+    // @ts-expect-error — dispatcher is an undici-specific fetch option not in the DOM RequestInit type
+    dispatcher: makeDispatcher(timeoutMs),
   });
   await throwOnError('match', res, sessionId);
   return res.json() as Promise<{ skipped: boolean; matches: unknown[]; stats: Record<string, number> }>;
@@ -150,48 +157,52 @@ async function callPlan(
   return res.json() as Promise<{ stats: { total: number } }>;
 }
 
-async function callDraft(sessionId: string): Promise<{ drafted: number; failed: number }> {
+async function callDraft(sessionId: string, planCount: number): Promise<{ drafted: number; failed: number }> {
+  // Dynamic timeout sized to planCount / DRAFT_CONCURRENCY batches × inner
+  // callDraftPage ceiling. See compile-timeouts.ts:computeDraftMs. Replaces
+  // the static 1.5M ms from PR #71 — that fired today at 16m on session
+  // 97f58805's 38-plan compile via undici's HeadersTimeoutError, because the
+  // static LONG_HTTP_AGENT.headersTimeout (16 min) was the real ceiling.
+  const timeoutMs = computeDraftMs(planCount);
   const res = await fetch(`${APP_URL}/api/compile/draft`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ session_id: sessionId }),
-    // 1500s = pLimit(N plans, DRAFT_CONCURRENCY=10) × inner callDraftPage 600s.
-    // For N=19 plans (~2 batches × ~600s = ~1200s) plus headroom. Prior 900s
-    // fired at 14m 59.9s on session d28d7644 even though all 19 drafts had
-    // succeeded server-side; outer killed the fetch before the inner JSON
-    // response landed. Matches callExtract's outer for symmetry.
-    signal: AbortSignal.timeout(1_500_000),
+    signal: AbortSignal.timeout(timeoutMs),
     // @ts-expect-error — dispatcher is an undici-specific fetch option not in the DOM RequestInit type
-    dispatcher: LONG_HTTP_AGENT,
+    dispatcher: makeDispatcher(timeoutMs),
   });
   await throwOnError('draft', res, sessionId);
   return res.json() as Promise<{ drafted: number; failed: number }>;
 }
 
-async function callCrossref(sessionId: string): Promise<{ wikilinks_added: number }> {
+async function callCrossref(sessionId: string, planCount: number): Promise<{ wikilinks_added: number }> {
+  // Dynamic timeout sized to planCount × per-plan wikilink-injection cost.
+  // See compile-timeouts.ts:computeCrossrefMs.
+  const timeoutMs = computeCrossrefMs(planCount);
   const res = await fetch(`${APP_URL}/api/compile/crossref`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ session_id: sessionId }),
-    signal: AbortSignal.timeout(600_000),
+    signal: AbortSignal.timeout(timeoutMs),
     // @ts-expect-error — dispatcher is an undici-specific fetch option not in the DOM RequestInit type
-    dispatcher: LONG_HTTP_AGENT,
+    dispatcher: makeDispatcher(timeoutMs),
   });
   await throwOnError('crossref', res, sessionId);
   return res.json() as Promise<{ wikilinks_added: number }>;
 }
 
-async function callCommit(sessionId: string): Promise<{ committed: number; thin_drafts_skipped: number; sources_activated: number }> {
+async function callCommit(sessionId: string, planCount: number): Promise<{ committed: number; thin_drafts_skipped: number; sources_activated: number }> {
+  // Dynamic timeout sized to planCount × per-plan (DB tx + write-page +
+  // vector-upsert) cost. See compile-timeouts.ts:computeCommitMs.
+  const timeoutMs = computeCommitMs(planCount);
   const res = await fetch(`${APP_URL}/api/compile/commit`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ session_id: sessionId }),
-    // 1200s = sequential `for plan` at commit/route.ts:124 × (DB tx + write-page
-    // 30s + vector-upsert 30s) per plan. Prior 120s fit only the trivial case
-    // (~3 plans); for N=19 plans worst case sums to ~20 min. 1200s defensively
-    // covers cases where any plan's file or vector call slows down — realistic
-    // case finishes in <2s/plan.
-    signal: AbortSignal.timeout(1_200_000),
+    signal: AbortSignal.timeout(timeoutMs),
+    // @ts-expect-error — dispatcher is an undici-specific fetch option not in the DOM RequestInit type
+    dispatcher: makeDispatcher(timeoutMs),
   });
   await throwOnError('commit', res, sessionId);
   return res.json() as Promise<{ committed: number; thin_drafts_skipped: number; sources_activated: number }>;
@@ -408,9 +419,15 @@ async function runCompilePipeline(sessionId: string): Promise<void> {
   }
   assertNotCancelled(sessionId);
 
+  // sourceCount feeds dynamic-timeout sizing for callResolve and callMatch.
+  // Both wrappers compute their outer AbortSignal + per-request undici Agent
+  // headersTimeout from this number — keeping the timer ≥ worst-case work
+  // even as the source pool grows. See lib/compile-timeouts.ts.
+  const sourceCount = sources.length;
+
   // Step 2: resolve — ALWAYS re-run (cheap: reads extractions table directly).
   updateCompileStep(sessionId, 'resolve', 'running');
-  const resolveResult = await timed(sessionId, 'resolve', () => callResolve(sessionId));
+  const resolveResult = await timed(sessionId, 'resolve', () => callResolve(sessionId, sourceCount));
   const canonicalEntities = resolveResult.canonical_entities;
   const canonicalConcepts = resolveResult.canonical_concepts;
   updateCompileStep(
@@ -423,7 +440,7 @@ async function runCompilePipeline(sessionId: string): Promise<void> {
 
   // Step 3: match — ALWAYS re-run (cheap: TF-IDF, no LLM unless triage).
   updateCompileStep(sessionId, 'match', 'running');
-  const matchResult = await timed(sessionId, 'match', () => callMatch(sessionId, canonicalEntities));
+  const matchResult = await timed(sessionId, 'match', () => callMatch(sessionId, canonicalEntities, sourceCount));
   if (matchResult.skipped) {
     updateCompileStep(sessionId, 'match', 'done', 'First compile — no existing pages');
   } else {
@@ -481,17 +498,25 @@ async function runCompilePipeline(sessionId: string): Promise<void> {
   }
   const hasNewSources = [...allExtractedIds].some((id) => !planSourceIds.has(id));
 
+  // planCount feeds dynamic-timeout sizing for callDraft / callCrossref /
+  // callCommit. Fresh path takes it from callPlan's return; retry-skip path
+  // derives it from the existing page_plans row count summed over statuses
+  // that downstream steps still operate on (planned + failed for draft;
+  // drafted + crossreffed for commit). Set inside the branches below.
+  let planCount: number;
+
   if (!planExists || hasNewSources) {
     // Fresh run: plan then draft.
     updateCompileStep(sessionId, 'plan', 'running');
     const planResult = await timed(sessionId, 'plan', () =>
       callPlan(sessionId, canonicalEntities, canonicalConcepts, matchResult.matches)
     );
-    updateCompileStep(sessionId, 'plan', 'done', `${planResult.stats.total} pages planned`);
+    planCount = planResult.stats.total;
+    updateCompileStep(sessionId, 'plan', 'done', `${planCount} pages planned`);
     assertNotCancelled(sessionId);
 
     updateCompileStep(sessionId, 'draft', 'running');
-    const draftResult = await timed(sessionId, 'draft', () => callDraft(sessionId));
+    const draftResult = await timed(sessionId, 'draft', () => callDraft(sessionId, planCount));
     updateCompileStep(
       sessionId,
       'draft',
@@ -504,9 +529,12 @@ async function runCompilePipeline(sessionId: string): Promise<void> {
   } else if (pendingDraftCount > 0) {
     // Retry path: plans exist, some are still 'planned' or were marked
     // 'failed' on a prior Gemini error. Re-draft only those.
+    // planCount uses the full row count (Object.values reduce above) so
+    // crossref/commit timeouts size to the whole plan set, not just pending.
+    planCount = Object.values(planCounts).reduce((sum, c) => sum + c, 0);
     console.log('[compile:%s] %d plans pending — re-drafting without re-planning', sanitizeLogValue(sessionId), pendingDraftCount);
     updateCompileStep(sessionId, 'draft', 'running');
-    const draftResult = await timed(sessionId, 'draft', () => callDraft(sessionId));
+    const draftResult = await timed(sessionId, 'draft', () => callDraft(sessionId, planCount));
     updateCompileStep(
       sessionId,
       'draft',
@@ -517,6 +545,9 @@ async function runCompilePipeline(sessionId: string): Promise<void> {
     );
     assertNotCancelled(sessionId);
   } else {
+    // No plan work to do; downstream still runs against committed plans, so
+    // crossref/commit need a planCount sized to the full plan set.
+    planCount = Object.values(planCounts).reduce((sum, c) => sum + c, 0);
     console.log('[compile:%s] plan+draft already complete — skipping both', sanitizeLogValue(sessionId));
   }
 
@@ -525,7 +556,7 @@ async function runCompilePipeline(sessionId: string): Promise<void> {
   // plans are already 'crossreffed' (commit-failure retry), this returns 0
   // wikilinks as a safe no-op — plans stay 'crossreffed' for commit to consume.
   updateCompileStep(sessionId, 'crossref', 'running');
-  const crossrefResult = await timed(sessionId, 'crossref', () => callCrossref(sessionId));
+  const crossrefResult = await timed(sessionId, 'crossref', () => callCrossref(sessionId, planCount));
   updateCompileStep(sessionId, 'crossref', 'done', `${crossrefResult.wikilinks_added} wikilinks added`);
   assertNotCancelled(sessionId);
 
@@ -533,7 +564,7 @@ async function runCompilePipeline(sessionId: string): Promise<void> {
   // Pass 5 is a synchronous better-sqlite3 transaction — cancel is blocked at
   // the route level once this step is 'running'. No mid-transaction abort.
   updateCompileStep(sessionId, 'commit', 'running');
-  const commitResult = await timed(sessionId, 'commit', () => callCommit(sessionId));
+  const commitResult = await timed(sessionId, 'commit', () => callCommit(sessionId, planCount));
   const thinMsg = commitResult.thin_drafts_skipped > 0 ? `, ${commitResult.thin_drafts_skipped} thin drafts skipped` : '';
   updateCompileStep(sessionId, 'commit', 'done', `${commitResult.committed} pages, ${commitResult.sources_activated} sources committed${thinMsg}`);
 

--- a/app/src/app/api/compile/run/route.ts
+++ b/app/src/app/api/compile/run/route.ts
@@ -427,11 +427,15 @@ async function runCompilePipeline(sessionId: string): Promise<void> {
   if (matchResult.skipped) {
     updateCompileStep(sessionId, 'match', 'done', 'First compile — no existing pages');
   } else {
+    // Surface candidates_found + sources_checked so the UI can distinguish
+    // "match found 0 candidates above the TF-IDF threshold" from "match
+    // acted on N candidates and decided u/c/s on each". Without these counts
+    // the prior `0u/0c/0s` rendering looked identical to a bug.
     updateCompileStep(
       sessionId,
       'match',
       'done',
-      `${matchResult.stats.updates} updates, ${matchResult.stats.contradictions} contradictions, ${matchResult.stats.skips} skipped`
+      `${matchResult.stats.candidates_found} candidates from ${matchResult.stats.sources_checked} sources → ${matchResult.stats.updates}u/${matchResult.stats.contradictions}c/${matchResult.stats.skips}s`
     );
   }
   assertNotCancelled(sessionId);

--- a/app/src/app/api/compile/run/route.ts
+++ b/app/src/app/api/compile/run/route.ts
@@ -24,7 +24,6 @@
  */
 
 import { NextResponse } from 'next/server';
-import { Agent } from 'undici';
 
 import {
   getCompileProgress,
@@ -44,31 +43,9 @@ import { runIngestFilesStep } from '@/lib/compile/steps/ingest-files';
 import { runIngestUrlsStep } from '@/lib/compile/steps/ingest-urls';
 import { runIngestTextsStep } from '@/lib/compile/steps/ingest-texts';
 import { sanitizeLogValue } from '@/lib/log-safe';
+import { LONG_HTTP_AGENT } from '@/lib/long-http-agent';
 
 const APP_URL = process.env.APP_URL ?? 'http://app:3000';
-
-// Node's built-in fetch (undici) defaults headersTimeout=300_000 ms — shorter
-// than the 600-900 s AbortSignal we set on long LLM steps (draft, crossref),
-// so HeadersTimeoutError fires before our AbortSignal ever kicks in. Scoped
-// Agent with a 16-min headersTimeout/bodyTimeout matches the longest step's
-// deadline plus buffer. Only applied to the steps that genuinely need >5 min;
-// keeping other calls on the default Agent preserves fail-fast behavior for
-// the short paths (extract, resolve, match, plan, commit, schema).
-// Ref: https://nodejs.org/api/globals.html#custom-dispatcher
-//
-// undici pinned to ^7 in package.json. undici 8 reworked dispatcher composition
-// to require an `onRequestStart` interceptor method shape that this Agent does
-// not expose when passed via `dispatcher:` to Node's built-in fetch — fails
-// with `InvalidArgumentError: invalid onRequestStart method` at draft/crossref
-// time. Dependabot will re-propose undici 8: do not merge that bump until
-// callDraft/callCrossref are migrated to undici-8-compatible dispatcher API
-// (`undici.request()` direct, or `setGlobalDispatcher()` on a v8 Agent).
-const LONG_HTTP_AGENT = new Agent({
-  headersTimeout: 16 * 60_000,
-  bodyTimeout: 16 * 60_000,
-  connectTimeout: 10_000,
-  keepAliveTimeout: 60_000,
-});
 
 // Shared error surfacer. On !res.ok, read the response body (race-capped at
 // 3 s so a hung chunked response doesn't stall the orchestrator) and embed
@@ -97,9 +74,16 @@ async function callExtract(sourceId: string, sessionId: string): Promise<void> {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ source_id: sourceId }),
-    // 660s = inner extract LLM (600s) + 60s margin for NER/keyphrase/handler I/O.
-    // Prior 180s aborted the extract step before the inner 300s LLM ever fired.
-    signal: AbortSignal.timeout(660_000),
+    // 1500s = NER (360s, sequential) + route (10s) + keyphrase/tfidf parallel (360s longest) + extract LLM (600s) + ~170s handler+I/O headroom.
+    // Inner NLP sub-call ceilings raised from 60s → 360s after session e2c8a59d (13 academic PDFs) failed all 13 sources twice on 60s NER timeouts under EXTRACT_CONCURRENCY=4 contention; outer wrapper had to grow to match.
+    signal: AbortSignal.timeout(1_500_000),
+    // LONG_HTTP_AGENT (16-min headersTimeout) — needed since the 360s NLP +
+    // 600s LLM bumps push per-source extract past undici's default 300s
+    // headersTimeout. Session 29be62eb hit `[cause] HeadersTimeoutError`
+    // here before the AbortSignal ever fired. Comment above LONG_HTTP_AGENT
+    // initially excluded extract as "short" — no longer true on dense PDFs.
+    // @ts-expect-error — dispatcher is an undici-specific fetch option not in the DOM RequestInit type
+    dispatcher: LONG_HTTP_AGENT,
   });
   await throwOnError('extract', res, sessionId);
 }
@@ -111,6 +95,8 @@ async function callResolve(sessionId: string): Promise<{ canonical_entities: unk
     body: JSON.stringify({ session_id: sessionId }),
     // 660s = inner disambiguate LLM (600s) + 60s margin. Prior 180s aborted before the inner LLM finished on DeepSeek.
     signal: AbortSignal.timeout(660_000),
+    // @ts-expect-error — dispatcher is an undici-specific fetch option not in the DOM RequestInit type
+    dispatcher: LONG_HTTP_AGENT, // 660s AbortSignal > undici 300s default headersTimeout
   });
   await throwOnError('resolve', res, sessionId);
   const parsed = await res.json() as { canonical_entities?: unknown[]; canonical_concepts?: unknown[] };
@@ -199,6 +185,8 @@ async function callSchema(sessionId: string): Promise<unknown> {
     body: JSON.stringify({ session_id: sessionId }),
     // 660s = inner generate-schema LLM (600s) + 60s margin. Prior 120s aborted before inner LLM finished on DeepSeek.
     signal: AbortSignal.timeout(660_000),
+    // @ts-expect-error — dispatcher is an undici-specific fetch option not in the DOM RequestInit type
+    dispatcher: LONG_HTTP_AGENT, // 660s AbortSignal > undici 300s default headersTimeout
   });
   await throwOnError('schema', res, sessionId);
   return res.json();

--- a/app/src/app/api/compile/schema/route.ts
+++ b/app/src/app/api/compile/schema/route.ts
@@ -16,6 +16,7 @@
 
 import { NextResponse } from 'next/server';
 import { getEffectiveCompileModel, getPagePlansByStatus } from '../../../../lib/db';
+import { LONG_HTTP_AGENT } from '../../../../lib/long-http-agent';
 
 const NLP_SERVICE_URL = process.env.NLP_SERVICE_URL ?? 'http://nlp-service:8000';
 const SCHEMA_PATH = '/data/schema.md';
@@ -77,6 +78,8 @@ export async function POST(request: Request) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ pages: pagesSummary, compile_model: getEffectiveCompileModel(session_id) }),
     signal: AbortSignal.timeout(600_000), // 10 min — generate-schema runs an LLM call; DeepSeek can take 200-400s on the page list. 120s (prior value) was Gemini-only sizing.
+    // @ts-expect-error — dispatcher is an undici-specific fetch option not in the DOM RequestInit type
+    dispatcher: LONG_HTTP_AGENT, // 600s AbortSignal > undici 300s default headersTimeout
   });
 
   if (!genRes.ok) {

--- a/app/src/app/api/health/route.ts
+++ b/app/src/app/api/health/route.ts
@@ -57,7 +57,7 @@ export async function GET() {
       nlpOk = nlpRes.ok;
     } catch { /* non-fatal */ }
 
-    const dbOk = dbWritable && allExpectedPresent && schemaVersion === 23;
+    const dbOk = dbWritable && allExpectedPresent && schemaVersion === 24;
 
     // status:'ok' requires DB healthy + NLP reachable + no vector backlog.
     // status:'degraded' means the app is serving but something needs attention.

--- a/app/src/app/onboarding/OnboardingClient.tsx
+++ b/app/src/app/onboarding/OnboardingClient.tsx
@@ -14,7 +14,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useEffect, useState } from 'react';
 import {
   Globe, FileUp, Bookmark, BookOpen, AtSign,
-  Smartphone, HardDrive, Book, ArrowRight, ClipboardType,
+  Smartphone, ArrowRight, ClipboardType,
 } from 'lucide-react';
 import { useToast } from '../../components/Toast';
 import { SUPPORTED_FORMATS_SHORT } from '../../lib/supported-formats';
@@ -37,8 +37,6 @@ const CONNECTORS: ConnectorDef[] = [
   { id: 'twitter',      Icon: AtSign,     title: 'Twitter / X',       subtitle: 'Twitter bookmarks export',      status: 'active' },
   { id: 'apple-notes',  Icon: Smartphone, title: 'Apple Notes',       subtitle: 'Notes export',                  status: 'active' },
   { id: 'upnote',       Icon: BookOpen,   title: 'Upnote',            subtitle: 'Markdown notes export',         status: 'active' },
-  { id: 'google-drive', Icon: HardDrive,  title: 'Google Drive',      subtitle: 'Cloud Storage',                 status: 'coming-soon' },
-  { id: 'notion',       Icon: Book,       title: 'Notion',            subtitle: 'Workspace',                     status: 'coming-soon' },
 ];
 
 const ACTIVE_IDS = new Set(CONNECTORS.filter(c => c.status === 'active').map(c => c.id));
@@ -50,6 +48,7 @@ function OnboardingPageInner() {
 
   const [sessionId, setSessionId] = useState<string>('');
   const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [compileModel, setCompileModel] = useState<string | null>(null);
 
   useEffect(() => {
     // Resume existing session if URL carries ?session_id (review page back-links).
@@ -58,6 +57,20 @@ function OnboardingPageInner() {
     sessionStorage.setItem('kompl_session_id', id);
     setSessionId(id);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    // Fetch the currently-selected compile model so the user can see which
+    // LLM provider this session will lock to. Per-session model lock means
+    // changing this in Settings mid-compile has no effect — visibility here
+    // catches the "I picked Gemini in Settings but DeepSeek is running"
+    // surprise before the user clicks Next.
+    void fetch('/api/settings')
+      .then((r) => r.json())
+      .then((data: { compile_model?: string }) => {
+        if (typeof data.compile_model === 'string') setCompileModel(data.compile_model);
+      })
+      .catch(() => { /* non-fatal */ });
+  }, []);
 
   function toggleConnector(id: string) {
     setSelected(prev => {
@@ -125,6 +138,19 @@ function OnboardingPageInner() {
           }}>
             {subtitle}
           </p>
+          {compileModel && (
+            <span style={{
+              fontFamily: 'var(--font-mono)',
+              fontWeight: 400,
+              fontSize: 10,
+              letterSpacing: '0.5px',
+              color: 'var(--accent)',
+              opacity: 0.85,
+              marginTop: 4,
+            }}>
+              compile model · {compileModel}
+            </span>
+          )}
         </section>
 
         <div style={{ textAlign: 'center', marginBottom: '0.75rem' }}>

--- a/app/src/app/onboarding/[connector]/page.tsx
+++ b/app/src/app/onboarding/[connector]/page.tsx
@@ -43,8 +43,6 @@ const CONNECTOR_LABELS: Record<string, string> = {
   paste: 'Paste Text',
   url: 'URLs',
   'file-upload': 'Files',
-  'google-drive': 'Google Drive',
-  notion: 'Notion',
   bookmarks: 'Browser Bookmarks',
   twitter: 'Twitter / X Bookmarks',
   upnote: 'Upnote',

--- a/app/src/app/onboarding/progress/page.tsx
+++ b/app/src/app/onboarding/progress/page.tsx
@@ -32,10 +32,20 @@ interface ProgressResponse {
   error:        string | null;
   started_at:   string | null;
   completed_at: string | null;
-  // Phase 4: count of collect_staging rows in 'failed' state for this
-  // session. When > 0 AND status is terminal, the "Retry N failed items"
-  // button is shown so the user can re-fire only those items.
+  // Per-item failure counters. When the sum is > 0 AND status is
+  // terminal, the "Retry N failed" button is shown so the user can
+  // re-fire only those items. failed_stage_count is intake-stage
+  // collect_staging failures; failed_draft_count is per-page draft
+  // failures (page_plans.draft_status='failed') — the draft step writes
+  // status='done' regardless so commit can run on what succeeded, so
+  // these don't trip the session-level retry path on their own.
+  // failed_extract_count is sources without an extractions row — the
+  // orchestrator's extract step tolerates per-item failures (only fails
+  // the session if EVERY source fails extraction), so partial-extract
+  // failures also leave the session 'completed' with stranded sources.
   failed_stage_count?: number;
+  failed_draft_count?: number;
+  failed_extract_count?: number;
 }
 
 // ── Per-step expand-to-reveal data ──────────────────────────────────────────
@@ -1097,13 +1107,18 @@ function ProgressPageInner() {
               </button>
             )}
 
-            {/* Phase 4: retry only per-item failed staging rows. Shows when
-                the session reached a terminal state but some items inside
-                ingest_{urls,files,texts} skipped. Distinct from the
-                session-level Retry above — that one resumes from first
-                non-done step, which is a no-op on completed sessions. */}
+            {/* Phase 4: retry per-item failures. Three sources:
+                  - collect_staging.failed (intake-stage URL/file/text skips)
+                  - page_plans.draft_status='failed' (per-page LLM draft errors)
+                  - sources w/o extractions (per-source extract failures —
+                    orchestrator tolerates partial extract failures, so these
+                    leave the session 'completed' with stranded sources)
+                The draft step (and the extract step on partial failures)
+                writes status='done' regardless, so none of these trip the
+                session-level Retry above. Any of the three being > 0
+                surfaces this button on a terminal session. */}
             {(isComplete || isFailedStatus || isCancelled) &&
-             (progress?.failed_stage_count ?? 0) > 0 && (
+             ((progress?.failed_stage_count ?? 0) + (progress?.failed_draft_count ?? 0) + (progress?.failed_extract_count ?? 0)) > 0 && (
               <button
                 onClick={handleRetryFailed}
                 disabled={retryingFailed}
@@ -1118,7 +1133,7 @@ function ProgressPageInner() {
               >
                 {retryingFailed
                   ? 'Retrying…'
-                  : `Retry ${progress?.failed_stage_count} failed`}
+                  : `Retry ${(progress?.failed_stage_count ?? 0) + (progress?.failed_draft_count ?? 0) + (progress?.failed_extract_count ?? 0)} failed`}
               </button>
             )}
           </div>

--- a/app/src/app/settings/page.tsx
+++ b/app/src/app/settings/page.tsx
@@ -938,16 +938,19 @@ export default function SettingsPage() {
                 </span>
               </div>
               <div style={{ fontSize: '0.85rem', color: 'var(--fg-muted)', lineHeight: 1.5 }}>
-                Hard USD ceiling on combined LLM API spend per UTC day (Gemini + DeepSeek share
-                this cap). When exceeded, LLM calls raise a cost-ceiling error and the pipeline
-                marks affected work as retryable. Resets at midnight UTC.
+                Hard USD ceiling on combined LLM API spend per UTC day across all providers
+                (one shared counter). When exceeded, LLM calls raise a cost-ceiling error and
+                the pipeline marks affected work as retryable. Resets at midnight UTC.
                 Set to <strong>0</strong> for unlimited (no cap).
-                {' '}The tracked number comes from each provider&apos;s usage metadata
-                (input + cached + output tokens, multiplied by the model&apos;s
-                published per-million-token price). It&apos;s an <strong>estimate</strong> —
-                real invoice totals may differ by a few percent due to token-count rounding,
-                cached-content discounts, and any price drift between the provider&apos;s
-                schedule and our constants.
+                {' '}The tracked number is a Kompl-side estimate from each call&apos;s usage
+                metadata (input + cached + output tokens × the model&apos;s per-million-token
+                price). It&apos;s independent of any provider&apos;s prepaid balance — your
+                DeepSeek/Gemini account ledger is separate.
+                {' '}<strong>Prices may be stale.</strong> Per-million-token rates are hard-coded
+                constants and providers update them periodically; we deliberately ignore
+                promotional discounts (overestimating is the safer side — the cap fires sooner
+                than necessary, never later). Reconcile with the provider&apos;s invoice for
+                ground truth.
               </div>
             </div>
             <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexShrink: 0 }}>

--- a/app/src/components/WhatsNext.tsx
+++ b/app/src/components/WhatsNext.tsx
@@ -3,7 +3,6 @@
 import { useState, useRef, useEffect } from 'react';
 
 const DEFERRED = [
-  'Google Drive and Notion connectors',
   'Image support via LLM vision',
   'Custom LLM provider support',
   'Tauri tray app — one-click Start/Stop/Open from the system tray',

--- a/app/src/lib/compile-timeouts.ts
+++ b/app/src/lib/compile-timeouts.ts
@@ -1,0 +1,70 @@
+// Outer-timeout formulas for run/route.ts orchestrator wrappers. Compute
+// headersTimeout = bodyTimeout = AbortSignal.timeout from the work-size N
+// already known to the orchestrator. Replaces the static AbortSignal.timeout
+// constants shipped in PR #71 (commit b7b2d48) — those were ticking bombs
+// that would fire at N+1.
+//
+// Each formula returns Math.max(FLOOR_MS, ceil(rate * N * OVERHEAD) +
+// HEADROOM_MS). Floors guard against degenerate N=0/1 producing sub-second
+// timeouts. OVERHEAD covers per-call latency variance; HEADROOM_MS covers
+// I/O blips (DNS, slow disk) independent of the work itself.
+//
+// Tuning: per-item rates are derived from the inner-call AbortSignals at
+// each route. If a wrapper still fires legitimately, change the rate
+// constant in this file (one place); do not retune at the call site.
+
+const OVERHEAD = 1.2;          // 20% relative slack for per-call variance
+const HEADROOM_MS = 180_000;   // 3 min absolute headroom for I/O blips
+
+// Floors per wrapper — ensures N=0/1 still produces a usable timeout.
+const RESOLVE_FLOOR_MS  = 300_000; // 5 min
+const MATCH_FLOOR_MS    = 120_000; // 2 min
+const DRAFT_FLOOR_MS    = 600_000; // 10 min — single-plan inner ceiling
+const CROSSREF_FLOOR_MS = 120_000; // 2 min
+const COMMIT_FLOOR_MS   = 120_000; // 2 min
+
+// Per-item rates — see the inline rationale comments in run/route.ts wrappers.
+const RESOLVE_PER_SOURCE_MS = 60_000;  // ~2 disambiguate batches × 30s avg
+const MATCH_PER_PAIR_MS     = 60_000;  // tfidf 30s + triage 30s, sequential
+const DRAFT_PER_BATCH_MS    = 600_000; // inner callDraftPage ceiling per batch
+const CROSSREF_PER_PLAN_MS  = 30_000;  // wikilink injection per plan
+const COMMIT_PER_PLAN_MS    = 60_000;  // db tx + write-page 30s + vector-upsert 30s
+
+function withSlack(rawMs: number, floorMs: number): number {
+  return Math.max(floorMs, Math.ceil(rawMs * OVERHEAD) + HEADROOM_MS);
+}
+
+// resolve = fuzzy 60s + embedding 60s + sourceCount × disambiguate-batch.
+// Empirical: 10 sources → 192 pairs → ~19 batches × 30s = 570s + 120s
+// prelude = 690s. Formula scales linearly past that.
+export function computeResolveMs(sourceCount: number): number {
+  const raw = 120_000 + sourceCount * RESOLVE_PER_SOURCE_MS;
+  return withSlack(raw, RESOLVE_FLOOR_MS);
+}
+
+// match = sequential `for source` × top-3 candidates × (tfidf + triage).
+// candidatesPerSource defaults to 3 (the slice(0, 3) cap in match/route.ts).
+export function computeMatchMs(sourceCount: number, candidatesPerSource = 3): number {
+  const raw = sourceCount * candidatesPerSource * MATCH_PER_PAIR_MS;
+  return withSlack(raw, MATCH_FLOOR_MS);
+}
+
+// draft = ⌈planCount / DRAFT_CONCURRENCY⌉ batches × per-batch inner ceiling.
+// concurrency defaults to 10 (DRAFT_CONCURRENCY env in /api/compile/draft).
+export function computeDraftMs(planCount: number, concurrency = 10): number {
+  const batches = Math.max(1, Math.ceil(planCount / concurrency));
+  const raw = batches * DRAFT_PER_BATCH_MS;
+  return withSlack(raw, DRAFT_FLOOR_MS);
+}
+
+// crossref = sequential per-plan wikilink injection (no LLM).
+export function computeCrossrefMs(planCount: number): number {
+  const raw = planCount * CROSSREF_PER_PLAN_MS;
+  return withSlack(raw, CROSSREF_FLOOR_MS);
+}
+
+// commit = sequential `for plan` × (DB tx + write-page 30s + vector-upsert 30s).
+export function computeCommitMs(planCount: number): number {
+  const raw = planCount * COMMIT_PER_PLAN_MS;
+  return withSlack(raw, COMMIT_FLOOR_MS);
+}

--- a/app/src/lib/db.ts
+++ b/app/src/lib/db.ts
@@ -1055,6 +1055,21 @@ export function markSourceExtracted(sourceId: string): void {
 }
 
 /**
+ * Replace a source's title — used when the extract LLM derives a real
+ * document title for a source whose original title was a filename stub
+ * (arxiv ID, digit-only filename, etc.). Trim + cap at 250 chars to keep
+ * the column index lean. No-op on empty input.
+ */
+export function updateSourceTitle(sourceId: string, newTitle: string): void {
+  const trimmed = (newTitle ?? '').trim();
+  if (!trimmed) return;
+  const capped = trimmed.length > 250 ? trimmed.slice(0, 250) : trimmed;
+  openDb()
+    .prepare(`UPDATE sources SET title = ? WHERE source_id = ?`)
+    .run(capped, sourceId);
+}
+
+/**
  * Reset a source back to 'pending' so the compile pipeline will re-process it.
  * Clears attempt counter and backoff timestamp. Used by the manual recompile
  * endpoint and the UI retry flow.

--- a/app/src/lib/db.ts
+++ b/app/src/lib/db.ts
@@ -2983,6 +2983,51 @@ export function countFailedStagingBySession(sessionId: string): number {
 }
 
 /**
+ * Count page_plans rows with draft_status='failed' for a session.
+ * Distinct from staging-failure count: these are wiki-page draft attempts
+ * that hit a per-item LLM error after planning — the "Writing pages" step
+ * marks itself 'done' regardless so commit can run on the drafts that
+ * succeeded, which is why these failures don't trip the session-level
+ * retry condition. Powers the "Retry N failed" button when failures live
+ * in the draft stage rather than at intake.
+ */
+export function countFailedDraftPlansBySession(sessionId: string): number {
+  const row = openDb()
+    .prepare(
+      `SELECT COUNT(*) AS n
+         FROM page_plans
+        WHERE session_id   = ?
+          AND draft_status = 'failed'`
+    )
+    .get(sessionId) as { n: number };
+  return row.n;
+}
+
+/**
+ * Count `sources` rows for a session that have no matching `extractions` row.
+ * This is the per-source extract-failure shape: the orchestrator's extract
+ * step tolerates per-item failures (only fails the session if EVERY source
+ * fails extraction — see app/src/app/api/compile/run/route.ts:387). Sources
+ * that failed extraction stay at compile_status='pending' (the initial
+ * value) with no `extractions` row, even after compile_progress reaches
+ * 'completed'. Powers the third arm of the "Retry N failed" button —
+ * alongside countFailedStagingBySession (intake-stage) and
+ * countFailedDraftPlansBySession (per-page LLM).
+ */
+export function countUnextractedSourcesBySession(sessionId: string): number {
+  const row = openDb()
+    .prepare(
+      `SELECT COUNT(*) AS n
+         FROM sources s
+         LEFT JOIN extractions e ON s.source_id = e.source_id
+        WHERE s.onboarding_session_id = ?
+          AND e.source_id IS NULL`
+    )
+    .get(sessionId) as { n: number };
+  return row.n;
+}
+
+/**
  * Return active sources older than thresholdDays, ordered oldest-first.
  * Uses julianday() for correct date arithmetic — avoids the SQLite
  * lexicographic timestamp gotcha.

--- a/app/src/lib/db.ts
+++ b/app/src/lib/db.ts
@@ -1292,6 +1292,7 @@ export interface PagePlanRow {
   related_plan_ids: string | null;  // JSON TEXT
   draft_content: string | null;
   draft_status: string;
+  draft_error: string | null;  // populated by updatePlanFailed (schema v24)
   created_at: string;
 }
 
@@ -1351,7 +1352,7 @@ export function getPagePlansByStatus(sessionId: string, status: string): PagePla
     .prepare(
       `SELECT plan_id, session_id, title, page_type, action,
               source_ids, existing_page_id, related_plan_ids,
-              draft_content, draft_status, created_at
+              draft_content, draft_status, draft_error, created_at
          FROM page_plans
         WHERE session_id = ? AND draft_status = ?
         ORDER BY created_at ASC`
@@ -1369,7 +1370,7 @@ export function getAllPagePlansBySession(sessionId: string): PagePlanRow[] {
     .prepare(
       `SELECT plan_id, session_id, title, page_type, action,
               source_ids, existing_page_id, related_plan_ids,
-              draft_content, draft_status, created_at
+              draft_content, draft_status, draft_error, created_at
          FROM page_plans
         WHERE session_id = ?
         ORDER BY created_at ASC`
@@ -1446,6 +1447,21 @@ export function updatePlanStatus(planId: string, status: string): void {
   openDb()
     .prepare(`UPDATE page_plans SET draft_status = ? WHERE plan_id = ?`)
     .run(status, planId);
+}
+
+/**
+ * Mark a page_plan as failed AND record the error message in one update.
+ * Replaces the silent `updatePlanStatus(plan_id, 'failed')` pattern that
+ * threw away every per-task error from the draft pLimit pool — operators
+ * had to grep app logs for 30+ min to recover the cause. Truncates to 1000
+ * chars to keep DB row size bounded; full stack lives in `console.error`
+ * at the call site.
+ */
+export function updatePlanFailed(planId: string, errorMessage: string): void {
+  const truncated = errorMessage.length > 1000 ? errorMessage.slice(0, 1000) + '… [truncated]' : errorMessage;
+  openDb()
+    .prepare(`UPDATE page_plans SET draft_status = 'failed', draft_error = ? WHERE plan_id = ?`)
+    .run(truncated, planId);
 }
 
 /** Fetch a page by title (case-insensitive). Returns null if not found. */
@@ -3233,7 +3249,7 @@ export function getPendingDrafts(): PagePlanRow[] {
     .prepare(
       `SELECT plan_id, session_id, title, page_type, action,
               source_ids, existing_page_id, related_plan_ids,
-              draft_content, draft_status, created_at
+              draft_content, draft_status, draft_error, created_at
          FROM page_plans
         WHERE draft_status = 'pending_approval'
         ORDER BY created_at DESC`

--- a/app/src/lib/long-http-agent.ts
+++ b/app/src/lib/long-http-agent.ts
@@ -28,3 +28,26 @@ export const LONG_HTTP_AGENT = new Agent({
   connectTimeout: 10_000,
   keepAliveTimeout: 60_000,
 });
+
+// Factory for orchestrator outer-call wrappers in run/route.ts. Returns a
+// fresh Agent sized to the work-size N at call-time. Static LONG_HTTP_AGENT
+// at 16-min headersTimeout is a ticking bomb — session 97f58805 hit
+// HeadersTimeoutError at 16m 46s into a 38-plan draft. Every static value
+// fires at some N+1; only formula-from-N keeps the ceiling above the work.
+//
+// Agent is GC'd when the fetch completes and the response body is consumed
+// (per undici #1989). Memory cost ~50KB/Agent; 7 agents per orchestrator
+// session is negligible.
+//
+// The caller MUST also pass `signal: AbortSignal.timeout(timeoutMs)` with
+// the same value — if AbortSignal fires later than headersTimeout, undici
+// raises HeadersTimeoutError instead of a clean AbortError. Keep them
+// equal so the abort signal owns the cancellation contract.
+export function makeDispatcher(timeoutMs: number): Agent {
+  return new Agent({
+    headersTimeout: timeoutMs,
+    bodyTimeout: timeoutMs,
+    connectTimeout: 10_000,
+    keepAliveTimeout: 60_000,
+  });
+}

--- a/app/src/lib/long-http-agent.ts
+++ b/app/src/lib/long-http-agent.ts
@@ -1,0 +1,30 @@
+import { Agent } from 'undici';
+
+// Node's built-in fetch (undici) defaults headersTimeout=300_000 ms — shorter
+// than the long AbortSignals we set on LLM-bound and dense-PDF NLP calls
+// (extract LLM, draft, crossref, NER on academic PDFs, etc.), so
+// HeadersTimeoutError fires before our AbortSignal ever kicks in. This shared
+// Agent has 16-min headersTimeout/bodyTimeout — covers the longest single
+// request (15-min draft) plus buffer.
+//
+// Apply via `dispatcher: LONG_HTTP_AGENT` to any fetch whose AbortSignal
+// exceeds 300_000 ms. Calls under 300_000 ms can stay on the default Agent
+// to preserve fail-fast behavior on short-path routes (resolve/match/plan/
+// commit are on the default Agent intentionally).
+//
+// Ref: https://nodejs.org/api/globals.html#custom-dispatcher
+//
+// undici pinned to ^7 in package.json. undici 8 reworked dispatcher
+// composition to require an `onRequestStart` interceptor method shape that
+// this Agent does not expose when passed via `dispatcher:` to Node's
+// built-in fetch — fails with `InvalidArgumentError: invalid onRequestStart
+// method` at draft/crossref time. Dependabot will re-propose undici 8: do
+// not merge that bump until callers are migrated to undici-8-compatible
+// dispatcher API (`undici.request()` direct, or `setGlobalDispatcher()` on
+// a v8 Agent).
+export const LONG_HTTP_AGENT = new Agent({
+  headersTimeout: 16 * 60_000,
+  bodyTimeout: 16 * 60_000,
+  connectTimeout: 10_000,
+  keepAliveTimeout: 60_000,
+});

--- a/app/src/lib/recompile.ts
+++ b/app/src/lib/recompile.ts
@@ -31,6 +31,7 @@ import {
   getPageTitleMap,
 } from './db';
 import { syncPageWikilinks } from './wikilinks';
+import { LONG_HTTP_AGENT } from './long-http-agent';
 
 const NLP_SERVICE_URL = process.env.NLP_SERVICE_URL ?? 'http://nlp-service:8000';
 
@@ -66,6 +67,8 @@ async function callDraftPage(
       compile_model: compileModel,
     }),
     signal: AbortSignal.timeout(600_000), // 10 min — recompile-on-source-delete runs an extract LLM call. DeepSeek can take 200-400s on dense sources. 180s (prior) was Gemini-only sizing.
+    // @ts-expect-error — dispatcher is an undici-specific fetch option not in the DOM RequestInit type
+    dispatcher: LONG_HTTP_AGENT, // 600s AbortSignal > undici 300s default headersTimeout
   });
 
   if (!res.ok) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,13 @@ services:
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
       DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
       FIRECRAWL_API_KEY: ${FIRECRAWL_API_KEY:-}
+      # Per-source extract workers in app/src/app/api/compile/run/route.ts.
+      # Default 4 saturated the prior 2GB / 2-CPU nlp-service container (12
+      # in-flight NLP calls = 'fetch failed' cascade on session 453e7fc1).
+      # Set to 2 alongside nlp-service bump to 4g/4.0 — gives 6 in-flight
+      # parallel NLP calls, comfortable on the new cap. Raise to 4 only if
+      # nlp-service memory stays well under limit on a real PDF batch.
+      EXTRACT_CONCURRENCY: ${EXTRACT_CONCURRENCY:-2}
     volumes:
       - kompl-data:/data
     depends_on:
@@ -113,8 +120,14 @@ services:
     deploy:
       resources:
         limits:
-          memory: 2g
-          cpus: '2.0'
+          # Bumped from 2g/2.0 after session 453e7fc1 (18 academic PDFs) saturated
+          # the prior cap (1.85GiB / 2GiB, 208% CPU) under EXTRACT_CONCURRENCY=4
+          # — kernel refused new TCP connections, surfacing as 'fetch failed' on
+          # the orchestrator. 4g/4.0 lets the container hold 4 spaCy NER + 4
+          # parallel keyphrase methods + TF-IDF without memory pressure on a
+          # laptop with 16GB RAM (Docker Desktop allocates 7.6GB).
+          memory: 4g
+          cpus: '4.0'
 
   n8n:
     image: n8nio/n8n:2.15.0

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -447,9 +447,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -19,6 +19,7 @@
   },
   "overrides": {
     "hono": "^4.12.14",
-    "ip-address": "^10.1.1"
+    "ip-address": "^10.1.1",
+    "fast-uri": "^3.1.2"
   }
 }

--- a/nlp-service/services/llm_client.py
+++ b/nlp-service/services/llm_client.py
@@ -945,7 +945,14 @@ def disambiguate_entities(
             ],
             response_model=DisambiguationResponse,
             thinking_budget=_read_thinking_budget('disambiguate_entities'),
-            max_output_tokens=2048,
+            # 8192 sized for the 10-pair batch in routers/resolution.py:665.
+            # Each decision is {entity_a, entity_b, decision, canonical, reason}
+            # where `reason` carries free-text justification (e.g., "Bagging is
+            # a specific ensemble method..."); 10 × ~250 tokens + thinking
+            # overhead easily exceeds 2048. Session 97f58805 hit truncation:
+            # raw_excerpt cut off mid-string at line 50 col 166 of the JSON.
+            # 8192 matches generate_schema (structured-creative reasoning tier).
+            max_output_tokens=8192,
             temperature=0.0,
             step="disambiguate",
         ))

--- a/nlp-service/services/llm_client.py
+++ b/nlp-service/services/llm_client.py
@@ -587,6 +587,7 @@ class LLMExtractionResponse(BaseModel):
     No extra='forbid' — google-genai rejects additionalProperties=false
     in response_schema (consistent with all other LLM output models here).
     """
+    title: str          # document title — empty string if not derivable
     entities: list[ExtractionEntity]
     concepts: list[ExtractionConcept]
     claims: list[ExtractionClaim]
@@ -603,27 +604,36 @@ Your job is precision, not creativity. Only extract information that is
 explicitly or strongly implicitly present in the source. Do not hallucinate.
 
 Return JSON with these fields:
-1. entities      — named entities with name, type, mentions, and context
+1. title         — the document's actual title as it appears in the source
+   - For papers: the paper's title from the title page (NOT the filename, NOT
+     a publisher boilerplate like "The X Center for Y Research", NOT an
+     arXiv/DOI identifier).
+   - For articles, books, posts: their stated title.
+   - Skip headers, running heads, page numbers, author lists, and any
+     reversed/garbled text from arXiv side stamps.
+   - If the document genuinely has no clear title, return an empty string ""
+     and the caller will fall back to the filename.
+2. entities      — named entities with name, type, mentions, and context
    - name: canonical name of the entity (a string — do NOT use the entity name as a dict key)
    - type: PERSON | ORG | PRODUCT | CONCEPT | EVENT | LOCATION | OTHER
    - mentions: list of exact text spans from the source
    - context: 1-2 sentence description of this entity as discussed in the source
-2. concepts      — key concepts with name and description
+3. concepts      — key concepts with name and description
    - name: short canonical name of the concept
    - description: 1-2 sentence description of the concept
-3. claims        — specific factual claims
+4. claims        — specific factual claims
    - claim: the claim text itself (a string — full sentence)
    - confidence: "stated" (explicit) | "implied" (strongly suggested) | "speculative"
    - entities_involved: list of entity/concept names from your entities/concepts lists
-4. relationships — connections between entities/concepts
+5. relationships — connections between entities/concepts
    - from_entity: name of first entity/concept
    - to: name of second entity/concept
    - type: uses | competes_with | part_of | created_by | related_to | contradicts
    - description: 1-sentence explanation of how these entities relate
-5. contradictions — claims that contradict other sources or internal logic
+6. contradictions — claims that contradict other sources or internal logic
    - claim: what this source claims
    - against: what it contradicts (leave empty string if unknown)
-6. summary       — 2-4 sentence summary of the source
+7. summary       — 2-4 sentence summary of the source
 
 Keep lists focused: 5-15 entities, 3-10 concepts, 3-15 claims, 3-10 relationships.
 Each entity appears once. Stop as soon as the source is covered — do NOT

--- a/nlp-service/services/providers/deepseek.py
+++ b/nlp-service/services/providers/deepseek.py
@@ -14,8 +14,9 @@ DeepSeek API specifics (2026-05-05):
 - Usage fields differ from Gemini: ``prompt_tokens``, ``completion_tokens``,
   ``prompt_cache_hit_tokens``. The Gemini-shape ``thoughts_token_count`` is
   absent — DeepSeek folds reasoning into completion_tokens.
-- Discount window through 2026-05-31T15:59:00Z (UTC). After that the wall
-  clock flips to list pricing automatically; operators can override via
+- Pricing tracks DeepSeek's published list rates only. Promotional discount
+  windows are deliberately ignored (cap counter overestimates during a
+  discount, which is the safe side); operators can pin per-rate via the
   DEEPSEEK_*_USD_PER_M env vars.
 
 Like gemini.py, this module MUST NOT import services.llm_client at module
@@ -28,7 +29,6 @@ from __future__ import annotations
 import os
 import sys
 import time
-from datetime import datetime, timezone
 from typing import Any
 
 import httpx
@@ -52,27 +52,25 @@ _DEEPSEEK_RPM = int(os.environ.get("DEEPSEEK_RPM", "60"))
 # Pricing (DeepSeek V4 Pro, $/M tokens)
 # ---------------------------------------------------------------------------
 #
-# Discount window through 2026-05-31T15:59:00Z UTC. After that the code path
-# automatically flips to the list-pricing dict (no manual edit at deadline).
-# Each rate is ~4× the discount; still below Gemini Flash on equivalent calls
-# in our 28-call spike.
+# List prices per api-docs.deepseek.com/quick_start/pricing (2026-05-09 read).
+# We deliberately do NOT model the promotional 75%-off discount window — when
+# DeepSeek runs a discount, our cap counter overestimates real spend, which is
+# the safe side to err on (cap fires earlier than necessary, never later than
+# the user budget). Constants drift over time; the surfaced "Daily LLM spend"
+# in the UI is an estimate — reconcile with the provider's invoice for ground
+# truth, and treat any V5/V4-Lite/etc. switch as a reason to revisit this dict.
+# Operators can override per-rate via DEEPSEEK_INPUT_USD_PER_M /
+# DEEPSEEK_OUTPUT_USD_PER_M / DEEPSEEK_CACHE_USD_PER_M without touching code.
 
-DISCOUNT_UNTIL = datetime(2026, 5, 31, 15, 59, 0, tzinfo=timezone.utc)
-_PRICES_DISCOUNT = {"input": 0.07, "output": 0.27, "cache": 0.014}
-_PRICES_LIST     = {"input": 0.27, "output": 1.10, "cache": 0.054}
+_PRICES = {"input": 1.74, "output": 3.48, "cache": 0.0145}
 
 
 def _prices_now() -> dict[str, float]:
-    """Per-million-token prices honoring the discount window + env overrides.
-
-    Wall-clock comparison: assumes the container clock is UTC (Docker default).
-    Operators on non-UTC hosts can pin via DEEPSEEK_*_USD_PER_M.
-    """
-    base = _PRICES_DISCOUNT if datetime.now(timezone.utc) < DISCOUNT_UNTIL else _PRICES_LIST
+    """Per-million-token list prices, with optional env-var overrides."""
     return {
-        "input":  float(os.environ.get("DEEPSEEK_INPUT_USD_PER_M",  base["input"])),
-        "output": float(os.environ.get("DEEPSEEK_OUTPUT_USD_PER_M", base["output"])),
-        "cache":  float(os.environ.get("DEEPSEEK_CACHE_USD_PER_M",  base["cache"])),
+        "input":  float(os.environ.get("DEEPSEEK_INPUT_USD_PER_M",  _PRICES["input"])),
+        "output": float(os.environ.get("DEEPSEEK_OUTPUT_USD_PER_M", _PRICES["output"])),
+        "cache":  float(os.environ.get("DEEPSEEK_CACHE_USD_PER_M",  _PRICES["cache"])),
     }
 
 

--- a/nlp-service/services/providers/test_providers.py
+++ b/nlp-service/services/providers/test_providers.py
@@ -444,46 +444,23 @@ def test_deepseek_emits_log_line_with_cache_hit(monkeypatch, capsys):
 # ---------------------------------------------------------------------------
 
 
-def test_deepseek_prices_in_discount_window(monkeypatch):
-    """One second before DISCOUNT_UNTIL: prices use the discount table."""
+def test_deepseek_prices_default_to_list(monkeypatch):
+    """Without env overrides, _prices_now returns the published list prices.
+
+    Discount-window code was removed 2026-05-09 — the cap counter intentionally
+    over-estimates during DeepSeek promotional periods (safe side: cap fires
+    sooner than necessary, never later than the user budget). See deepseek.py
+    pricing block for the rationale.
+    """
     from services.providers import deepseek as D
     monkeypatch.delenv("DEEPSEEK_INPUT_USD_PER_M", raising=False)
     monkeypatch.delenv("DEEPSEEK_OUTPUT_USD_PER_M", raising=False)
     monkeypatch.delenv("DEEPSEEK_CACHE_USD_PER_M", raising=False)
 
-    import datetime as _dt
-    target = D.DISCOUNT_UNTIL - _dt.timedelta(seconds=1)
-
-    class _FakeDateTime(_dt.datetime):
-        @classmethod
-        def now(cls, tz=None): return target
-
-    monkeypatch.setattr(D, "datetime", _FakeDateTime)
     prices = D._prices_now()
-    assert prices["input"] == D._PRICES_DISCOUNT["input"]
-    assert prices["output"] == D._PRICES_DISCOUNT["output"]
-    assert prices["cache"] == D._PRICES_DISCOUNT["cache"]
-
-
-def test_deepseek_prices_after_discount_window(monkeypatch):
-    """One second after DISCOUNT_UNTIL: prices flip to the list table."""
-    from services.providers import deepseek as D
-    monkeypatch.delenv("DEEPSEEK_INPUT_USD_PER_M", raising=False)
-    monkeypatch.delenv("DEEPSEEK_OUTPUT_USD_PER_M", raising=False)
-    monkeypatch.delenv("DEEPSEEK_CACHE_USD_PER_M", raising=False)
-
-    import datetime as _dt
-    target = D.DISCOUNT_UNTIL + _dt.timedelta(seconds=1)
-
-    class _FakeDateTime(_dt.datetime):
-        @classmethod
-        def now(cls, tz=None): return target
-
-    monkeypatch.setattr(D, "datetime", _FakeDateTime)
-    prices = D._prices_now()
-    assert prices["input"] == D._PRICES_LIST["input"]
-    assert prices["output"] == D._PRICES_LIST["output"]
-    assert prices["cache"] == D._PRICES_LIST["cache"]
+    assert prices["input"] == D._PRICES["input"]
+    assert prices["output"] == D._PRICES["output"]
+    assert prices["cache"] == D._PRICES["cache"]
 
 
 def test_deepseek_prices_env_override_wins(monkeypatch):

--- a/nlp-service/tests/test_llm_contracts.py
+++ b/nlp-service/tests/test_llm_contracts.py
@@ -158,19 +158,33 @@ def test_lint_prompt_anchors_contradictions():
     assert "contradictions" in _LINT_SYSTEM_PROMPT
 
 
-# ── LLMExtractionResponse — flat 6-key shape ──────────────────────────────────
+# ── LLMExtractionResponse — flat 7-key shape ──────────────────────────────────
 
 def test_extraction_canonical():
     p = LLMExtractionResponse.model_validate({
+        "title": "Sample Paper Title",
         "entities": [], "concepts": [], "claims": [],
         "relationships": [], "contradictions": [], "summary": "x",
     })
     assert p.summary == "x"
+    assert p.title == "Sample Paper Title"
+
+
+def test_extraction_accepts_empty_title():
+    # Per the prompt: LLM returns "" when no title is derivable. Caller falls
+    # back to the filename-based title_hint via updateSourceTitle's no-op path.
+    p = LLMExtractionResponse.model_validate({
+        "title": "",
+        "entities": [], "concepts": [], "claims": [],
+        "relationships": [], "contradictions": [], "summary": "x",
+    })
+    assert p.title == ""
 
 
 def test_extraction_rejects_data_wrapper():
     with pytest.raises(ValidationError):
         LLMExtractionResponse.model_validate({"data": {
+            "title": "",
             "entities": [], "concepts": [], "claims": [],
             "relationships": [], "contradictions": [], "summary": "x",
         }})
@@ -182,7 +196,7 @@ def test_extraction_rejects_bare_list():
 
 
 def test_extraction_prompt_anchors_keys():
-    for key in ("entities", "concepts", "claims", "relationships", "summary"):
+    for key in ("title", "entities", "concepts", "claims", "relationships", "summary"):
         assert key in _EXTRACTION_SYSTEM_PROMPT, f"missing wrapper key: {key}"
 
 

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -15,7 +15,7 @@
 #
 # Stage state at commit 8:
 #   Stage 0  — REAL (cold start)
-#   Stage 1  — REAL (migration & schema sanity via /api/health, schema_version=23)
+#   Stage 1  — REAL (migration & schema sanity via /api/health, schema_version=24)
 #   Stage 4  — REAL (text connector stage end-to-end, no API key needed)
 #   Stage 11 — REAL (onboarding API canary via /stage → /finalize → pipeline)
 #   Stage 11b — REAL (finalize surfaces n8n-down as 503)
@@ -202,8 +202,8 @@ stage_1_migration_schema() {
         record_stage 1 REAL FAIL
         return 1
     fi
-    if ! echo "$response" | grep -q '"schema_version":23'; then
-        echo "  FAIL: schema_version != 23"
+    if ! echo "$response" | grep -q '"schema_version":24'; then
+        echo "  FAIL: schema_version != 24"
         record_stage 1 REAL FAIL
         return 1
     fi

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -11,7 +11,7 @@ except ImportError:
 
 DB_PATH = os.environ.get("DB_PATH", os.path.join("data", "db", "kompl.db"))
 
-SCHEMA_VERSION = 23
+SCHEMA_VERSION = 24
 
 SCHEMA_SQL = """
 -- Sources: raw ingested content metadata
@@ -632,6 +632,17 @@ def migrate():
         conn.execute("ALTER TABLE activity_log ADD COLUMN step_key TEXT")
         conn.execute("CREATE INDEX IF NOT EXISTS idx_activity_session ON activity_log(session_id)")
         conn.execute("CREATE INDEX IF NOT EXISTS idx_activity_session_step ON activity_log(session_id, step_key)")
+
+    if current < 24:
+        print("  applying migration v24 (page_plans.draft_error column)...")
+        # Per-plan error capture for draft + commit failures. Before v24, a
+        # failed page_plan recorded only draft_status='failed' with no
+        # explanation — operators had to grep app logs to diagnose.
+        # Session 29be62eb (15 source-summary HeadersTimeoutErrors) wasted
+        # 30+ min of debugging because the actual error was swallowed by the
+        # pLimit worker pool in /api/compile/draft. Nullable; pre-v24 rows
+        # stay NULL — no backfill possible.
+        conn.execute("ALTER TABLE page_plans ADD COLUMN draft_error TEXT")
 
     conn.execute(
         "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",


### PR DESCRIPTION
## Summary

- Adds a third arm to the "Retry N failed" button on the progress page — sources without an `extractions` row (per-source extract-failure shape; the orchestrator tolerates partial failures, marking the step `done (N failed)` and leaving the session `'completed'` with stranded sources).
- Extends `/api/compile/retry-failed` to count and trigger retry over the third counter.
- **Load-bearing piece:** orchestrator gains a `hasNewSources` check at `app/src/app/api/compile/run/route.ts` that re-plans when extracted sources extend beyond the existing plan set. Without this, the new extractions would land in the DB unused (planExists=true would skip plan), and the retry button would be a dead UI.
- Deliberately does NOT clear `page_plans` inside `retry-failed` — that would clobber the just-shipped failed-draft retry path. Plan re-runs are decided in the orchestrator, which is the correct semantic boundary.

## Test plan

- [x] `npm run test src/__tests__/retry-failed-items.test.ts` — 9/9 pass (7 existing + 2 new)
- [x] `npm run test` — 406/406 across 42 files
- [x] `npx tsc --noEmit` — clean
- [x] GitNexus impact on `runCompilePipeline` upstream — LOW (1 direct caller)
- [ ] CI green
- [ ] End-to-end smoke: stage 4 URLs with one likely to time out on extract; confirm progress page shows "Retry 1 failed", click retry, observe plan step transition `pending → running → done` (this is the load-bearing observable — without the orchestrator change, plan step would stay `pending`)