### PR TITLE
feat: better page titles for file uploads (heuristic + LLM rescue)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,8 @@ docs/launch/
 # Agent instruction files (local only — not for public repo)
 CLAUDE.md
 AGENTS.md
+CURSOR.md
+docs/CURSOR.md
 tui-read.me
 tui-readme.md
 docs/Tui-read.me

--- a/app/src/__tests__/helpers/schema.sql
+++ b/app/src/__tests__/helpers/schema.sql
@@ -226,4 +226,4 @@ CREATE INDEX idx_relationship_mentions_source ON relationship_mentions(source_id
 CREATE INDEX idx_collect_staging_session ON collect_staging(session_id);
 CREATE INDEX idx_collect_staging_session_status ON collect_staging(session_id, status);
 
-INSERT INTO settings (key, value) VALUES ('schema_version', '24');
+INSERT INTO settings (key, value) VALUES ('schema_version', '25');

--- a/app/src/__tests__/helpers/schema.sql
+++ b/app/src/__tests__/helpers/schema.sql
@@ -1,4 +1,4 @@
--- Final schema for unit tests. Mirrors scripts/migrate.py at SCHEMA_VERSION=19.
+-- Final schema for unit tests. Mirrors scripts/migrate.py at SCHEMA_VERSION=25.
 -- If migrate.py changes, update this file. Tests will fail loudly on drift.
 
 CREATE TABLE sources (
@@ -14,7 +14,10 @@ CREATE TABLE sources (
   compile_status TEXT DEFAULT 'pending',
   compile_attempts INTEGER DEFAULT 0,
   compile_next_eligible_at DATETIME,
-  onboarding_session_id TEXT
+  onboarding_session_id TEXT,
+  -- v25: cascade-winner + LLM-rescue idempotency
+  title_source TEXT,
+  title_rescued_at TIMESTAMP
 );
 
 CREATE TABLE pages (

--- a/app/src/__tests__/source-title-source-roundtrip.test.ts
+++ b/app/src/__tests__/source-title-source-roundtrip.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Round-trip test for sources.title_source + title_rescued_at (v25 columns).
+ *
+ * Guards the contract between insertSource (writes) and getSource (reads):
+ *   - title_source persists exactly as written
+ *   - title_source omitted → stored as NULL (legacy/back-compat behavior)
+ *   - title_rescued_at is NULL on insert (only set by commit-3 rescue path)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+
+import { insertSource, getSource } from '../lib/db';
+import { setupTestDb, type TestDbHandle } from './helpers/test-db';
+
+describe('sources.title_source round-trip (v25)', () => {
+  let handle: TestDbHandle;
+
+  beforeEach(() => {
+    handle = setupTestDb();
+  });
+
+  afterEach(() => {
+    handle.cleanup();
+  });
+
+  it('persists title_source when provided', () => {
+    const source_id = randomUUID();
+    insertSource({
+      source_id,
+      title: 'Q3 Roadmap',
+      source_type: 'file',
+      source_url: null,
+      content_hash: 'sha256-abc',
+      file_path: `/data/raw/${source_id}.md.gz`,
+      metadata: null,
+      title_source: 'body_h1',
+    });
+    const row = getSource(source_id);
+    expect(row).not.toBeNull();
+    expect(row!.title_source).toBe('body_h1');
+    expect(row!.title_rescued_at).toBeNull();
+  });
+
+  it('stores NULL when title_source is omitted (back-compat for legacy callers)', () => {
+    const source_id = randomUUID();
+    insertSource({
+      source_id,
+      title: 'Old-style insert',
+      source_type: 'file',
+      source_url: null,
+      content_hash: 'sha256-xyz',
+      file_path: `/data/raw/${source_id}.md.gz`,
+      metadata: null,
+    });
+    const row = getSource(source_id);
+    expect(row).not.toBeNull();
+    expect(row!.title_source).toBeNull();
+    expect(row!.title_rescued_at).toBeNull();
+  });
+
+  it('round-trips all cascade-winner values used by ingest-* steps', () => {
+    // Catches typo/drift between the Python ConvertResponse Literal and JS
+    // call sites. Lower-cased string compare since the column is plain TEXT.
+    const values = [
+      'markitdown',
+      'body_h1',
+      'body_h2',
+      'filename',
+      'stem',
+      'firecrawl',
+      'firecrawl_url_fallback',
+      'github_api',
+      'youtube_oembed',
+      'paste',
+      'text_first_line',
+    ];
+    for (const v of values) {
+      const source_id = randomUUID();
+      insertSource({
+        source_id,
+        title: `t-${v}`,
+        source_type: 'file',
+        source_url: null,
+        content_hash: `sha256-${v}`,
+        file_path: `/data/raw/${source_id}.md.gz`,
+        metadata: null,
+        title_source: v,
+      });
+      const row = getSource(source_id);
+      expect(row?.title_source, `value=${v}`).toBe(v);
+    }
+  });
+
+  it('explicit null title_source stores as NULL (not the string "null")', () => {
+    const source_id = randomUUID();
+    insertSource({
+      source_id,
+      title: 'Explicit null',
+      source_type: 'file',
+      source_url: null,
+      content_hash: 'sha256-null',
+      file_path: `/data/raw/${source_id}.md.gz`,
+      metadata: null,
+      title_source: null,
+    });
+    const row = getSource(source_id);
+    expect(row?.title_source).toBeNull();
+  });
+});

--- a/app/src/__tests__/title-rescue-trigger.test.ts
+++ b/app/src/__tests__/title-rescue-trigger.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for the LLM-title rescue idempotency primitives (commit 3 of phase 2).
+ *
+ * The rescue trigger itself lives inline in /api/compile/extract/route.ts
+ * (line ~315) because lifting it would require restructuring the route's
+ * dependency tree. These tests cover:
+ *   1. updateSourceTitle({ markRescued: true }) atomically sets title +
+ *      title_rescued_at in a single UPDATE.
+ *   2. Idempotency: a rescued row's title_rescued_at survives subsequent
+ *      reads and is what the trigger checks to skip re-rescuing.
+ *   3. Round-tripping the trigger inputs (title_source values) to ensure
+ *      the trigger's predicate hits the correct branches.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+
+import { insertSource, getSource, updateSourceTitle } from '../lib/db';
+import { setupTestDb, type TestDbHandle } from './helpers/test-db';
+
+describe('updateSourceTitle — markRescued atomicity (v25)', () => {
+  let handle: TestDbHandle;
+
+  beforeEach(() => {
+    handle = setupTestDb();
+  });
+
+  afterEach(() => {
+    handle.cleanup();
+  });
+
+  function seedSource(overrides: { title?: string; title_source?: string | null } = {}): string {
+    const source_id = randomUUID();
+    insertSource({
+      source_id,
+      title: overrides.title ?? 'rec_000068',
+      source_type: 'file',
+      source_url: null,
+      content_hash: `sha256-${source_id.slice(0, 8)}`,
+      file_path: `/data/raw/${source_id}.md.gz`,
+      metadata: null,
+      title_source: overrides.title_source ?? 'filename',
+    });
+    return source_id;
+  }
+
+  it('markRescued: true sets title AND title_rescued_at in one UPDATE', () => {
+    const source_id = seedSource();
+    expect(getSource(source_id)?.title_rescued_at).toBeNull();
+
+    updateSourceTitle(source_id, 'TRADING STOCK MARKET INDICES', { markRescued: true });
+
+    const row = getSource(source_id);
+    expect(row?.title).toBe('TRADING STOCK MARKET INDICES');
+    expect(row?.title_rescued_at).not.toBeNull();
+    // SQLite datetime('now') returns "YYYY-MM-DD HH:MM:SS" — sanity-check shape.
+    expect(row?.title_rescued_at).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+  });
+
+  it('default (no opts) updates title only; title_rescued_at stays NULL', () => {
+    const source_id = seedSource();
+    updateSourceTitle(source_id, 'Plain Update');
+
+    const row = getSource(source_id);
+    expect(row?.title).toBe('Plain Update');
+    expect(row?.title_rescued_at).toBeNull();
+  });
+
+  it('markRescued: false is equivalent to omitting opts', () => {
+    const source_id = seedSource();
+    updateSourceTitle(source_id, 'No Mark', { markRescued: false });
+
+    expect(getSource(source_id)?.title_rescued_at).toBeNull();
+  });
+
+  it('empty/whitespace newTitle is a no-op (does not stamp title_rescued_at)', () => {
+    const source_id = seedSource();
+    updateSourceTitle(source_id, '   ', { markRescued: true });
+    updateSourceTitle(source_id, '', { markRescued: true });
+
+    const row = getSource(source_id);
+    expect(row?.title).toBe('rec_000068'); // unchanged
+    expect(row?.title_rescued_at).toBeNull(); // never stamped
+  });
+
+  it('caps title at 250 chars even when markRescued is set', () => {
+    const source_id = seedSource();
+    const long = 'A'.repeat(300);
+    updateSourceTitle(source_id, long, { markRescued: true });
+
+    const row = getSource(source_id);
+    expect(row?.title?.length).toBe(250);
+    expect(row?.title_rescued_at).not.toBeNull();
+  });
+
+  it('subsequent markRescued call refreshes title_rescued_at timestamp', () => {
+    // Real rescue trigger uses title_rescued_at as a "do not rescue again"
+    // marker — but if a caller does invoke updateSourceTitle({markRescued: true})
+    // a second time, the timestamp should advance (not stay frozen). This
+    // proves the column is a normal UPDATE target, not write-once.
+    const source_id = seedSource();
+    updateSourceTitle(source_id, 'First Rescue', { markRescued: true });
+    const first = getSource(source_id)?.title_rescued_at;
+
+    // Force a measurable gap so the second datetime('now') differs even at
+    // 1-second resolution.
+    const start = Date.now();
+    while (Date.now() - start < 1100) {
+      // busy-wait ~1.1s
+    }
+
+    updateSourceTitle(source_id, 'Second Rescue', { markRescued: true });
+    const second = getSource(source_id)?.title_rescued_at;
+
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(second!.localeCompare(first!)).toBeGreaterThan(0);
+  });
+});
+
+describe('title-rescue trigger inputs (v25)', () => {
+  let handle: TestDbHandle;
+
+  beforeEach(() => {
+    handle = setupTestDb();
+  });
+
+  afterEach(() => {
+    handle.cleanup();
+  });
+
+  // These tests sanity-check the round-trip of the values the rescue
+  // trigger predicate switches on. The trigger lives inline in extract/
+  // route.ts; lifting it for direct unit-test would require restructuring
+  // the route. These guards catch the silent failure where a value gets
+  // renamed in one place but not the other.
+
+  it('title_source="filename" + title_rescued_at=NULL is the rescue-eligible shape', () => {
+    const source_id = randomUUID();
+    insertSource({
+      source_id,
+      title: 'rec_000068',
+      source_type: 'file',
+      source_url: null,
+      content_hash: 'sha256-rec',
+      file_path: `/data/raw/${source_id}.md.gz`,
+      metadata: null,
+      title_source: 'filename',
+    });
+    const row = getSource(source_id);
+    expect(row?.title_source).toBe('filename');
+    expect(row?.title_rescued_at).toBeNull();
+  });
+
+  it('title_source="paste" marks user-curated → never rescued', () => {
+    const source_id = randomUUID();
+    insertSource({
+      source_id,
+      title: 'My pasted note',
+      source_type: 'paste',
+      source_url: null,
+      content_hash: 'sha256-paste',
+      file_path: `/data/raw/${source_id}.md.gz`,
+      metadata: null,
+      title_source: 'paste',
+    });
+    expect(getSource(source_id)?.title_source).toBe('paste');
+  });
+
+  it('once rescued, title_rescued_at persists across re-reads', () => {
+    const source_id = randomUUID();
+    insertSource({
+      source_id,
+      title: 'rec_000068',
+      source_type: 'file',
+      source_url: null,
+      content_hash: 'sha256-persist',
+      file_path: `/data/raw/${source_id}.md.gz`,
+      metadata: null,
+      title_source: 'filename',
+    });
+    updateSourceTitle(source_id, 'Real Paper Title', { markRescued: true });
+    expect(getSource(source_id)?.title_rescued_at).not.toBeNull();
+    // Second read returns same value (sanity)
+    expect(getSource(source_id)?.title_rescued_at).not.toBeNull();
+  });
+});

--- a/app/src/app/api/compile/extract/route.ts
+++ b/app/src/app/api/compile/extract/route.ts
@@ -74,6 +74,47 @@ function isGarbageTitle(s: string): boolean {
   return false;
 }
 
+// Known template/placeholder titles the LLM occasionally returns when a
+// document literally contains them as bold body text (e.g., a Word
+// document built from a corporate template with "Document Title" still
+// in the title field). Distinct from `isGarbageTitle`, which is a
+// FILENAME-shape heuristic — those patterns would FALSE-REJECT valid
+// synthesized titles like "2024_03_15_meeting" and FALSE-ACCEPT
+// "Document Title" (has a space). Keep this list lowercase + trimmed.
+const _LLM_TITLE_PLACEHOLDERS: ReadonlySet<string> = new Set([
+  'document title',
+  'untitled',
+  'untitled document',
+  'new document',
+  'document1',
+  'presentation1',
+  'book1',
+  'click here to edit title',
+  'title',
+  'heading',
+  'placeholder',
+  'sample document',
+]);
+function isLLMTitlePlaceholder(s: string): boolean {
+  return _LLM_TITLE_PLACEHOLDERS.has((s ?? '').trim().toLowerCase());
+}
+
+// Cascade-winner values that indicate the title came from a filename-shaped
+// source (no real document title was extracted). Rescue trigger fires for
+// these AND for any title that looks garbage by isGarbageTitle (catches
+// DOCX/PPTX rows where MarkItDown returned a junk author-set title like
+// "TestDoc" — title_source='markitdown' but the title is still garbage).
+const _RESCUE_TITLE_SOURCES: ReadonlySet<string> = new Set(['filename', 'stem']);
+
+// Sources whose title is user-curated, not document-derived. The extract
+// LLM's "real document title" doesn't apply — the user picked these
+// titles deliberately. Never overwrite them.
+const _USER_CURATED_TITLE_SOURCES: ReadonlySet<string> = new Set([
+  'paste',
+  'text_first_line',
+  'saved_link',
+]);
+
 const NLP_SERVICE_URL = process.env.NLP_SERVICE_URL ?? 'http://nlp-service:8000';
 
 // ── NLP service call helpers ──────────────────────────────────────────────────
@@ -304,16 +345,50 @@ export async function POST(request: Request) {
     });
     markSourceExtracted(source_id);
 
-    // Step 7a: title rescue. MarkItDown's PDF path doesn't extract a title
-    // (it's `absent for PDFs (MarkItDown 0.1.5 never sets it)`), so the
-    // ingest cascade falls through to the filename stub — leaving wiki
-    // pages titled `0611`, `2307.08768v4`, `12800_Vaughan-Williams`, etc.
-    // The extract LLM is now prompted to derive the document's real title;
-    // if it did, replace the filename stub with it. Source-summary pages
-    // (Rule 1 in plan/route.ts) then use the rescued title automatically.
+    // Step 7a: title rescue (phase 2). MarkItDown's PDF path doesn't extract
+    // a title, so the ingest cascade falls through to the filename stub —
+    // leaving wiki pages titled `0611`, `2307.08768v4`, `rec_000068`, etc.
+    // The extract LLM is prompted to derive the document's real title;
+    // if it did, replace the stub. Source-summary pages (Rule 1 in
+    // plan/route.ts) then use the rescued title automatically.
+    //
+    // Trigger conditions (ALL must hold):
+    //   - LLM returned a non-empty title that isn't a known placeholder
+    //   - source.title_rescued_at IS NULL (idempotency: don't re-rescue
+    //     on recompile, otherwise the wiki page title flips every cycle)
+    //   - source is NOT user-curated (paste/text_first_line/saved_link —
+    //     those titles are the user's intent, not document extraction)
+    //   - title_source ∈ {filename, stem} OR isGarbageTitle(source.title)
+    //     (the OR clause catches DOCX/PPTX where MarkItDown returned a junk
+    //     author-set title — title_source='markitdown' but title is junk)
+    //
+    // Pre-v25 rows have title_source = NULL: the source==null path falls
+    // through to the isGarbageTitle clause, preserving the legacy
+    // pre-phase-2 behavior exactly for already-ingested sources.
     const llmTitle = (llmOutput?.title ?? '').toString().trim();
-    if (llmTitle && isGarbageTitle(source.title) && !isGarbageTitle(llmTitle)) {
-      updateSourceTitle(source_id, llmTitle);
+    const titleSource = source.title_source ?? null;
+    const isUserCurated =
+      titleSource !== null && _USER_CURATED_TITLE_SOURCES.has(titleSource);
+    const isCascadeStub =
+      titleSource !== null && _RESCUE_TITLE_SOURCES.has(titleSource);
+    const shouldRescue =
+      llmTitle.length > 0 &&
+      !isLLMTitlePlaceholder(llmTitle) &&
+      source.title_rescued_at === null &&
+      !isUserCurated &&
+      (isCascadeStub || isGarbageTitle(source.title));
+    if (shouldRescue) {
+      updateSourceTitle(source_id, llmTitle, { markRescued: true });
+      logActivity('title_rescued', {
+        source_id,
+        session_id: source.onboarding_session_id ?? null,
+        step_key: 'extract',
+        details: {
+          old_title: source.title,
+          new_title: llmTitle,
+          title_source: titleSource,
+        },
+      });
     }
 
     // Step 7b: record entity/concept mentions for wiki-wide threshold counting.

--- a/app/src/app/api/health/route.ts
+++ b/app/src/app/api/health/route.ts
@@ -57,7 +57,7 @@ export async function GET() {
       nlpOk = nlpRes.ok;
     } catch { /* non-fatal */ }
 
-    const dbOk = dbWritable && allExpectedPresent && schemaVersion === 24;
+    const dbOk = dbWritable && allExpectedPresent && schemaVersion === 25;
 
     // status:'ok' requires DB healthy + NLP reachable + no vector backlog.
     // status:'degraded' means the app is serving but something needs attention.

--- a/app/src/lib/activity-events.tsx
+++ b/app/src/lib/activity-events.tsx
@@ -382,6 +382,26 @@ function renderChatDraftsCleaned(row: FeedActivityRow): RowContent {
   return { primary: <strong>{page_title}</strong>, secondary, action: null, isError: false };
 }
 
+function renderTitleRescued(row: FeedActivityRow): RowContent {
+  // Phase-2 LLM-title rescue: the extract LLM derived a real document title
+  // and replaced the filename stub. Show old → new so the user understands
+  // why the source's display name changed.
+  const { str } = makeGetters(row);
+  const oldTitle = str('old_title') ?? '…';
+  const newTitle = str('new_title') ?? str('title') ?? '…';
+  const source_id = row.source_id;
+  const primary = source_id
+    ? <Link href={`/source/${source_id}`} style={LINK_STYLE}><strong>{newTitle}</strong></Link>
+    : <strong>{newTitle}</strong>;
+  const secondary = (
+    <span style={MONO_DIM}>was: {oldTitle}</span>
+  );
+  const action = source_id
+    ? <Link href={`/source/${source_id}`} style={{ ...LINK_STYLE, color: 'var(--fg-dim)' }}>View</Link>
+    : null;
+  return { primary, secondary, action, isError: false };
+}
+
 function renderSavedLinkDismissed(row: FeedActivityRow): RowContent {
   const { str, num } = makeGetters(row);
   const count = num('count');
@@ -547,6 +567,7 @@ export const ACTIVITY_EVENTS = {
   source_unarchived:      { key: 'source_unarchived',      badge: { label: 'RESTORED',   tone: 'dim'  as Tone }, render: renderSourceStateChange(false) },
   source_deleted:         { key: 'source_deleted',         badge: { label: 'DELETED',    tone: 'red'  as Tone }, render: renderSourceStateChange(true) },
   source_recompile_triggered: { key: 'source_recompile_triggered', badge: { label: 'RETRYING', tone: 'dim' as Tone }, render: renderSourceRecompileTriggered },
+  title_rescued:          { key: 'title_rescued',          badge: { label: 'RETITLED',   tone: 'mint' as Tone }, render: renderTitleRescued },
   // ── Pages ───────────────────────────────────────────────────────────────
   page_deleted:           { key: 'page_deleted',           badge: { label: 'PAGE DEL',   tone: 'red'  as Tone }, render: renderPageDeleted },
   page_archived:          { key: 'page_archived',          badge: { label: 'ARCHIVED',   tone: 'dim'  as Tone }, render: renderPageArchived },

--- a/app/src/lib/compile/steps/ingest-files.ts
+++ b/app/src/lib/compile/steps/ingest-files.ts
@@ -116,6 +116,7 @@ export async function runIngestFilesStep(
         metadata: finalMetadata,
         compile_status: 'pending',
         onboarding_session_id: sessionId,
+        title_source: convertResult.title_source,
       });
 
       markStagingIngested(row.stage_id, sourceId);

--- a/app/src/lib/compile/steps/ingest-texts.ts
+++ b/app/src/lib/compile/steps/ingest-texts.ts
@@ -162,6 +162,7 @@ export async function runIngestTextsStep(
           metadata: payload.metadata ?? null,
           compile_status: 'pending',
           onboarding_session_id: sessionId,
+          title_source: 'paste',
         });
 
         markStagingIngested(row.stage_id, sourceId);
@@ -216,11 +217,29 @@ export async function runIngestTextsStep(
       const sourceId = randomUUID();
       const filePath = storeRawMarkdown(sourceId, payload.markdown);
       const source_type = payload.source_type_hint ?? 'text';
-      const title =
-        payload.title_hint ??
-        // Fall back to first non-empty line, capped at 80 chars.
-        payload.markdown.split('\n').find((l) => l.trim())?.trim().slice(0, 80) ??
-        'Untitled note';
+      // Title cascade for text rows — capture which step won so the rescue
+      // trigger in /api/compile/extract can skip these (text-derived titles
+      // are user-curated input, not document conversion output, so the LLM
+      // rescue would replace user intent with a synthesized title).
+      let title: string;
+      let title_source: string;
+      if (payload.title_hint) {
+        title = payload.title_hint;
+        title_source = 'paste'; // user-supplied caption (Upnote title, etc.)
+      } else {
+        const firstLine = payload.markdown
+          .split('\n')
+          .find((l) => l.trim())
+          ?.trim()
+          .slice(0, 80);
+        if (firstLine) {
+          title = firstLine;
+          title_source = 'text_first_line';
+        } else {
+          title = 'Untitled note';
+          title_source = 'text_first_line';
+        }
+      }
 
       insertSource({
         source_id: sourceId,
@@ -232,6 +251,7 @@ export async function runIngestTextsStep(
         metadata: payload.metadata ?? null,
         compile_status: 'pending',
         onboarding_session_id: sessionId,
+        title_source,
       });
 
       markStagingIngested(row.stage_id, sourceId);

--- a/app/src/lib/compile/steps/ingest-urls.ts
+++ b/app/src/lib/compile/steps/ingest-urls.ts
@@ -133,6 +133,7 @@ export async function runIngestUrlsStep(
         metadata: finalMetadata,
         compile_status: 'pending',
         onboarding_session_id: sessionId,
+        title_source: convertResult.title_source,
       });
 
       // YouTube + no-transcript is now rejected upstream by nlp-service

--- a/app/src/lib/db.ts
+++ b/app/src/lib/db.ts
@@ -171,6 +171,16 @@ export interface SourceRow {
   compile_status: string | null;
   compile_attempts: number | null;
   onboarding_session_id: string | null;
+  /** Which cascade step produced `title` at ingest time. Drives the
+   *  /api/compile/extract rescue trigger. NULL for rows ingested before
+   *  schema v25 — the rescue trigger falls back to the legacy
+   *  isGarbageTitle heuristic for those rows. */
+  title_source: string | null;
+  /** ISO timestamp when title was LLM-rescued in /api/compile/extract.
+   *  NULL = never rescued (or pre-v25 row). Used as the idempotency
+   *  marker so recompile does not re-rescue and rename the wiki page
+   *  on every cycle. */
+  title_rescued_at: string | null;
 }
 
 export interface ActivityRow {
@@ -239,6 +249,11 @@ export interface InsertSourceArgs {
   metadata: Record<string, unknown> | null;
   compile_status?: 'pending';
   onboarding_session_id?: string | null;
+  /** Cascade winner from the converter (file/url) or ingest-text path
+   *  ('paste'|'text_first_line'|'saved_link'). Optional for backward
+   *  compatibility with call sites not yet updated; missing → NULL,
+   *  which the rescue trigger treats as "legacy row, use isGarbageTitle". */
+  title_source?: string | null;
 }
 
 /**
@@ -251,10 +266,12 @@ export function insertSource(args: InsertSourceArgs): void {
     .prepare(
       `INSERT INTO sources
          (source_id, title, source_type, source_url, content_hash,
-          file_path, status, metadata, compile_status, onboarding_session_id)
+          file_path, status, metadata, compile_status, onboarding_session_id,
+          title_source)
        VALUES
          (@source_id, @title, @source_type, @source_url, @content_hash,
-          @file_path, 'active', @metadata, @compile_status, @onboarding_session_id)`
+          @file_path, 'active', @metadata, @compile_status, @onboarding_session_id,
+          @title_source)`
     )
     .run({
       source_id: args.source_id,
@@ -266,6 +283,7 @@ export function insertSource(args: InsertSourceArgs): void {
       metadata: args.metadata ? JSON.stringify(args.metadata) : null,
       compile_status: args.compile_status ?? 'pending',
       onboarding_session_id: args.onboarding_session_id ?? null,
+      title_source: args.title_source ?? null,
     });
 }
 
@@ -278,7 +296,8 @@ export function getSource(sourceId: string): SourceRow | null {
     .prepare(
       `SELECT source_id, title, source_type, source_url, content_hash,
               file_path, status, date_ingested, metadata,
-              compile_status, compile_attempts, onboarding_session_id
+              compile_status, compile_attempts, onboarding_session_id,
+              title_source, title_rescued_at
          FROM sources
          WHERE source_id = ?`
     )

--- a/app/src/lib/db.ts
+++ b/app/src/lib/db.ts
@@ -1073,19 +1073,45 @@ export function markSourceExtracted(sourceId: string): void {
     .run(sourceId);
 }
 
+export interface UpdateSourceTitleOpts {
+  /** When true, also stamp title_rescued_at = now in the same UPDATE.
+   *  Used by the /api/compile/extract LLM-title rescue path so subsequent
+   *  recompiles can detect "this title was already rescued" and skip
+   *  re-rescuing (prevents wiki-page title churn on every recompile). */
+  markRescued?: boolean;
+}
+
 /**
  * Replace a source's title — used when the extract LLM derives a real
  * document title for a source whose original title was a filename stub
  * (arxiv ID, digit-only filename, etc.). Trim + cap at 250 chars to keep
  * the column index lean. No-op on empty input.
+ *
+ * Atomic when markRescued is set: title and title_rescued_at update in
+ * the same UPDATE statement, so a crash between them cannot leave the
+ * row in a "rescued title, no marker → re-rescue forever" state.
  */
-export function updateSourceTitle(sourceId: string, newTitle: string): void {
+export function updateSourceTitle(
+  sourceId: string,
+  newTitle: string,
+  opts: UpdateSourceTitleOpts = {}
+): void {
   const trimmed = (newTitle ?? '').trim();
   if (!trimmed) return;
   const capped = trimmed.length > 250 ? trimmed.slice(0, 250) : trimmed;
-  openDb()
-    .prepare(`UPDATE sources SET title = ? WHERE source_id = ?`)
-    .run(capped, sourceId);
+  if (opts.markRescued) {
+    openDb()
+      .prepare(
+        `UPDATE sources
+            SET title = ?, title_rescued_at = datetime('now')
+          WHERE source_id = ?`
+      )
+      .run(capped, sourceId);
+  } else {
+    openDb()
+      .prepare(`UPDATE sources SET title = ? WHERE source_id = ?`)
+      .run(capped, sourceId);
+  }
 }
 
 /**

--- a/app/src/lib/nlp-convert.ts
+++ b/app/src/lib/nlp-convert.ts
@@ -12,10 +12,25 @@ const NLP_SERVICE_URL = process.env.NLP_SERVICE_URL ?? 'http://nlp-service:8000'
 // Types
 // ---------------------------------------------------------------------------
 
+export type TitleSource =
+  | 'markitdown'
+  | 'body_h1'
+  | 'body_h2'
+  | 'filename'
+  | 'stem'
+  | 'firecrawl'
+  | 'firecrawl_url_fallback'
+  | 'github_api'
+  | 'youtube_oembed';
+
 export interface ConvertResponse {
   source_id: string;
   source_type: string;
   title: string;
+  /** Which step of the title cascade produced `title`. Consumed by the
+   *  /api/compile/extract rescue trigger to decide whether to overwrite
+   *  the title with the LLM-derived one. Always populated. */
+  title_source: TitleSource;
   source_url: string | null;
   markdown: string;
   content_hash: string;

--- a/nlp-service/routers/conversion.py
+++ b/nlp-service/routers/conversion.py
@@ -137,6 +137,82 @@ _ALLOWED_EXTENSIONS = {
     ".wav",
 }
 
+# Junk-title fragments — case-insensitive substring match. Module-level so the
+# body-heading extractor and the existing MarkItDown title filter share one
+# source of truth.
+_JUNK_TITLE_FRAGMENTS: tuple[str, ...] = ("untitled", "microsoft word - ", "document1")
+
+# Body-heading title extraction (file-upload titles for filename-junk cases:
+# arxiv IDs, scan_*, IMG_*, Document1.docx, etc.).
+_BODY_TITLE_SCAN_CAP = 4096
+_H1_RE = re.compile(r"^#\s+(.+?)\s*$")
+_H2_RE = re.compile(r"^##\s+(.+?)\s*$")
+_FENCE_RE = re.compile(r"^\s*```")
+# Anchored on the full stripped line: "Abstract Algebra" must NOT match, but
+# "Abstract" alone must. Numbered prefixes ("1. Introduction") match too.
+_SECTION_LABEL_RE = re.compile(
+    r"^(abstract|introduction|contents|table of contents|references|"
+    r"bibliography|acknowledgements|appendix|index|chapter \d+|"
+    r"section \d+|\d+\.?\s*introduction|\d+\.?\s*abstract|"
+    r"conclusion|conclusions|summary|preface|foreword)$",
+    re.IGNORECASE,
+)
+
+
+def _extract_title_from_markdown_body(markdown: str) -> str | None:
+    """Pick the first usable H1/H2 from the start of a markdown document.
+
+    Used as the file-upload title cascade step between MarkItDown's extracted
+    title and the filename fallback. Operates on the first 4 KB only (latency
+    + safety cap) and skips fenced code blocks to avoid picking
+    ``# heading-inside-code`` as the title.
+
+    Invariant: on candidate reject, CONTINUES scanning at the SAME heading
+    level. ``# Abstract`` followed by ``# Real Title`` returns ``Real Title``,
+    not ``None``. (This is the subtle bug the original cascade design
+    introduced when it short-circuited from H1-reject straight to H2-only.)
+
+    Returns None when no heading passes validation; the caller's cascade then
+    falls through to the filename hint.
+    """
+    head = markdown[:_BODY_TITLE_SCAN_CAP]
+    h1_candidates: list[str] = []
+    h2_candidates: list[str] = []
+    in_fence = False
+    for line in head.splitlines():
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        m = _H1_RE.match(line)
+        if m:
+            h1_candidates.append(m.group(1))
+            continue
+        m = _H2_RE.match(line)
+        if m:
+            h2_candidates.append(m.group(1))
+
+    for cand in h1_candidates:
+        if _is_valid_body_title(cand):
+            return cand.strip()
+    for cand in h2_candidates:
+        if _is_valid_body_title(cand):
+            return cand.strip()
+    return None
+
+
+def _is_valid_body_title(candidate: str) -> bool:
+    stripped = candidate.strip()
+    if len(stripped) < 3 or len(stripped) > 200:
+        return False
+    lowered = stripped.lower()
+    if any(frag in lowered for frag in _JUNK_TITLE_FRAGMENTS):
+        return False
+    if _SECTION_LABEL_RE.match(stripped):
+        return False
+    return True
+
 
 # ---------------------------------------------------------------------------
 # Endpoint 1 — POST /convert/url

--- a/nlp-service/routers/conversion.py
+++ b/nlp-service/routers/conversion.py
@@ -34,7 +34,7 @@ import mimetypes
 import os
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +74,20 @@ class ConvertResponse(BaseModel):
     source_id: str
     source_type: str  # "url" or "file"
     title: str
+    # Which step of the title cascade produced `title`. Consumed by the
+    # JS rescue trigger in /api/compile/extract to decide whether to
+    # overwrite with the LLM-derived title. Always populated — never None.
+    title_source: Literal[
+        "markitdown",
+        "body_h1",
+        "body_h2",
+        "filename",
+        "stem",
+        "firecrawl",
+        "firecrawl_url_fallback",
+        "github_api",
+        "youtube_oembed",
+    ]
     source_url: str | None = None
     markdown: str
     content_hash: str
@@ -315,6 +329,7 @@ def _convert_github_repo(
         source_id=source_id,
         source_type="github-repo",
         title=full_name,
+        title_source="github_api",
         source_url=url,
         markdown=markdown,
         content_hash=content_hash,
@@ -566,6 +581,7 @@ def _convert_youtube(source_id: str, url: str) -> "ConvertResponse":
         source_id=source_id,
         source_type="url",
         title=meta["title"],
+        title_source="youtube_oembed",
         source_url=url,
         markdown=markdown,
         content_hash=content_hash,
@@ -615,12 +631,18 @@ def _try_markitdown_url(source_id: str, url: str) -> "ConvertResponse | None":
         return None
 
     title = result.title or url
+    # title_source: "markitdown" when MarkItDown extracted a real title from
+    # the page; "firecrawl_url_fallback" name reused here for the URL-as-title
+    # case (contract value covers any URL-fallback path, regardless of which
+    # converter produced it). Keeps the Literal small.
+    title_source = "markitdown" if result.title else "firecrawl_url_fallback"
     content_hash = hashlib.sha256(markdown.encode("utf-8")).hexdigest()
 
     return ConvertResponse(
         source_id=source_id,
         source_type="url",
         title=title,
+        title_source=title_source,
         source_url=url,
         markdown=markdown,
         content_hash=content_hash,
@@ -752,6 +774,7 @@ def convert_url(req: UrlConvertRequest) -> ConvertResponse:
     # The contract (2a) permits falling back to the request URL when Firecrawl
     # does not surface a title. This is the only allowed `or` fallback.
     title = fc_title if fc_title else req.url
+    title_source = "firecrawl" if fc_title else "firecrawl_url_fallback"
 
     # Prefer sourceURL, fall back to url. Both are the flat root `source_url`.
     fc_source_url = fc_metadata.get("sourceURL")
@@ -786,6 +809,7 @@ def convert_url(req: UrlConvertRequest) -> ConvertResponse:
         source_id=req.source_id,
         source_type="url",
         title=title,
+        title_source=title_source,
         source_url=fc_source_url,
         markdown=markdown,
         content_hash=content_hash,
@@ -879,6 +903,7 @@ def convert_file_path(req: FileConvertRequest) -> ConvertResponse:
         source_id=req.source_id,
         source_type="file",
         title=title,
+        title_source=title_source,
         source_url=None,
         markdown=markdown,
         content_hash=content_hash,

--- a/nlp-service/routers/conversion.py
+++ b/nlp-service/routers/conversion.py
@@ -826,18 +826,25 @@ def convert_file_path(req: FileConvertRequest) -> ConvertResponse:
         raise HTTPException(status_code=422, detail="markitdown_empty_output")
 
     # Title cascade (order matters):
-    #   1. MarkItDown's extracted title — present for DOCX/PPTX with core.xml
-    #      metadata; absent for PDFs (MarkItDown 0.1.5 never sets it for PDFs).
-    #   2. title_hint — original filename without extension, sent by the caller
-    #      before the UUID prefix was added. Guaranteed for browser uploads.
-    #   3. p.stem — last resort; will include the UUID prefix if title_hint
-    #      was omitted, which is the bug we're preventing.
+    #   1.   MarkItDown's extracted title — present for DOCX/PPTX with core.xml
+    #        metadata; absent for PDFs (MarkItDown 0.1.5 never sets it for PDFs).
+    #   1.5. Body-extracted heading — first usable H1 (then H2) in the first
+    #        4 KB of converted markdown. Fixes the dominant file-upload bug:
+    #        PDFs of academic papers, reports, etc. have a real title as the
+    #        first heading but a junk filename (arxiv IDs, scan_*, IMG_*,
+    #        Document1.docx). See _extract_title_from_markdown_body docstring
+    #        for the reject rules.
+    #   2.   title_hint — original filename without extension, sent by the
+    #        caller before the UUID prefix was added. Guaranteed for browser
+    #        uploads.
+    #   3.   p.stem — last resort; will include the UUID prefix if title_hint
+    #        was omitted, which is the bug we're preventing.
     # Discard obviously-junk titles from MarkItDown (Word's default filenames).
-    _JUNK_TITLE_FRAGMENTS = ("untitled", "microsoft word - ", "document1")
     markitdown_title = result.title or ""
     if any(frag in markitdown_title.lower() for frag in _JUNK_TITLE_FRAGMENTS):
         markitdown_title = ""
-    title = markitdown_title or req.title_hint or p.stem
+    body_title = _extract_title_from_markdown_body(markdown)
+    title = markitdown_title or body_title or req.title_hint or p.stem
 
     content_type = mimetypes.guess_type(str(p))[0] or "application/octet-stream"
 

--- a/nlp-service/routers/conversion.py
+++ b/nlp-service/routers/conversion.py
@@ -29,11 +29,14 @@ from __future__ import annotations
 
 import concurrent.futures
 import hashlib
+import logging
 import mimetypes
 import os
 import re
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 import httpx
 from fastapi import APIRouter, HTTPException
@@ -159,7 +162,7 @@ _SECTION_LABEL_RE = re.compile(
 )
 
 
-def _extract_title_from_markdown_body(markdown: str) -> str | None:
+def _extract_title_from_markdown_body(markdown: str) -> tuple[str, str] | None:
     """Pick the first usable H1/H2 from the start of a markdown document.
 
     Used as the file-upload title cascade step between MarkItDown's extracted
@@ -168,12 +171,15 @@ def _extract_title_from_markdown_body(markdown: str) -> str | None:
     ``# heading-inside-code`` as the title.
 
     Invariant: on candidate reject, CONTINUES scanning at the SAME heading
-    level. ``# Abstract`` followed by ``# Real Title`` returns ``Real Title``,
-    not ``None``. (This is the subtle bug the original cascade design
-    introduced when it short-circuited from H1-reject straight to H2-only.)
+    level. ``# Abstract`` followed by ``# Real Title`` returns
+    ``("Real Title", "body_h1")``, not ``None``. (This is the subtle bug the
+    original cascade design introduced when it short-circuited from H1-reject
+    straight to H2-only.)
 
-    Returns None when no heading passes validation; the caller's cascade then
-    falls through to the filename hint.
+    Returns ``(title, level)`` where level is ``"body_h1"`` or ``"body_h2"``,
+    or ``None`` when no heading passes validation; the caller's cascade then
+    falls through to the filename hint. The level is consumed by the
+    cascade-source telemetry log.
     """
     head = markdown[:_BODY_TITLE_SCAN_CAP]
     h1_candidates: list[str] = []
@@ -195,10 +201,10 @@ def _extract_title_from_markdown_body(markdown: str) -> str | None:
 
     for cand in h1_candidates:
         if _is_valid_body_title(cand):
-            return cand.strip()
+            return (cand.strip(), "body_h1")
     for cand in h2_candidates:
         if _is_valid_body_title(cand):
-            return cand.strip()
+            return (cand.strip(), "body_h2")
     return None
 
 
@@ -843,8 +849,27 @@ def convert_file_path(req: FileConvertRequest) -> ConvertResponse:
     markitdown_title = result.title or ""
     if any(frag in markitdown_title.lower() for frag in _JUNK_TITLE_FRAGMENTS):
         markitdown_title = ""
-    body_title = _extract_title_from_markdown_body(markdown)
+    body_result = _extract_title_from_markdown_body(markdown)
+    body_title = body_result[0] if body_result else ""
     title = markitdown_title or body_title or req.title_hint or p.stem
+
+    # Cascade-winner telemetry — informs the phase-2 decision (whether the
+    # residual filename/stem fallback rate justifies adding an LLM titling
+    # step). One of: markitdown | body_h1 | body_h2 | filename | stem.
+    if markitdown_title:
+        title_source = "markitdown"
+    elif body_result is not None:
+        title_source = body_result[1]
+    elif req.title_hint:
+        title_source = "filename"
+    else:
+        title_source = "stem"
+    logger.info(
+        "convert_file_path done source_id=%s title_source=%s ext=%s",
+        req.source_id,
+        title_source,
+        p.suffix.lower(),
+    )
 
     content_type = mimetypes.guess_type(str(p))[0] or "application/octet-stream"
 

--- a/nlp-service/tests/test_convert_file_path_title.py
+++ b/nlp-service/tests/test_convert_file_path_title.py
@@ -13,9 +13,17 @@ with on-disk .md fixtures rooted at a tmp_path-monkeypatched _DATA_ROOT.
 
 from __future__ import annotations
 
-import pytest
+from pathlib import Path
 
-from routers.conversion import _extract_title_from_markdown_body
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from routers import conversion as conv
+from routers.conversion import (
+    _extract_title_from_markdown_body,
+    router as conversion_router,
+)
 
 
 # ─── Unit tests for the helper ───────────────────────────────────────────────
@@ -86,5 +94,88 @@ def test_heading_with_trailing_whitespace_stripped():
     assert _extract_title_from_markdown_body("#   Spaced Title   \n") == "Spaced Title"
 
 
-# End-to-end tests through /convert/file-path are added in commit 2,
-# once the cascade is wired to call _extract_title_from_markdown_body.
+# ─── End-to-end tests through /convert/file-path ─────────────────────────────
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    # _DATA_ROOT controls safe_join; pointing it at tmp_path lets us stage
+    # fixture files under a real tmpdir without needing /data to exist.
+    monkeypatch.setattr(conv, "_DATA_ROOT", Path(tmp_path))
+    app = FastAPI()
+    app.include_router(conversion_router)
+    return TestClient(app), tmp_path
+
+
+def _write_md(root: Path, relpath: str, content: str) -> str:
+    p = root / relpath
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return relpath
+
+
+def test_e2e_md_h1_wins_over_filename(client):
+    tc, root = client
+    rel = _write_md(
+        root,
+        "junk_filename.md",
+        "# Attention Is All You Need\n\n## Abstract\n\nWe propose...",
+    )
+    res = tc.post(
+        "/convert/file-path",
+        json={
+            "source_id": "src-1",
+            "file_path": rel,
+            "title_hint": "junk_filename",
+        },
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["title"] == "Attention Is All You Need"
+
+
+def test_e2e_md_h1_beats_junk_filename(client):
+    tc, root = client
+    rel = _write_md(root, "Document1.md", "# Q3 Roadmap\n\nbody")
+    res = tc.post(
+        "/convert/file-path",
+        json={
+            "source_id": "src-2",
+            "file_path": rel,
+            "title_hint": "Document1",
+        },
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["title"] == "Q3 Roadmap"
+
+
+def test_e2e_no_h1_falls_through_to_hint(client):
+    tc, root = client
+    rel = _write_md(root, "real_doc.md", "Just body text, no headings here.\n")
+    res = tc.post(
+        "/convert/file-path",
+        json={
+            "source_id": "src-3",
+            "file_path": rel,
+            "title_hint": "real_doc",
+        },
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["title"] == "real_doc"
+
+
+def test_e2e_rejected_h1_falls_through_to_hint(client):
+    tc, root = client
+    rel = _write_md(root, "scan_2023.md", "# Abstract\n\nThis is a paper.\n")
+    res = tc.post(
+        "/convert/file-path",
+        json={
+            "source_id": "src-4",
+            "file_path": rel,
+            "title_hint": "scan_2023",
+        },
+    )
+    assert res.status_code == 200, res.text
+    # Body H1 "Abstract" is rejected as section-label; cascade falls through
+    # to title_hint (filename). This is the case phase 2 LLM titling would
+    # address; phase 1 acknowledges it as a known limit.
+    assert res.json()["title"] == "scan_2023"

--- a/nlp-service/tests/test_convert_file_path_title.py
+++ b/nlp-service/tests/test_convert_file_path_title.py
@@ -140,7 +140,9 @@ def test_e2e_md_h1_wins_over_filename(client, caplog):
             },
         )
     assert res.status_code == 200, res.text
-    assert res.json()["title"] == "Attention Is All You Need"
+    body = res.json()
+    assert body["title"] == "Attention Is All You Need"
+    assert body["title_source"] == "body_h1"
     assert any("title_source=body_h1" in r.message for r in caplog.records)
     assert any("source_id=src-1" in r.message for r in caplog.records)
 
@@ -157,7 +159,9 @@ def test_e2e_md_h1_beats_junk_filename(client):
         },
     )
     assert res.status_code == 200, res.text
-    assert res.json()["title"] == "Q3 Roadmap"
+    body = res.json()
+    assert body["title"] == "Q3 Roadmap"
+    assert body["title_source"] == "body_h1"
 
 
 def test_e2e_no_h1_falls_through_to_hint(client, caplog):
@@ -173,8 +177,43 @@ def test_e2e_no_h1_falls_through_to_hint(client, caplog):
             },
         )
     assert res.status_code == 200, res.text
-    assert res.json()["title"] == "real_doc"
+    body = res.json()
+    assert body["title"] == "real_doc"
+    assert body["title_source"] == "filename"
     assert any("title_source=filename" in r.message for r in caplog.records)
+
+
+def test_convert_response_requires_title_source():
+    # Pydantic extra='forbid' + Literal: missing title_source MUST raise,
+    # invalid value MUST raise. Guards against a future refactor that drops
+    # the field or accepts arbitrary strings (rule #2 — strict contracts).
+    from pydantic import ValidationError
+    from routers.conversion import ConvertResponse, ContentMetadata
+
+    base_kwargs = dict(
+        source_id="x",
+        source_type="file",
+        title="t",
+        source_url=None,
+        markdown="md",
+        content_hash="abc",
+        metadata=ContentMetadata(),
+    )
+
+    # Missing title_source → ValidationError
+    with pytest.raises(ValidationError):
+        ConvertResponse(**base_kwargs)
+
+    # Invalid title_source → ValidationError
+    with pytest.raises(ValidationError):
+        ConvertResponse(**base_kwargs, title_source="not_a_real_value")
+
+    # All valid values construct cleanly
+    for ts in (
+        "markitdown", "body_h1", "body_h2", "filename", "stem",
+        "firecrawl", "firecrawl_url_fallback", "github_api", "youtube_oembed",
+    ):
+        ConvertResponse(**base_kwargs, title_source=ts)
 
 
 def test_e2e_rejected_h1_falls_through_to_hint(client):
@@ -189,7 +228,9 @@ def test_e2e_rejected_h1_falls_through_to_hint(client):
         },
     )
     assert res.status_code == 200, res.text
+    body = res.json()
     # Body H1 "Abstract" is rejected as section-label; cascade falls through
     # to title_hint (filename). This is the case phase 2 LLM titling would
     # address; phase 1 acknowledges it as a known limit.
-    assert res.json()["title"] == "scan_2023"
+    assert body["title"] == "scan_2023"
+    assert body["title_source"] == "filename"

--- a/nlp-service/tests/test_convert_file_path_title.py
+++ b/nlp-service/tests/test_convert_file_path_title.py
@@ -1,0 +1,90 @@
+"""Tests for body-heading title extraction in /convert/file-path.
+
+Phase 1 of the file-upload title-quality work: extract the first usable H1/H2
+from the markdown body when MarkItDown didn't give us a title (PDFs always,
+DOCX with junk core.xml titles often) and before we fall back to the
+filename hint. Phase 2 (LLM fallback) is deferred until phase-1 telemetry
+shows the residual filename-fallback rate justifies it.
+
+Unit tests hit ``_extract_title_from_markdown_body`` directly.
+End-to-end tests exercise the cascade through ``POST /convert/file-path``
+with on-disk .md fixtures rooted at a tmp_path-monkeypatched _DATA_ROOT.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from routers.conversion import _extract_title_from_markdown_body
+
+
+# ─── Unit tests for the helper ───────────────────────────────────────────────
+
+
+def test_h1_wins_over_h2_abstract():
+    md = "# Attention Is All You Need\n\n## Abstract\n\nWe propose..."
+    assert _extract_title_from_markdown_body(md) == "Attention Is All You Need"
+
+
+def test_continues_past_rejected_h1():
+    md = "# Abstract\n\n# Real Title\n\nbody"
+    assert _extract_title_from_markdown_body(md) == "Real Title"
+
+
+def test_skips_fenced_code_block():
+    md = "```\n# not a heading\n```\n\n# Real Title\n"
+    assert _extract_title_from_markdown_body(md) == "Real Title"
+
+
+def test_numbered_section_label_rejected():
+    assert _extract_title_from_markdown_body("# 1. Introduction\n\nbody") is None
+
+
+def test_anchored_regex_no_false_reject_abstract_algebra():
+    md = "# Abstract Algebra\n\nA textbook by..."
+    assert _extract_title_from_markdown_body(md) == "Abstract Algebra"
+
+
+def test_cap_respected_heading_beyond_4kb():
+    md = ("x" * 5000) + "\n# Real Title\n"
+    assert _extract_title_from_markdown_body(md) is None
+
+
+@pytest.mark.parametrize("md", ["", "   \n\n  ", "\n\n\n"])
+def test_empty_and_whitespace_returns_none(md):
+    assert _extract_title_from_markdown_body(md) is None
+
+
+def test_too_short_heading_rejected():
+    assert _extract_title_from_markdown_body("# AB\n\nbody") is None
+
+
+def test_h2_fallback_when_no_h1():
+    assert _extract_title_from_markdown_body("## Real H2\n\nbody") == "Real H2"
+
+
+def test_junk_fragment_rejects_untitled():
+    assert _extract_title_from_markdown_body("# Untitled\n\nbody") is None
+
+
+def test_junk_fragment_rejects_document1():
+    assert _extract_title_from_markdown_body("# Document1\n\nbody") is None
+
+
+def test_continues_past_two_rejected_h1s():
+    md = "# Abstract\n\n# Introduction\n\n# Real Title\n"
+    assert _extract_title_from_markdown_body(md) == "Real Title"
+
+
+def test_h1_too_long_rejected_then_h2_used():
+    long_title = "x" * 201
+    md = f"# {long_title}\n\n## Good H2\n"
+    assert _extract_title_from_markdown_body(md) == "Good H2"
+
+
+def test_heading_with_trailing_whitespace_stripped():
+    assert _extract_title_from_markdown_body("#   Spaced Title   \n") == "Spaced Title"
+
+
+# End-to-end tests through /convert/file-path are added in commit 2,
+# once the cascade is wired to call _extract_title_from_markdown_body.

--- a/nlp-service/tests/test_convert_file_path_title.py
+++ b/nlp-service/tests/test_convert_file_path_title.py
@@ -31,17 +31,20 @@ from routers.conversion import (
 
 def test_h1_wins_over_h2_abstract():
     md = "# Attention Is All You Need\n\n## Abstract\n\nWe propose..."
-    assert _extract_title_from_markdown_body(md) == "Attention Is All You Need"
+    assert _extract_title_from_markdown_body(md) == (
+        "Attention Is All You Need",
+        "body_h1",
+    )
 
 
 def test_continues_past_rejected_h1():
     md = "# Abstract\n\n# Real Title\n\nbody"
-    assert _extract_title_from_markdown_body(md) == "Real Title"
+    assert _extract_title_from_markdown_body(md) == ("Real Title", "body_h1")
 
 
 def test_skips_fenced_code_block():
     md = "```\n# not a heading\n```\n\n# Real Title\n"
-    assert _extract_title_from_markdown_body(md) == "Real Title"
+    assert _extract_title_from_markdown_body(md) == ("Real Title", "body_h1")
 
 
 def test_numbered_section_label_rejected():
@@ -50,7 +53,7 @@ def test_numbered_section_label_rejected():
 
 def test_anchored_regex_no_false_reject_abstract_algebra():
     md = "# Abstract Algebra\n\nA textbook by..."
-    assert _extract_title_from_markdown_body(md) == "Abstract Algebra"
+    assert _extract_title_from_markdown_body(md) == ("Abstract Algebra", "body_h1")
 
 
 def test_cap_respected_heading_beyond_4kb():
@@ -68,7 +71,10 @@ def test_too_short_heading_rejected():
 
 
 def test_h2_fallback_when_no_h1():
-    assert _extract_title_from_markdown_body("## Real H2\n\nbody") == "Real H2"
+    assert _extract_title_from_markdown_body("## Real H2\n\nbody") == (
+        "Real H2",
+        "body_h2",
+    )
 
 
 def test_junk_fragment_rejects_untitled():
@@ -81,17 +87,20 @@ def test_junk_fragment_rejects_document1():
 
 def test_continues_past_two_rejected_h1s():
     md = "# Abstract\n\n# Introduction\n\n# Real Title\n"
-    assert _extract_title_from_markdown_body(md) == "Real Title"
+    assert _extract_title_from_markdown_body(md) == ("Real Title", "body_h1")
 
 
 def test_h1_too_long_rejected_then_h2_used():
     long_title = "x" * 201
     md = f"# {long_title}\n\n## Good H2\n"
-    assert _extract_title_from_markdown_body(md) == "Good H2"
+    assert _extract_title_from_markdown_body(md) == ("Good H2", "body_h2")
 
 
 def test_heading_with_trailing_whitespace_stripped():
-    assert _extract_title_from_markdown_body("#   Spaced Title   \n") == "Spaced Title"
+    assert _extract_title_from_markdown_body("#   Spaced Title   \n") == (
+        "Spaced Title",
+        "body_h1",
+    )
 
 
 # ─── End-to-end tests through /convert/file-path ─────────────────────────────
@@ -114,23 +123,26 @@ def _write_md(root: Path, relpath: str, content: str) -> str:
     return relpath
 
 
-def test_e2e_md_h1_wins_over_filename(client):
+def test_e2e_md_h1_wins_over_filename(client, caplog):
     tc, root = client
     rel = _write_md(
         root,
         "junk_filename.md",
         "# Attention Is All You Need\n\n## Abstract\n\nWe propose...",
     )
-    res = tc.post(
-        "/convert/file-path",
-        json={
-            "source_id": "src-1",
-            "file_path": rel,
-            "title_hint": "junk_filename",
-        },
-    )
+    with caplog.at_level("INFO", logger="routers.conversion"):
+        res = tc.post(
+            "/convert/file-path",
+            json={
+                "source_id": "src-1",
+                "file_path": rel,
+                "title_hint": "junk_filename",
+            },
+        )
     assert res.status_code == 200, res.text
     assert res.json()["title"] == "Attention Is All You Need"
+    assert any("title_source=body_h1" in r.message for r in caplog.records)
+    assert any("source_id=src-1" in r.message for r in caplog.records)
 
 
 def test_e2e_md_h1_beats_junk_filename(client):
@@ -148,19 +160,21 @@ def test_e2e_md_h1_beats_junk_filename(client):
     assert res.json()["title"] == "Q3 Roadmap"
 
 
-def test_e2e_no_h1_falls_through_to_hint(client):
+def test_e2e_no_h1_falls_through_to_hint(client, caplog):
     tc, root = client
     rel = _write_md(root, "real_doc.md", "Just body text, no headings here.\n")
-    res = tc.post(
-        "/convert/file-path",
-        json={
-            "source_id": "src-3",
-            "file_path": rel,
-            "title_hint": "real_doc",
-        },
-    )
+    with caplog.at_level("INFO", logger="routers.conversion"):
+        res = tc.post(
+            "/convert/file-path",
+            json={
+                "source_id": "src-3",
+                "file_path": rel,
+                "title_hint": "real_doc",
+            },
+        )
     assert res.status_code == 200, res.text
     assert res.json()["title"] == "real_doc"
+    assert any("title_source=filename" in r.message for r in caplog.records)
 
 
 def test_e2e_rejected_h1_falls_through_to_hint(client):

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -15,7 +15,7 @@
 #
 # Stage state at commit 8:
 #   Stage 0  — REAL (cold start)
-#   Stage 1  — REAL (migration & schema sanity via /api/health, schema_version=24)
+#   Stage 1  — REAL (migration & schema sanity via /api/health, schema_version=25)
 #   Stage 4  — REAL (text connector stage end-to-end, no API key needed)
 #   Stage 11 — REAL (onboarding API canary via /stage → /finalize → pipeline)
 #   Stage 11b — REAL (finalize surfaces n8n-down as 503)
@@ -202,8 +202,8 @@ stage_1_migration_schema() {
         record_stage 1 REAL FAIL
         return 1
     fi
-    if ! echo "$response" | grep -q '"schema_version":24'; then
-        echo "  FAIL: schema_version != 24"
+    if ! echo "$response" | grep -q '"schema_version":25'; then
+        echo "  FAIL: schema_version != 25"
         record_stage 1 REAL FAIL
         return 1
     fi

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -11,7 +11,7 @@ except ImportError:
 
 DB_PATH = os.environ.get("DB_PATH", os.path.join("data", "db", "kompl.db"))
 
-SCHEMA_VERSION = 24
+SCHEMA_VERSION = 25
 
 SCHEMA_SQL = """
 -- Sources: raw ingested content metadata
@@ -643,6 +643,32 @@ def migrate():
         # pLimit worker pool in /api/compile/draft. Nullable; pre-v24 rows
         # stay NULL — no backfill possible.
         conn.execute("ALTER TABLE page_plans ADD COLUMN draft_error TEXT")
+
+    if current < 25:
+        print("  applying migration v25 (sources.title_source + title_rescued_at)...")
+        # Phase-2 title-rescue infrastructure. title_source records which step
+        # of the convert/ingest cascade produced the title — one of:
+        #   markitdown | body_h1 | body_h2 | filename | stem
+        #   firecrawl | firecrawl_url_fallback
+        #   paste | text_first_line | saved_link
+        # The rescue trigger in /api/compile/extract uses this field to decide
+        # whether to overwrite the title with the LLM-derived one.
+        #
+        # title_rescued_at marks rows whose title was already LLM-rescued —
+        # prevents recompile-loop title churn (every recompile would re-rescue,
+        # re-rename the wiki page, and the user would see drift).
+        #
+        # Pre-v25 rows stay NULL on both; the extract route falls back to the
+        # legacy isGarbageTitle heuristic for them, preserving today's
+        # behaviour exactly.
+        existing_cols = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(sources)").fetchall()
+        }
+        if "title_source" not in existing_cols:
+            conn.execute("ALTER TABLE sources ADD COLUMN title_source TEXT")
+        if "title_rescued_at" not in existing_cols:
+            conn.execute("ALTER TABLE sources ADD COLUMN title_rescued_at TIMESTAMP")
 
     conn.execute(
         "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",


### PR DESCRIPTION
## Summary
- **Phase 1 (heuristic, zero LLM cost):** body-heading title extraction. PDFs of academic papers / DOCX with a real H1/H2 in the first 4 KB now get their actual title instead of the filename stub. E.g. `arxiv-2103.04561v2.pdf` → "Attention Is All You Need" automatically.
- **Phase 2 (LLM-title rescue via existing extract pass):** the case phase 1 can't reach — PDFs where the title is rendered as bold body text with no markdown heading (e.g. `rec_000068.pdf` → "TRADING STOCK MARKET INDICES. A SIMPLE APPROACH"). Widens the rescue trigger that already exists in /api/compile/extract, plus a new `title_source` column and idempotency marker so recompile doesn't flip the title every cycle.
- **No new endpoints, no new pipeline steps, no new LLM calls** — phase 2 piggybacks the extract LLM call that already runs per source and is already prompted to return the document's real title.

## What changes

### nlp-service
- `_extract_title_from_markdown_body()` in `routers/conversion.py`: scans first 4 KB, picks first usable H1 (then H2), skips fenced code blocks, rejects section labels (`Abstract`/`Introduction`/`Chapter \d+`/etc) with anchored regex + continues scanning on reject.
- `ConvertResponse.title_source: Literal[...]` — new always-populated field on the contract (Pydantic `extra='forbid'` + Literal guarantees exactly one of 9 known values).
- Cascade-winner telemetry log on every `/convert/file-path` call (informs whether phase-2 rescue rate justifies the column).

### app
- Schema migration v24 → v25: `sources.title_source TEXT` + `sources.title_rescued_at TIMESTAMP`.
- `insertSource` persists `title_source` from all 4 ingest paths (files/urls/paste/text-first-line). User-curated sources (`paste`, `text_first_line`, `saved_link`) marked so the rescue trigger skips them.
- `updateSourceTitle(id, title, { markRescued: true })`: atomic single-UPDATE for title + rescued_at marker (no two-write race).
- Rescue trigger rewired:
  - Fires when `title_rescued_at IS NULL` AND (`title_source` ∈ {`filename`, `stem`} OR `isGarbageTitle(source.title)`).
  - LLM output sanity-checked against an explicit placeholder denylist (`Document Title`, `Untitled`, `Document1`, `Presentation1`, etc.) — replaces the old `isGarbageTitle` reuse, which asymmetrically accepted placeholders and rejected valid synthesized titles.
  - Logs `title_rescued` activity event with old/new title.
- `.gitignore`: adds `CURSOR.md` / `docs/CURSOR.md` to the existing IDE-instructions block.

## Test plan
- [x] 16 unit tests for `_extract_title_from_markdown_body` (H1 wins, continue-scanning on reject, code-fence skip, section-label reject, 4 KB cap, etc.)
- [x] 5 end-to-end tests through `/convert/file-path` via FastAPI TestClient (real .md fixtures, real cascade)
- [x] 1 contract test asserting `ConvertResponse` validates all 9 `title_source` values and rejects missing/invalid
- [x] 4 round-trip tests for `insertSource` / `getSource` of `title_source` + `title_rescued_at`
- [x] 9 tests for `updateSourceTitle({ markRescued })` atomicity + idempotency
- [x] v25 migration smoke-tested against fresh in-memory DB: columns added, schema_version updated, second run is no-op
- [x] Full app vitest suite: 445/445 green
- [x] Full nlp-service pytest: 199/199 green (pre-existing `youtube_transcript_api` API-drift failures excluded — unrelated to this work)
- [ ] CI green
- [ ] Manual test: re-upload `rec_000068.pdf` → verify wiki page title is the real paper title, not `rec_000068`
- [ ] Manual test: recompile the same source → verify title doesn't flip (rescued_at marker fires)

## Background — why this exists
PDFs typically don't have title metadata MarkItDown can read, and filenames are routinely garbage (`Document1.docx`, `IMG_4521.pdf`, arxiv IDs, scan-IDs like `rec_000068`). The previous rescue trigger only caught a narrow set of digit-prefix patterns. This PR widens the trigger to the full "title_source landed on filename/stem" category and adds an idempotency marker so the rescue is one-shot per source.

The plan + debate + revision lived in `~/.claude/plans/2026-05-18-llm-title-for-file-uploads.md` and `~/.claude/plans/2026-05-18-llm-title-phase-2.md`. Both phases shipped under the 3-commit-per-phase discipline (commits + tests bundled tightly, no half-finished implementations).

## Files touched (7 commits)
```
f99d602 nlp-service/routers/conversion.py (helper) + tests
6a41f24 nlp-service/routers/conversion.py (cascade wiring) + e2e tests
1fc33d0 nlp-service/routers/conversion.py (telemetry log) + caplog assertions
f2fcbc1 nlp-service/routers/conversion.py (title_source field), scripts/migrate.py (v25), app/src/lib/nlp-convert.ts
8cfda10 app/src/lib/db.ts, app/src/lib/compile/steps/{ingest-files,ingest-urls,ingest-texts}.ts, app/src/__tests__/helpers/schema.sql, app/src/__tests__/source-title-source-roundtrip.test.ts
28075c3 app/src/app/api/compile/extract/route.ts, app/src/lib/db.ts, app/src/__tests__/title-rescue-trigger.test.ts
fcb6b74 .gitignore
```