### PR TITLE
fix(ingest): distinguish YouTube IP-block from no-captions

### DIFF
--- a/app/src/__tests__/ingest-error-copy.test.ts
+++ b/app/src/__tests__/ingest-error-copy.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractIngestErrorCode,
+  friendlyIngestError,
+} from '../lib/ingest-error-copy';
+
+describe('extractIngestErrorCode', () => {
+  it('extracts the code from a wrapped FastAPI envelope', () => {
+    const raw = 'nlp_convert_failed: 422 {"detail":"youtube_transcript_blocked"}';
+    expect(extractIngestErrorCode(raw)).toBe('youtube_transcript_blocked');
+  });
+
+  it('extracts the code with whitespace around the colon', () => {
+    const raw = 'nlp_convert_failed: 422 {"detail" : "youtube_no_transcript"}';
+    expect(extractIngestErrorCode(raw)).toBe('youtube_no_transcript');
+  });
+
+  it('returns null when no envelope is present', () => {
+    expect(extractIngestErrorCode('nlp_unreachable: ECONNREFUSED')).toBeNull();
+    expect(extractIngestErrorCode('saved_link_no_content')).toBeNull();
+    expect(extractIngestErrorCode('')).toBeNull();
+  });
+});
+
+describe('friendlyIngestError', () => {
+  it('maps youtube_transcript_blocked to the proxy hint', () => {
+    const raw = 'nlp_convert_failed: 422 {"detail":"youtube_transcript_blocked"}';
+    expect(friendlyIngestError(raw)).toBe(
+      'YouTube blocked our IP — try a residential proxy'
+    );
+  });
+
+  it('maps youtube_no_transcript to the no-captions copy', () => {
+    const raw = 'nlp_convert_failed: 422 {"detail":"youtube_no_transcript"}';
+    expect(friendlyIngestError(raw)).toBe('Video has no captions');
+  });
+
+  it('maps youtube_metadata_unavailable', () => {
+    const raw = 'nlp_convert_failed: 422 {"detail":"youtube_metadata_unavailable"}';
+    expect(friendlyIngestError(raw)).toBe('YouTube metadata unavailable');
+  });
+
+  it('returns null for unknown codes so callers can fall back', () => {
+    const raw = 'nlp_convert_failed: 422 {"detail":"some_future_code"}';
+    expect(friendlyIngestError(raw)).toBeNull();
+  });
+
+  it('returns null when the wrapper has no JSON envelope at all', () => {
+    expect(friendlyIngestError('nlp_unreachable: fetch failed')).toBeNull();
+    expect(friendlyIngestError('saved_link_no_content')).toBeNull();
+  });
+});

--- a/app/src/lib/activity-events.tsx
+++ b/app/src/lib/activity-events.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import Link from 'next/link';
 import { RetryButton } from '@/components/RetryButton';
+import { friendlyIngestError } from './ingest-error-copy';
 
 // ── Shared shapes ──────────────────────────────────────────────────────────
 // FeedActivityRow is the CLIENT-facing row shape — includes server-joined
@@ -482,23 +483,19 @@ function renderOnboardingBlockedUrlsSkipped(row: FeedActivityRow): RowContent {
   };
 }
 
