### PR TITLE
refactor(blocklist): skip blocked-host URLs per-item instead of aborting batch

### DIFF
--- a/app/src/__tests__/stage-blocklist.test.ts
+++ b/app/src/__tests__/stage-blocklist.test.ts
@@ -1,0 +1,183 @@
+/**
+ * POST /api/onboarding/stage — blocklist behaviour
+ *
+ * Regression: pre-fix, the route returned 422 on the first blocked-host
+ * (x.com / twitter.com / t.co) URL it saw, aborting the whole batch. A user
+ * importing 300 Chrome bookmarks lost all 300 because a handful linked to
+ * Twitter.
+ *
+ * Fix: blocked URLs are skipped per-item and reported via `blocked_count` +
+ * `blocked_urls` in the 200 response. The saved-link exemption is preserved
+ * (Twitter export's tweet permalinks must still ingest).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getDb } from '../lib/db';
+import { setupTestDb, type TestDbHandle } from './helpers/test-db';
+
+import { POST } from '../app/api/onboarding/stage/route';
+
+function post(body: unknown): Request {
+  return new Request('http://localhost/api/onboarding/stage', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+interface StageResponse {
+  session_id: string;
+  stage_ids: string[];
+  blocked_count: number;
+  blocked_urls?: string[];
+}
+
+describe('POST /api/onboarding/stage — blocklist behaviour', () => {
+  let handle: TestDbHandle;
+
+  beforeEach(() => {
+    handle = setupTestDb();
+  });
+
+  afterEach(() => {
+    handle.cleanup();
+  });
+
+  function countStagingRows(sessionId: string): number {
+    const row = getDb()
+      .prepare(`SELECT COUNT(*) AS n FROM collect_staging WHERE session_id = ?`)
+      .get(sessionId) as { n: number };
+    return row.n;
+  }
+
+  function activityRows(sessionId: string, actionType: string): Array<{
+    details: string | null;
+  }> {
+    // Stage route logs onboarding_staged / onboarding_blocked_urls_skipped
+    // with details JSON containing session_id. The activity_log table's
+    // session_id column is not populated by the stage route (it passes
+    // source_id: null and no session_id field), so we filter via the JSON.
+    return getDb()
+      .prepare(
+        `SELECT details FROM activity_log
+         WHERE action_type = ?
+           AND json_extract(details, '$.session_id') = ?`
+      )
+      .all(actionType, sessionId) as Array<{ details: string | null }>;
+  }
+
+  it('mixed batch: drops blocked URLs, stages the rest, reports blocked_count', async () => {
+    const sessionId = 'session-mixed';
+    const res = await POST(
+      post({
+        session_id: sessionId,
+        connector: 'url',
+        items: [
+          { url: 'https://example.com/good1' },
+          { url: 'https://x.com/user/status/1' },
+          { url: 'https://example.com/good2' },
+          { url: 'https://twitter.com/user/status/2' },
+        ],
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as StageResponse;
+    expect(body.stage_ids).toHaveLength(2);
+    expect(body.blocked_count).toBe(2);
+    expect(body.blocked_urls).toEqual([
+      'https://x.com/user/status/1',
+      'https://twitter.com/user/status/2',
+    ]);
+    expect(countStagingRows(sessionId)).toBe(2);
+
+    // Both activity rows should be present
+    expect(activityRows(sessionId, 'onboarding_staged')).toHaveLength(1);
+    expect(activityRows(sessionId, 'onboarding_blocked_urls_skipped')).toHaveLength(1);
+  });
+
+  it('all-blocked batch: returns 200 with empty stage_ids, no onboarding_staged log', async () => {
+    const sessionId = 'session-all-blocked';
+    const res = await POST(
+      post({
+        session_id: sessionId,
+        connector: 'url',
+        items: [
+          { url: 'https://x.com/a' },
+          { url: 'https://twitter.com/b' },
+          { url: 'https://t.co/c' },
+        ],
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as StageResponse;
+    expect(body.stage_ids).toEqual([]);
+    expect(body.blocked_count).toBe(3);
+    expect(body.blocked_urls).toEqual([
+      'https://x.com/a',
+      'https://twitter.com/b',
+      'https://t.co/c',
+    ]);
+    expect(countStagingRows(sessionId)).toBe(0);
+
+    // No onboarding_staged row (count would be 0 — don't emit noise)
+    expect(activityRows(sessionId, 'onboarding_staged')).toHaveLength(0);
+    // One onboarding_blocked_urls_skipped row
+    expect(activityRows(sessionId, 'onboarding_blocked_urls_skipped')).toHaveLength(1);
+  });
+
+  it("preserves saved-link exemption: x.com URL via connector='saved-link' is staged, not blocked", async () => {
+    const sessionId = 'session-saved-link';
+    const res = await POST(
+      post({
+        session_id: sessionId,
+        connector: 'saved-link',
+        items: [{ url: 'https://x.com/user/status/123' }],
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as StageResponse;
+    expect(body.stage_ids).toHaveLength(1);
+    expect(body.blocked_count).toBe(0);
+    expect(body.blocked_urls).toBeUndefined();
+    expect(countStagingRows(sessionId)).toBe(1);
+  });
+
+  it('empty items array still returns 422 (malformed request, distinct from filtered-empty)', async () => {
+    const res = await POST(
+      post({
+        session_id: 'session-empty',
+        connector: 'url',
+        items: [],
+      })
+    );
+    expect(res.status).toBe(422);
+  });
+
+  it('sample_urls in activity event is capped at 3 even when 10+ URLs are blocked', async () => {
+    const sessionId = 'session-cap';
+    const blockedItems = Array.from({ length: 10 }, (_, i) => ({
+      url: `https://x.com/user/status/${i}`,
+    }));
+    const res = await POST(
+      post({
+        session_id: sessionId,
+        connector: 'url',
+        items: blockedItems,
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as StageResponse;
+    expect(body.blocked_count).toBe(10);
+    // Response cap: 10 (so all of them in this case, but the cap is 10)
+    expect(body.blocked_urls).toHaveLength(10);
+
+    const rows = activityRows(sessionId, 'onboarding_blocked_urls_skipped');
+    expect(rows).toHaveLength(1);
+    const details = JSON.parse(rows[0].details ?? '{}') as {
+      count: number;
+      sample_urls: string[];
+    };
+    expect(details.count).toBe(10);
+    expect(details.sample_urls).toHaveLength(3);
+  });
+});

--- a/app/src/app/api/onboarding/stage/route.ts
+++ b/app/src/app/api/onboarding/stage/route.ts
@@ -18,11 +18,17 @@
  *   }
  *
  * Response:
- *   { session_id: string; stage_ids: string[] }
+ *   {
+ *     session_id: string;
+ *     stage_ids: string[];
+ *     blocked_count: number;
+ *     blocked_urls?: string[];   // present when blocked_count > 0, capped at 10
+ *   }
  *
- * No per-item failure path — staging is a local DB insert that shouldn't
- * fail under normal conditions. Whole-batch failure returns 500 with the
- * best available error message.
+ * Per-item failure path — blocked-host URLs (x.com, twitter.com, t.co) are
+ * skipped and reported via blocked_count/blocked_urls without aborting the
+ * batch. Other validation errors still 422 the whole batch (malformed-payload
+ * signal). DB-level batch failure still returns 500 with the underlying error.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -34,7 +40,7 @@ import {
   insertCollectStaging,
   type StagingConnector,
 } from '../../../../lib/db';
-import { isBlockedHost, URL_HOST_BLOCKED_MESSAGE } from '../../../../lib/url-blocklist';
+import { isBlockedHost } from '../../../../lib/url-blocklist';
 
 const VALID_CONNECTORS: readonly StagingConnector[] = [
   'url',
@@ -99,6 +105,7 @@ export async function POST(request: Request) {
   // this route does minimum gating so obviously-broken client calls fail
   // fast rather than at pipeline dispatch time.
   const validatedItems: Array<{ stage_id: string; item: Record<string, unknown> }> = [];
+  const blockedUrls: string[] = [];
   for (const raw of items) {
     if (typeof raw !== 'object' || raw === null) {
       return NextResponse.json(
@@ -118,15 +125,13 @@ export async function POST(request: Request) {
       // The URL connector is user-initiated ("paste a link"); saved-link is
       // internal plumbing that may legitimately carry an x.com tweet_url in
       // its metadata. Only block the user-initiated path.
+      //
+      // Per-item skip, not batch-abort: a Chrome bookmarks export with 300
+      // links and 3 Twitter URLs should stage 297 and report 3 as blocked,
+      // not reject the whole batch (regression from earlier 422 behaviour).
       if (connector === 'url' && isBlockedHost(item.url)) {
-        return NextResponse.json(
-          {
-            error: URL_HOST_BLOCKED_MESSAGE,
-            error_code: 'url_host_blocked',
-            blocked_url: item.url,
-          },
-          { status: 422 }
-        );
+        blockedUrls.push(item.url);
+        continue;
       }
     } else if (connector === 'file-upload') {
       if (typeof item.file_path !== 'string' || !item.file_path) {
@@ -181,27 +186,58 @@ export async function POST(request: Request) {
 
   // Phase 2 — batch insert in one transaction. Matters for bulk imports
   // (200-bookmark exports go from ~100 individual transactions to 1).
-  try {
-    getDb().transaction(() => {
-      for (const { stage_id, item } of validatedItems) {
-        insertCollectStaging({ stage_id, session_id, connector, payload: item });
-      }
-    })();
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : 'unknown';
-    return NextResponse.json(
-      { error: `stage_insert_failed: ${msg}` },
-      { status: 500 }
-    );
+  // Skipped when validatedItems is empty (all URLs filtered out) — no point
+  // opening a tx to do nothing.
+  if (validatedItems.length > 0) {
+    try {
+      getDb().transaction(() => {
+        for (const { stage_id, item } of validatedItems) {
+          insertCollectStaging({ stage_id, session_id, connector, payload: item });
+        }
+      })();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'unknown';
+      return NextResponse.json(
+        { error: `stage_insert_failed: ${msg}` },
+        { status: 500 }
+      );
+    }
   }
 
   // Observability: emitted once per batch so the feed shows a timeline of
-  // "user staged X at 14:02".
-  logActivity('onboarding_staged', {
-    source_id: null,
-    details: { session_id, connector, count: validatedItems.length },
-  });
+  // "user staged X at 14:02". Suppressed when count would be 0 (nothing
+  // staged) to keep the feed quiet.
+  if (validatedItems.length > 0) {
+    logActivity('onboarding_staged', {
+      source_id: null,
+      details: { session_id, connector, count: validatedItems.length },
+    });
+  }
+  if (blockedUrls.length > 0) {
+    logActivity('onboarding_blocked_urls_skipped', {
+      source_id: null,
+      details: {
+        session_id,
+        connector,
+        count: blockedUrls.length,
+        sample_urls: blockedUrls.slice(0, 3),
+      },
+    });
+  }
 
   const stage_ids = validatedItems.map((v) => v.stage_id);
-  return NextResponse.json({ session_id, stage_ids }, { status: 200 });
+  const response: {
+    session_id: string;
+    stage_ids: string[];
+    blocked_count: number;
+    blocked_urls?: string[];
+  } = {
+    session_id,
+    stage_ids,
+    blocked_count: blockedUrls.length,
+  };
+  if (blockedUrls.length > 0) {
+    response.blocked_urls = blockedUrls.slice(0, 10);
+  }
+  return NextResponse.json(response, { status: 200 });
 }

--- a/app/src/app/onboarding/[connector]/_shared.tsx
+++ b/app/src/app/onboarding/[connector]/_shared.tsx
@@ -39,7 +39,7 @@ export async function stageItems(
   sessionId: string,
   connector: 'url' | 'file-upload' | 'text' | 'saved-link' | 'paste',
   items: Array<Record<string, unknown>>,
-): Promise<{ stage_ids: string[] }> {
+): Promise<{ stage_ids: string[]; blocked_count: number; blocked_urls?: string[] }> {
   const res = await fetch('/api/onboarding/stage', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
@@ -48,13 +48,19 @@ export async function stageItems(
   const body = (await res.json()) as {
     session_id?: string;
     stage_ids?: string[];
+    blocked_count?: number;
+    blocked_urls?: string[];
     error?: string;
     error_code?: string;
   };
   if (!res.ok) {
     throw new Error(body.error_code ?? body.error ?? `stage_failed_${res.status}`);
   }
-  return { stage_ids: body.stage_ids ?? [] };
+  return {
+    stage_ids: body.stage_ids ?? [],
+    blocked_count: body.blocked_count ?? 0,
+    ...(body.blocked_urls ? { blocked_urls: body.blocked_urls } : {}),
+  };
 }
 
 // ── Navigation ────────────────────────────────────────────────────────────────

--- a/app/src/app/onboarding/[connector]/page.tsx
+++ b/app/src/app/onboarding/[connector]/page.tsx
@@ -576,7 +576,18 @@ function BookmarksConnector({ sessionId, connectors, connectorIdx, showToast, mo
     const reader = new FileReader();
     reader.onload = e => {
       const items = parseBookmarksHtml(e.target?.result as string);
-      setParsedItems(items);
+      // Client-side pre-filter so the user sees the "skipped Twitter URLs"
+      // toast immediately on file pick, not after the stage round-trip.
+      // Server still filters as backstop (handleIngest reads blocked_count
+      // from the response).
+      const valid = items.filter(it => !isBlockedHost(it.url));
+      const blockedCount = items.length - valid.length;
+      setParsedItems(valid);
+      if (blockedCount > 0) {
+        showToast(
+          `Skipping ${blockedCount} X/Twitter URL${blockedCount !== 1 ? 's' : ''} — use the Twitter bookmark connector for those.`
+        );
+      }
     };
     reader.readAsText(file);
   }
@@ -585,7 +596,7 @@ function BookmarksConnector({ sessionId, connectors, connectorIdx, showToast, mo
     if (parsedItems.length === 0) { showToast('No valid bookmarks found in this file.', 'error'); return; }
     setSaving(true);
     try {
-      await stageItems(
+      const { blocked_count } = await stageItems(
         sessionId,
         'url',
         parsedItems.map(({ url, title, dateSaved }) => ({
@@ -602,6 +613,14 @@ function BookmarksConnector({ sessionId, connectors, connectorIdx, showToast, mo
           },
         })),
       );
+      // Backstop: pre-filter at file-pick time should mean blocked_count is
+      // 0 here in practice. This covers stale-client / future-blocklist-drift
+      // cases where the server caught something the client missed.
+      if (blocked_count > 0) {
+        showToast(
+          `Skipping ${blocked_count} X/Twitter URL${blocked_count !== 1 ? 's' : ''} — use the Twitter bookmark connector for those.`
+        );
+      }
       navigateNext(sessionId, connectors, connectorIdx, router, mode);
     } catch (e) {
       showToast(toUserMessage(e instanceof Error ? e.message : 'stage_failed'), 'error');

--- a/app/src/lib/activity-events.tsx
+++ b/app/src/lib/activity-events.tsx
@@ -460,6 +460,28 @@ function renderOnboardingStaged(row: FeedActivityRow): RowContent {
   };
 }
 
+function renderOnboardingBlockedUrlsSkipped(row: FeedActivityRow): RowContent {
+  const { d, str, num } = makeGetters(row);
+  const count = num('count') ?? 0;
+  const connector = str('connector');
+  const samples = d && Array.isArray(d.sample_urls)
+    ? (d.sample_urls as unknown[]).filter((u): u is string => typeof u === 'string')
+    : [];
+  const label = count === 1 ? 'X/Twitter URL skipped' : 'X/Twitter URLs skipped';
+  const parts: string[] = [];
+  if (connector) parts.push(`via ${connector}`);
+  if (samples.length > 0) parts.push(samples.join(', '));
+  const secondary = parts.length > 0
+    ? <span style={MONO_DIM}>{parts.join(' · ')}</span>
+    : null;
+  return {
+    primary: <>{count} {label}</>,
+    secondary,
+    action: null,
+    isError: false,
+  };
+}
+
 function renderIngestUrlWarning(row: FeedActivityRow): RowContent {
   const { str } = makeGetters(row);
   const warning = str('warning');
@@ -568,6 +590,7 @@ export const ACTIVITY_EVENTS = {
   digest_sent:            { key: 'digest_sent',            badge: { label: 'DIGEST',     tone: 'neut' as Tone }, render: renderDigestSent },
   // ── Onboarding v2 Phase 1 (no prior renderer cases) ─────────────────────
   onboarding_staged:      { key: 'onboarding_staged',      badge: { label: 'STAGED',     tone: 'dim'  as Tone }, render: renderOnboardingStaged },
+  onboarding_blocked_urls_skipped: { key: 'onboarding_blocked_urls_skipped', badge: { label: 'SKIPPED', tone: 'dim' as Tone }, render: renderOnboardingBlockedUrlsSkipped },
   ingest_url_warning:     { key: 'ingest_url_warning',     badge: { label: 'WARN',       tone: 'dim'  as Tone }, render: renderIngestUrlWarning },
   ingest_url_failed:      { key: 'ingest_url_failed',      badge: { label: 'URL FAIL',   tone: 'red'  as Tone }, render: renderIngestUrlFailed },
   ingest_file_failed:     { key: 'ingest_file_failed',     badge: { label: 'FILE FAIL',  tone: 'red'  as Tone }, render: renderIngestFileFailed },

--- a/app/src/lib/service-errors.ts
+++ b/app/src/lib/service-errors.ts
@@ -24,7 +24,6 @@ export const SERVICE_ERROR_MESSAGES = {
   file_upload_failed:   'File upload failed. Try again.',
   no_items_staged:      'No sources to compile. Add at least one, or uncheck fewer items.',
   stage_insert_failed:  'Could not save your selection. Try again.',
-  url_host_blocked:     'x.com, twitter.com, and t.co URLs can\u2019t be auto-scraped \u2014 X gates all content behind JavaScript. Import tweets via the Twitter bookmark connector, or paste the post body into the Paste Text connector.',
   session_in_progress:  'Another compile session is already running. Wait for it to finish or cancel it from the progress page.',
 } as const;
 


### PR DESCRIPTION
## Summary
- Bookmark imports containing x.com / twitter.com / t.co URLs no longer reject the whole batch with HTTP 422. Blocked URLs are skipped per-item and reported via `blocked_count` / `blocked_urls` in the 200 response.
- BookmarksConnector pre-filters at file-pick time with an instant toast; server filter is the backstop.
- New `onboarding_blocked_urls_skipped` activity event renders the skip in the feed with a SKIPPED badge and sample URLs (capped at 3 in the event, 10 in the response).

## Test plan
- [ ] `cd app && npm test` — 45 files, 437 tests including new `stage-blocklist.test.ts` (mixed batch, all-blocked, saved-link exemption, empty-items 422, sample_urls cap)
- [ ] `cd app && npx tsc --noEmit`
- [ ] Manual: upload a Chrome bookmarks .html with 3-5 normal links + 2 Twitter links → toast "Skipping 2 X/Twitter URLs..." fires on file pick, review page shows only the normal links staged, Activity feed shows both `onboarding_staged` and `onboarding_blocked_urls_skipped` rows.
- [ ] Manual: confirm Twitter export connector still ingests tweet permalinks (`connector='saved-link'` exemption preserved)