### PR TITLE
chore(deps): bundle #97 #98 #99 (codeql, buildx, @types/node)

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -90,7 +90,7 @@ jobs:
           df -h
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
       - name: Run integration test
         run: bash scripts/integration-test.sh

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -45,6 +45,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # v3
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0
         with:
           sarif_file: results.sarif

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -13,7 +13,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@types/node": "^24.12.3",
+        "@types/node": "^24.12.4",
         "typescript": "^6.0.3"
       }
     },
@@ -70,9 +70,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.12.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.3.tgz",
-      "integrity": "sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "typescript": "^6.0.3",
-    "@types/node": "^24.12.3"
+    "@types/node": "^24.12.4"
   },
   "overrides": {
     "hono": "^4.12.16",


### PR DESCRIPTION
## Summary
Bundles three low-risk Dependabot PRs into one CI run (same pattern as #94 / #105).

| Bump | PR | File |
|------|-----|------|
| `github/codeql-action` upload-sarif → 4.36.0 | #97 | `.github/workflows/scorecard.yml` |
| `docker/setup-buildx-action` → 4.1.0 | #99 | `.github/workflows/integration-test.yml` |
| `@types/node` 24.12.3 → 24.12.4 | #98 | `mcp-server/` |

## Why
Consolidate CI; all three are dev/CI-only with no runtime app impact.

## Test plan
- [ ] CI: unit-tests-* + integration-test + DCO