-function renderIngestUrlWarning(row: FeedActivityRow): RowContent {
-  const { str } = makeGetters(row);
-  const warning = str('warning');
-  const url = str('url');
-  const primary = warning === 'youtube_no_transcript'
-    ? <>YouTube transcript unavailable</>
-    : <>{warning ?? 'Ingest warning'}</>;
-  const secondary = url ? <span style={MONO_DIM}>{url}</span> : null;
-  return { primary, secondary, action: null, isError: false };
-}
-
 function renderIngestUrlFailed(row: FeedActivityRow): RowContent {
   const { str } = makeGetters(row);
   const url = str('url');
   const error_code = str('error_code');
+  const error = str('error');
   const name = url ?? '(unknown URL)';
-  const secondary = error_code ? <span style={MONO_ERR}>{error_code}</span> : null;
+  // Prefer the friendly copy for known FastAPI `detail` codes embedded in the
+  // wrapped error string (e.g. `nlp_convert_failed: 422 {"detail":"youtube_transcript_blocked"}`).
+  // Falls back to the bare outer error_code for everything else.
+  const friendly = error ? friendlyIngestError(error) : null;
+  const secondary = friendly
+    ? <span style={MONO_ERR}>{friendly}</span>
+    : error_code ? <span style={MONO_ERR}>{error_code}</span> : null;
   return {
     primary: <strong>{name}</strong>,
     secondary,
@@ -591,7 +588,6 @@ export const ACTIVITY_EVENTS = {
   // ── Onboarding v2 Phase 1 (no prior renderer cases) ─────────────────────
   onboarding_staged:      { key: 'onboarding_staged',      badge: { label: 'STAGED',     tone: 'dim'  as Tone }, render: renderOnboardingStaged },
   onboarding_blocked_urls_skipped: { key: 'onboarding_blocked_urls_skipped', badge: { label: 'SKIPPED', tone: 'dim' as Tone }, render: renderOnboardingBlockedUrlsSkipped },
-  ingest_url_warning:     { key: 'ingest_url_warning',     badge: { label: 'WARN',       tone: 'dim'  as Tone }, render: renderIngestUrlWarning },
   ingest_url_failed:      { key: 'ingest_url_failed',      badge: { label: 'URL FAIL',   tone: 'red'  as Tone }, render: renderIngestUrlFailed },
   ingest_file_failed:     { key: 'ingest_file_failed',     badge: { label: 'FILE FAIL',  tone: 'red'  as Tone }, render: renderIngestFileFailed },
   ingest_text_failed:     { key: 'ingest_text_failed',     badge: { label: 'TEXT FAIL',  tone: 'red'  as Tone }, render: renderIngestTextFailed },

--- a/app/src/lib/ingest-error-copy.ts
+++ b/app/src/lib/ingest-error-copy.ts
@@ -1,0 +1,40 @@
+/**
+ * Friendly-copy mapping for ingest_failures.error strings.
+ *
+ * The raw `error` column stores the wrapper produced in compile/steps/ingest-urls.ts:
+ *   `nlp_convert_failed: 422 {"detail":"<code>"}`
+ *
+ * — the wrapper prefix comes from callConvertUrl, and the inner JSON envelope
+ * is FastAPI's default body shape for `raise HTTPException(detail=...)`. The
+ * Saved Links page and the activity feed both want a short human-readable
+ * reason instead of either layer of that wrapper.
+ *
+ * Unknown codes fall through to a `null` friendly copy so the caller can keep
+ * its existing raw-truncation behaviour.
+ */
+
+const FRIENDLY: Record<string, string> = {
+  youtube_transcript_blocked: 'YouTube blocked our IP — try a residential proxy',
+  youtube_no_transcript: 'Video has no captions',
+  youtube_metadata_unavailable: 'YouTube metadata unavailable',
+};
+
+/**
+ * Extract the inner FastAPI `detail` code from a wrapped ingest error string.
+ * Returns the bare code (e.g. `youtube_transcript_blocked`) or null when the
+ * envelope isn't recognised.
+ */
+export function extractIngestErrorCode(raw: string): string | null {
+  const m = raw.match(/\{"detail"\s*:\s*"([a-z0-9_]+)"\}/i);
+  return m ? m[1] : null;
+}
+
+/**
+ * Map a raw ingest_failures.error string to a friendly one-liner.
+ * Returns null when the error doesn't map to a known code — callers should
+ * fall back to whatever raw display they were doing before.
+ */
+export function friendlyIngestError(raw: string): string | null {
+  const code = extractIngestErrorCode(raw);
+  return code ? FRIENDLY[code] ?? null : null;
+}

--- a/app/src/lib/saved-links.ts
+++ b/app/src/lib/saved-links.ts
@@ -20,6 +20,7 @@ import {
   clearPendingContent,
   type SavedLinkRow,
 } from './db';
+import { friendlyIngestError } from './ingest-error-copy';
 
 const PAGE_ID = 'saved-links';
 const PAGE_TITLE = 'Saved Links';
@@ -69,15 +70,20 @@ function buildMarkdown(links: SavedLinkRow[]): string {
     const titleSource = link.title ?? meta.title ?? link.source_url;
     const title = titleSource.replace(/[[\]]/g, '');
     const dateStr = link.date_saved ?? link.date_attempted.slice(0, 10);
-    // Trim verbose error prefixes so the page stays readable
-    const reason = link.error
-      .replace(
-        /^(nlp_unreachable|nlp_convert_failed|nlp_convert_timeout):\s*(\d+\s*)?/i,
-        ''
-      )
-      .replace(/^convert_url_failed:\s*\d+\s*/i, '')
-      .replace(/^ingest_failed:\s*/i, '')
-      .slice(0, 80);
+    // Prefer the friendly copy for known FastAPI `detail` codes — keeps the
+    // page readable when the raw error is a wrapped JSON envelope like
+    // `nlp_convert_failed: 422 {"detail":"youtube_transcript_blocked"}`.
+    // Falls back to the prefix-strip + truncate path for everything else.
+    const reason =
+      friendlyIngestError(link.error) ??
+      link.error
+        .replace(
+          /^(nlp_unreachable|nlp_convert_failed|nlp_convert_timeout):\s*(\d+\s*)?/i,
+          ''
+        )
+        .replace(/^convert_url_failed:\s*\d+\s*/i, '')
+        .replace(/^ingest_failed:\s*/i, '')
+        .slice(0, 80);
     lines.push(`- [${title}](${link.source_url}) — ${dateStr} · *${reason}*`);
     if (meta.description) {
       lines.push(`  > ${truncate(meta.description, 160)}`);

--- a/nlp-service/routers/conversion.py
+++ b/nlp-service/routers/conversion.py
@@ -363,22 +363,27 @@ def _fetch_youtube_transcript(video_id: str) -> tuple[list[dict[str, Any]], str 
         segments = chosen.fetch()
         return segments, getattr(chosen, "language_code", None)
     except (TranscriptsDisabled, NoTranscriptFound, VideoUnavailable, CouldNotRetrieveTranscript) as e:
-        # Package's own "no transcript" classes — clean signal.
+        # Package's own "no captions exist" classes — clean signal.
         raise HTTPException(
             status_code=422,
             detail="youtube_no_transcript",
         ) from e
     except Exception as e:
-        # Wider net: youtube-transcript-api leaks bare xml.etree.ElementTree.
-        # ParseError (and similar) when YouTube returns an empty body for the
-        # transcript XML fetch — e.g. rate-limit, bot-detection, or the IP
-        # being on YouTube's blocklist. From the user's perspective this is
-        # still "transcript unavailable", so route to Saved Links rather than
-        # bubbling a 500. See session-smoke test on `youtu.be/Ub3GoFaUcds` —
-        # list_transcripts succeeded, fetch() returned empty XML body.
+        # Reached when list_transcripts() SUCCEEDED (captions exist) but
+        # fetch() failed — almost always because YouTube returned HTTP 200
+        # with an empty body for the timedtext request. The classic
+        # cloud-IP / bot-detection fingerprint. The library leaks bare
+        # xml.etree.ElementTree.ParseError("no element found: line 1, column 0")
+        # in that case. Verified live on session-smoke `youtu.be/Ub3GoFaUcds`
+        # AND on Q7Ryv1M7CvI (2026-05-18) — both have auto-generated English
+        # tracks that browser tools can fetch but our datacenter IP cannot.
+        # Distinct from "no captions exist" so the app can show a workaround-
+        # specific message (use a residential proxy) instead of "video has
+        # no captions" (which would be wrong and would push the user to
+        # blame the video).
         raise HTTPException(
             status_code=422,
-            detail="youtube_no_transcript",
+            detail="youtube_transcript_blocked",
         ) from e
 
 

--- a/nlp-service/tests/test_conversion_youtube.py
+++ b/nlp-service/tests/test_conversion_youtube.py
@@ -228,11 +228,12 @@ def test_youtube_transcripts_disabled(monkeypatch, client):
 
 
 def test_youtube_fetch_raises_unexpected_exception(monkeypatch, client):
-    """youtube-transcript-api's fetch() can raise bare xml.etree.ElementTree.
-    ParseError when YouTube returns empty body (rate-limit / bot-detection / IP
-    block — observed live on session smoke test). The handler must catch any
-    exception during transcript retrieval and 422 to Saved Links rather than
-    bubble a 500."""
+    """list_transcripts() SUCCEEDS (captions exist) but fetch() raises bare
+    xml.etree.ElementTree.ParseError because YouTube returned an empty body —
+    the cloud-IP / bot-detection fingerprint. Must surface as the distinct
+    `youtube_transcript_blocked` code (NOT youtube_no_transcript) so the app
+    can show a workaround-specific message. Observed live on session smoke
+    test `youtu.be/Ub3GoFaUcds` and again on `Q7Ryv1M7CvI` (2026-05-18)."""
     import xml.etree.ElementTree as ET
     from youtube_transcript_api import YouTubeTranscriptApi
 
@@ -253,7 +254,7 @@ def test_youtube_fetch_raises_unexpected_exception(monkeypatch, client):
         json={"source_id": "src-empty-xml", "url": "https://youtu.be/Ub3GoFaUcds"},
     )
     assert res.status_code == 422
-    assert res.json()["detail"] == "youtube_no_transcript"
+    assert res.json()["detail"] == "youtube_transcript_blocked"
 
 
 # ─── /convert/url: metadata missing ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **nlp-service**: split `_fetch_youtube_transcript`'s catch-all into a distinct `422 youtube_transcript_blocked` (list_transcripts succeeded, fetch returned empty XML — the cloud-IP / bot-detection fingerprint) vs the existing `422 youtube_no_transcript` (named library exceptions: captions genuinely don't exist).
- **app**: new `lib/ingest-error-copy.ts` unwraps the FastAPI `{"detail":"..."}` envelope that was leaking literally into the Saved Links page, maps known codes to friendly one-liners ("YouTube blocked our IP — try a residential proxy" / "Video has no captions"), and is wired into both Saved Links and the activity feed. Drops a dead `renderIngestUrlWarning` renderer that was never logged from TS or n8n.

## Why

User tried to ingest `https://www.youtube.com/watch?v=Q7Ryv1M7CvI` — the video has an auto-generated English transcript, browser tools fetch it fine, but the nlp-service container's egress IP got HTTP 200 with body length 0 from both legacy and signed timedtext endpoints. The catch-all collapsed that into `youtube_no_transcript`, telling the user the video had no captions when the real fix is network-side (residential proxy, deferred per the existing inline comment about Webshare).

## Test plan

- [x] `pytest tests/test_conversion_youtube.py` — 27 passed, including the updated `test_youtube_fetch_raises_unexpected_exception` asserting the new code
- [x] Full nlp-service `pytest` — 237 passed
- [x] `vitest run src/__tests__/ingest-error-copy.test.ts` — 8 new tests passed
- [x] `vitest run src/__tests__/saved-links.test.ts` — no regression
- [x] `tsc --noEmit` clean
- [x] Live repro against the original failing URL: `POST /convert/url` now returns `422 {"detail":"youtube_transcript_blocked"}` (was: `youtube_no_transcript`)
- [ ] End-to-end onboarding ingest of the same URL produces a Saved Links entry that reads `*YouTube blocked our IP — try a residential proxy*` instead of the raw JSON envelope

## Out of scope

Webshare residential-proxy plumbing + `youtube-transcript-api` 1.0.3 → 1.2.4 bump. Both stay deferred — the library bump wouldn't help here (the empty-body block is YouTube-side regardless of library version: verified with signed-URL fetch + browser headers + session cookies all returning 0 bytes).