### PR TITLE
chore(deps): bundle 5 dependabot bumps

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -45,6 +45,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v3
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # v3
         with:
           sarif_file: results.sarif

--- a/nlp-service/requirements.txt
+++ b/nlp-service/requirements.txt
@@ -11,7 +11,7 @@ markitdown[all]==0.1.5
 # watch-page HTML when no transcript exists (returns ~800 chars of footer
 # chrome — verified live on session 4a00f339). We need the transcript-vs-no-
 # transcript signal explicitly, which only the direct API exposes.
-youtube-transcript-api>=1.2.4,<2.0.0
+youtube-transcript-api>=1.0.0,<2.0.0
 # Commit 4: LLM compile. Use google-genai NOT google-generativeai (deprecated 2025-Q1).
 google-genai==2.4.0
 # Commit 4: async token-bucket rate limiter. Single uvicorn worker only —

--- a/nlp-service/requirements.txt
+++ b/nlp-service/requirements.txt
@@ -1,7 +1,7 @@
 # Kompl v2 nlp-service — commit 4. Pins per docs/research/2026-04-08-conversion-deps.md
 # and docs/research/2026-04-09-llm-compile.md.
 fastapi==0.136.1
-uvicorn[standard]==0.46.0
+uvicorn[standard]==0.47.0
 pydantic==2.13.4
 httpx==0.28.1
 markitdown[all]==0.1.5
@@ -11,9 +11,9 @@ markitdown[all]==0.1.5
 # watch-page HTML when no transcript exists (returns ~800 chars of footer
 # chrome — verified live on session 4a00f339). We need the transcript-vs-no-
 # transcript signal explicitly, which only the direct API exposes.
-youtube-transcript-api>=1.0.0,<2.0.0
+youtube-transcript-api>=1.2.4,<2.0.0
 # Commit 4: LLM compile. Use google-genai NOT google-generativeai (deprecated 2025-Q1).
-google-genai==1.73.1
+google-genai==2.4.0
 # Commit 4: async token-bucket rate limiter. Single uvicorn worker only —
 # InMemoryBucket is process-local; see research artifact section 3.
 pyrate-limiter==3.7.0
@@ -22,7 +22,7 @@ spacy==3.8.14
 rake-nltk==1.0.6
 yake==0.7.3
 keybert==0.9.0
-sentence-transformers==5.4.1
+sentence-transformers==5.5.0
 # pytextrank: spaCy-native TextRank component (PyPI-available, no git dep).
 pytextrank==3.3.0
 scikit-learn==1.8.0
@@ -32,7 +32,7 @@ nltk==3.9.4
 rapidfuzz>=3.14.5
 # Recovers truncated JSON from Gemini 2.5 Flash repetition-loop bug
 # (see issue in repo) — salvages already-billed output on parse failure.
-json-repair>=0.59.5
+json-repair>=0.59.10
 # Commit 7: Chroma vector store (embedded, no separate server). 0.4.x API:
 # PersistentClient, get_or_create_collection, cosine distance.
 chromadb==0.4.24


### PR DESCRIPTION
## Summary

Bundles 5 Dependabot PRs into one CI run. Supersedes #88, #89, #90, #92, #93. Closes #91 separately (chromadb blocker).

| PR | Change | Risk |
|---|---|---|
| #88 | `github/codeql-action` 4.35.4 → 4.35.5 | Bundle-size refactor, no runtime impact |
| #89 | `uvicorn[standard]` 0.46.0 → 0.47.0 | Eager-import is no-op for single-worker Docker |
| #89 | `sentence-transformers` 5.4.1 → 5.5.0 | Additive; CLS-pool fix N/A for all-MiniLM-L6-v2 mean-pool; no torch bump |
| #90 | `google-genai` 1.73.1 → 2.4.0 | Major bump — v2.0.0 breaking changes scoped to new Interactions API; Kompl uses only `generate_content` path |
| #92 | `youtube-transcript-api` floor `>=1.0.0` → `>=1.2.4` | Patch (WebshareProxyConfig dup `-rotate` suffix fix); we don't use proxies |
| #93 | `json-repair` floor `>=0.59.5` → `>=0.59.10` | Patch (balanced-brace handling in strings — directly improves Gemini-truncation salvage path) |

**Excluded:** #91 (`numpy <2` → `<3`) blocked by chromadb 0.4.24 pinning `numpy<2` (see [nlp-service/requirements.txt:39-41](https://github.com/tuirk/Kompl/blob/main/nlp-service/requirements.txt#L39-L41) comment about `np.float_` removal).

## google-genai 2.4.0 verification

Smoke-tested every API surface used in [nlp-service/services/providers/gemini.py](https://github.com/tuirk/Kompl/blob/main/nlp-service/services/providers/gemini.py) against the live Gemini API on `gemini-2.5-flash-lite` with 2.4.0 installed:

- `from google import genai` / `from google.genai import types, errors` (APIError, ClientError, ServerError)
- `genai.Client(api_key=...)`
- `types.GenerateContentConfig(max_output_tokens, temperature, thinking_config, system_instruction, response_mime_type, response_schema)`
- `types.ThinkingConfig(thinking_budget=0)`
- `client.models.generate_content(model, contents, config)` → `response.text`
- `response.candidates[0].finish_reason` → `STOP`
- `response.usage_metadata.{prompt,candidates,thoughts,cached_content}_token_count`
- `response_schema` + Pydantic `model_validate_json` round-trip
- `response_mime_type="application/json"` without schema (lint_scan path)
- `errors.APIError` raised on bad key, `code` attribute intact (400) — retry filter at `gemini.py:176-177` keeps working

All passed.

## Test plan

- [ ] CI green (one run instead of six)
- [ ] Integration-test stages 0,1,4,11,12,13,20,21 pass
- [ ] Eyeball nlp-service container boots