### PR TITLE
feat(onboarding): pre-stage health checks before compile

### DIFF
--- a/app/src/__tests__/api-health-route.test.ts
+++ b/app/src/__tests__/api-health-route.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { GET } from '../app/api/health/route';
+import { setupTestDb, type TestDbHandle } from './helpers/test-db';
+
+describe('GET /api/health — additive fields for pre-stage health table', () => {
+  let handle: TestDbHandle;
+
+  beforeEach(() => {
+    handle = setupTestDb();
+  });
+
+  afterEach(() => {
+    handle.cleanup();
+  });
+
+  async function getBody(): Promise<Record<string, unknown>> {
+    const res = await GET();
+    return (await res.json()) as Record<string, unknown>;
+  }
+
+  it('returns selected_compile_model as a non-empty string', async () => {
+    const body = await getBody();
+    expect(typeof body.selected_compile_model).toBe('string');
+    expect((body.selected_compile_model as string).length).toBeGreaterThan(0);
+  });
+
+  it('returns selected_compile_provider as gemini or deepseek', async () => {
+    const body = await getBody();
+    expect(['gemini', 'deepseek']).toContain(body.selected_compile_provider);
+  });
+
+  it('returns selected_compile_provider matching the model prefix', async () => {
+    const body = await getBody();
+    const model = body.selected_compile_model as string;
+    const provider = body.selected_compile_provider as string;
+    if (model.startsWith('deepseek-')) {
+      expect(provider).toBe('deepseek');
+    } else {
+      expect(provider).toBe('gemini');
+    }
+  });
+
+  it('returns integration_keys.firecrawl_present as a boolean', async () => {
+    const body = await getBody();
+    const integ = body.integration_keys as Record<string, unknown> | undefined;
+    expect(integ).toBeDefined();
+    expect(typeof integ!.firecrawl_present).toBe('boolean');
+  });
+
+  it('returns integration_keys.youtube_present as a boolean', async () => {
+    const body = await getBody();
+    const integ = body.integration_keys as Record<string, unknown> | undefined;
+    expect(typeof integ!.youtube_present).toBe('boolean');
+  });
+
+  it('integration_keys.firecrawl_present reflects process.env.FIRECRAWL_API_KEY', async () => {
+    const prev = process.env.FIRECRAWL_API_KEY;
+    process.env.FIRECRAWL_API_KEY = 'test-key-for-presence-check';
+    try {
+      const body = await getBody();
+      expect((body.integration_keys as Record<string, boolean>).firecrawl_present).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env.FIRECRAWL_API_KEY;
+      else process.env.FIRECRAWL_API_KEY = prev;
+    }
+  });
+
+  it('integration_keys.youtube_present reflects process.env.YOUTUBE_API_KEY absence', async () => {
+    const prev = process.env.YOUTUBE_API_KEY;
+    delete process.env.YOUTUBE_API_KEY;
+    try {
+      const body = await getBody();
+      expect((body.integration_keys as Record<string, boolean>).youtube_present).toBe(false);
+    } finally {
+      if (prev !== undefined) process.env.YOUTUBE_API_KEY = prev;
+    }
+  });
+});
+
+describe('GET /api/health — regression: stage-1 grep targets preserved', () => {
+  let handle: TestDbHandle;
+
+  beforeEach(() => {
+    handle = setupTestDb();
+  });
+
+  afterEach(() => {
+    handle.cleanup();
+  });
+
+  it('preserves all field names asserted by scripts/integration-test.sh stage 1', async () => {
+    const res = await GET();
+    const body = (await res.json()) as Record<string, unknown>;
+    // grep -q '"status":...'
+    expect(typeof body.status).toBe('string');
+    expect(['ok', 'degraded']).toContain(body.status);
+    // grep -q '"nlp_ok":...'
+    expect(typeof body.nlp_ok).toBe('boolean');
+    // grep -q '"db_writable":true'
+    expect(typeof body.db_writable).toBe('boolean');
+    // grep -q '"schema_version":...'
+    expect(typeof body.schema_version).toBe('number');
+    // grep -q '"table_count":...'
+    expect(typeof body.table_count).toBe('number');
+    // grep -q '"tables":[...,"ingest_failures",...]
+    expect(Array.isArray(body.tables)).toBe(true);
+    const tables = body.tables as string[];
+    expect(tables).toContain('ingest_failures');
+    expect(tables).toContain('vector_backfill_queue');
+    expect(tables).toContain('entity_mentions');
+    expect(tables).toContain('relationship_mentions');
+    // provider_keys still present with both LLM fields (Phase 1 pre-existing)
+    const pk = body.provider_keys as Record<string, unknown>;
+    expect(typeof pk.gemini_present).toBe('boolean');
+    expect(typeof pk.deepseek_present).toBe('boolean');
+  });
+});

--- a/app/src/__tests__/health-providers.test.ts
+++ b/app/src/__tests__/health-providers.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import {
+  INTEGRATION_KEYS,
+  LLM_PROVIDERS,
+  type IntegrationDef,
+  type LlmProviderDef,
+} from '../lib/health-providers';
+
+describe('LLM_PROVIDERS', () => {
+  it('includes gemini with GEMINI_API_KEY', () => {
+    const gemini = LLM_PROVIDERS.find((p) => p.id === 'gemini');
+    expect(gemini).toBeDefined();
+    expect(gemini!.envKey).toBe('GEMINI_API_KEY');
+    expect(gemini!.displayName.length).toBeGreaterThan(0);
+  });
+
+  it('includes deepseek with DEEPSEEK_API_KEY', () => {
+    const deepseek = LLM_PROVIDERS.find((p) => p.id === 'deepseek');
+    expect(deepseek).toBeDefined();
+    expect(deepseek!.envKey).toBe('DEEPSEEK_API_KEY');
+    expect(deepseek!.displayName.length).toBeGreaterThan(0);
+  });
+
+  it('every id maps to a unique provider', () => {
+    const ids = LLM_PROVIDERS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('shape satisfies LlmProviderDef at the type level', () => {
+    const sample: LlmProviderDef = LLM_PROVIDERS[0];
+    expect(typeof sample.id).toBe('string');
+    expect(typeof sample.envKey).toBe('string');
+    expect(typeof sample.displayName).toBe('string');
+  });
+});
+
+describe('INTEGRATION_KEYS', () => {
+  it('includes firecrawl with FIRECRAWL_API_KEY and amber severity', () => {
+    const fc = INTEGRATION_KEYS.find((k) => k.id === 'firecrawl');
+    expect(fc).toBeDefined();
+    expect(fc!.envKey).toBe('FIRECRAWL_API_KEY');
+    expect(fc!.severity).toBe('amber');
+    expect(fc!.breaks.length).toBeGreaterThan(0);
+    expect(fc!.displayName.length).toBeGreaterThan(0);
+  });
+
+  it('includes youtube with YOUTUBE_API_KEY and amber severity', () => {
+    const yt = INTEGRATION_KEYS.find((k) => k.id === 'youtube');
+    expect(yt).toBeDefined();
+    expect(yt!.envKey).toBe('YOUTUBE_API_KEY');
+    expect(yt!.severity).toBe('amber');
+    expect(yt!.breaks.length).toBeGreaterThan(0);
+    expect(yt!.displayName.length).toBeGreaterThan(0);
+  });
+
+  it('every id maps to a unique integration', () => {
+    const ids = INTEGRATION_KEYS.map((k) => k.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('shape satisfies IntegrationDef at the type level', () => {
+    const sample: IntegrationDef = INTEGRATION_KEYS[0];
+    expect(typeof sample.id).toBe('string');
+    expect(typeof sample.envKey).toBe('string');
+    expect(sample.severity).toBe('amber');
+  });
+});

--- a/app/src/__tests__/onboarding-health-evaluator.test.ts
+++ b/app/src/__tests__/onboarding-health-evaluator.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import {
+  evaluateHealth,
+  type HealthApiResponse,
+} from '../lib/onboarding-health-evaluator';
+
+const allGreen: HealthApiResponse = {
+  status: 'ok',
+  nlp_ok: true,
+  provider_keys: { gemini_present: true, deepseek_present: true },
+  selected_compile_model: 'gemini-2.5-flash',
+  selected_compile_provider: 'gemini',
+  integration_keys: { firecrawl_present: true, youtube_present: true },
+};
+
+describe('evaluateHealth — all checks pass', () => {
+  it('every row has status pass when everything is wired', () => {
+    const rows = evaluateHealth(allGreen);
+    expect(rows.every((r) => r.status === 'pass')).toBe(true);
+  });
+
+  it('returns exactly four rows in stable order', () => {
+    const rows = evaluateHealth(allGreen);
+    expect(rows.map((r) => r.id)).toEqual([
+      'nlp',
+      'selected_provider',
+      'firecrawl',
+      'youtube',
+    ]);
+  });
+
+  it('every row has a non-empty label', () => {
+    const rows = evaluateHealth(allGreen);
+    for (const r of rows) {
+      expect(r.label.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('evaluateHealth — nlp_unreachable', () => {
+  it('nlp_ok=false produces a red failing row with code nlp_unreachable', () => {
+    const rows = evaluateHealth({ ...allGreen, nlp_ok: false });
+    const r = rows.find((row) => row.id === 'nlp');
+    expect(r).toBeDefined();
+    expect(r!.severity).toBe('red');
+    expect(r!.status).toBe('fail');
+    expect(r!.code).toBe('nlp_unreachable');
+  });
+});
+
+describe('evaluateHealth — selected provider', () => {
+  it('gemini selected + gemini key missing → red fail (selected_provider_key_missing)', () => {
+    const rows = evaluateHealth({
+      ...allGreen,
+      selected_compile_model: 'gemini-2.5-flash',
+      selected_compile_provider: 'gemini',
+      provider_keys: { gemini_present: false, deepseek_present: true },
+    });
+    const r = rows.find((row) => row.id === 'selected_provider');
+    expect(r).toBeDefined();
+    expect(r!.severity).toBe('red');
+    expect(r!.status).toBe('fail');
+    expect(r!.code).toBe('selected_provider_key_missing');
+  });
+
+  it('gemini selected + gemini key present + deepseek absent → row passes (other provider irrelevant)', () => {
+    const rows = evaluateHealth({
+      ...allGreen,
+      selected_compile_model: 'gemini-2.5-flash',
+      selected_compile_provider: 'gemini',
+      provider_keys: { gemini_present: true, deepseek_present: false },
+    });
+    const r = rows.find((row) => row.id === 'selected_provider');
+    expect(r!.status).toBe('pass');
+  });
+
+  it('deepseek selected + deepseek key missing → red fail', () => {
+    const rows = evaluateHealth({
+      ...allGreen,
+      selected_compile_model: 'deepseek-v4-pro',
+      selected_compile_provider: 'deepseek',
+      provider_keys: { gemini_present: true, deepseek_present: false },
+    });
+    const r = rows.find((row) => row.id === 'selected_provider');
+    expect(r!.severity).toBe('red');
+    expect(r!.status).toBe('fail');
+    expect(r!.code).toBe('selected_provider_key_missing');
+  });
+
+  it('deepseek selected + deepseek key present + gemini absent → row passes', () => {
+    const rows = evaluateHealth({
+      ...allGreen,
+      selected_compile_model: 'deepseek-v4-pro',
+      selected_compile_provider: 'deepseek',
+      provider_keys: { gemini_present: false, deepseek_present: true },
+    });
+    const r = rows.find((row) => row.id === 'selected_provider');
+    expect(r!.status).toBe('pass');
+  });
+
+  it('row label includes the selected model name (visibility)', () => {
+    const rows = evaluateHealth({
+      ...allGreen,
+      selected_compile_model: 'deepseek-v4-pro',
+      selected_compile_provider: 'deepseek',
+    });
+    const r = rows.find((row) => row.id === 'selected_provider');
+    expect(r!.label).toContain('deepseek-v4-pro');
+  });
+});
+
+describe('evaluateHealth — integration keys (amber)', () => {
+  it('firecrawl missing → amber fail with code firecrawl_key_missing', () => {
+    const rows = evaluateHealth({
+      ...allGreen,
+      integration_keys: { firecrawl_present: false, youtube_present: true },
+    });
+    const r = rows.find((row) => row.id === 'firecrawl');
+    expect(r!.severity).toBe('amber');
+    expect(r!.status).toBe('fail');
+    expect(r!.code).toBe('firecrawl_key_missing');
+  });
+
+  it('youtube missing → amber fail with code youtube_key_missing', () => {
+    const rows = evaluateHealth({
+      ...allGreen,
+      integration_keys: { firecrawl_present: true, youtube_present: false },
+    });
+    const r = rows.find((row) => row.id === 'youtube');
+    expect(r!.severity).toBe('amber');
+    expect(r!.status).toBe('fail');
+    expect(r!.code).toBe('youtube_key_missing');
+  });
+});

--- a/app/src/__tests__/service-errors.test.ts
+++ b/app/src/__tests__/service-errors.test.ts
@@ -40,3 +40,32 @@ describe('getRemediation', () => {
     expect(getRemediation('totally_unknown_code')).toBeUndefined();
   });
 });
+
+describe('pre-stage health codes', () => {
+  it.each([
+    ['selected_provider_key_missing', /api key|provider/i],
+    ['firecrawl_key_missing',         /firecrawl/i],
+    ['youtube_key_missing',           /youtube/i],
+  ])('%s has full populated remediation matching %s', (code, titleHint) => {
+    const r = getRemediation(code);
+    expect(r).toBeDefined();
+    expect(r!.title.length).toBeGreaterThan(0);
+    expect(r!.body.length).toBeGreaterThan(0);
+    expect(r!.fix.length).toBeGreaterThan(0);
+    expect(r!.title).toMatch(titleHint);
+  });
+
+  it('firecrawl_key_missing.fix mentions FIRECRAWL_API_KEY env var', () => {
+    expect(getRemediation('firecrawl_key_missing')!.fix).toMatch(/FIRECRAWL_API_KEY/);
+  });
+
+  it('youtube_key_missing.fix mentions YOUTUBE_API_KEY env var', () => {
+    expect(getRemediation('youtube_key_missing')!.fix).toMatch(/YOUTUBE_API_KEY/);
+  });
+
+  it('selected_provider_key_missing.fix mentions both GEMINI_API_KEY and DEEPSEEK_API_KEY (provider-agnostic)', () => {
+    const fix = getRemediation('selected_provider_key_missing')!.fix;
+    expect(fix).toMatch(/GEMINI_API_KEY/);
+    expect(fix).toMatch(/DEEPSEEK_API_KEY/);
+  });
+});

--- a/app/src/__tests__/service-errors.test.ts
+++ b/app/src/__tests__/service-errors.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { getRemediation, toUserMessage } from '../lib/service-errors';
+
+describe('toUserMessage — back-compat shim', () => {
+  it('returns the title string for a known code (nlp_unreachable)', () => {
+    const msg = toUserMessage('nlp_unreachable');
+    expect(typeof msg).toBe('string');
+    expect(msg.length).toBeGreaterThan(0);
+    expect(msg).toMatch(/NLP/i);
+  });
+
+  it('returns the title string for n8n_unreachable', () => {
+    const msg = toUserMessage('n8n_unreachable');
+    expect(typeof msg).toBe('string');
+    expect(msg).toMatch(/n8n/i);
+  });
+
+  it('falls back to default for unknown code', () => {
+    expect(toUserMessage('totally_unknown_code')).toBe('Something went wrong');
+  });
+
+  it('falls back to custom fallback for unknown code', () => {
+    expect(toUserMessage('totally_unknown_code', 'custom fallback')).toBe('custom fallback');
+  });
+});
+
+describe('getRemediation', () => {
+  it('returns { title, body, fix } for nlp_unreachable', () => {
+    const r = getRemediation('nlp_unreachable');
+    expect(r).toBeDefined();
+    expect(typeof r!.title).toBe('string');
+    expect(typeof r!.body).toBe('string');
+    expect(typeof r!.fix).toBe('string');
+    expect(r!.title.length).toBeGreaterThan(0);
+    expect(r!.body.length).toBeGreaterThan(0);
+    expect(r!.fix.length).toBeGreaterThan(0);
+  });
+
+  it('returns undefined for unknown code', () => {
+    expect(getRemediation('totally_unknown_code')).toBeUndefined();
+  });
+});

--- a/app/src/app/api/health/route.ts
+++ b/app/src/app/api/health/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from 'next/server';
 import {
   dbPath,
+  getCompileModel,
   getDb,
   getPageCount,
+  getProviderForModel,
   getSchemaVersion,
   getVectorBacklogCount,
   listUserTables,
@@ -83,6 +85,19 @@ export async function GET() {
         provider_keys: {
           gemini_present: !!process.env.GEMINI_API_KEY,
           deepseek_present: !!process.env.DEEPSEEK_API_KEY,
+        },
+        // Pre-stage health table (consumed by /onboarding/health):
+        // - selected_compile_model + selected_compile_provider let the table
+        //   resolve which LLM provider key is the red gate for this session.
+        //   Per CLAUDE.md per-session model lock, the dashboard's "Settings"
+        //   value reflects the next-session choice; this route reads the same.
+        // - integration_keys are amber per INTEGRATION_KEYS severity (missing
+        //   key fails specific ingest types, not the whole pipeline).
+        selected_compile_model: getCompileModel(),
+        selected_compile_provider: getProviderForModel(getCompileModel()),
+        integration_keys: {
+          firecrawl_present: !!process.env.FIRECRAWL_API_KEY,
+          youtube_present: !!process.env.YOUTUBE_API_KEY,
         },
       },
       // Return 200 for both 'ok' and 'degraded' so Docker healthcheck only

--- a/app/src/app/onboarding/OnboardingClient.tsx
+++ b/app/src/app/onboarding/OnboardingClient.tsx
@@ -88,7 +88,10 @@ function OnboardingPageInner() {
     if (activeSelected.length === 0 || !sessionId) return;
     sessionStorage.setItem('kompl_connectors', JSON.stringify(activeSelected));
     sessionStorage.setItem('kompl_connector_idx', '0');
-    router.push(`/onboarding/${activeSelected[0]}?session_id=${sessionId}`);
+    // Pre-stage health step gates red configuration failures before the user
+    // walks through individual connector pages. HealthClient forwards to
+    // /onboarding/${connectors[0]} on its own Next click.
+    router.push(`/onboarding/health?session_id=${sessionId}`);
   }
 
   const heading = 'Select Your Data Sources.';

--- a/app/src/app/onboarding/health/HealthClient.tsx
+++ b/app/src/app/onboarding/health/HealthClient.tsx
@@ -1,0 +1,306 @@
+'use client';
+
+/**
+ * HealthClient — pre-stage health-check step rendered at /onboarding/health.
+ *
+ * Fetches /api/health once on mount and renders a table of deterministic
+ * configuration checks. Red rows block the Next button; amber rows let
+ * Next through with a note. No recheck button by design — fixing env vars
+ * requires `docker compose restart` which kills the browser session, so
+ * the user naturally re-enters this page on return.
+ *
+ * Connector-list handoff matches the source-selector pattern:
+ *   - kompl_connectors and kompl_connector_idx sessionStorage keys are
+ *     read here and forwarded to /onboarding/${connectors[0]}?session_id=…
+ *     when Next is clicked.
+ */
+
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { ArrowRight } from 'lucide-react';
+import {
+  evaluateHealth,
+  type HealthApiResponse,
+  type HealthRow,
+} from '@/lib/onboarding-health-evaluator';
+import { getRemediation } from '@/lib/service-errors';
+
+type FetchState =
+  | { kind: 'loading' }
+  | { kind: 'error'; message: string }
+  | { kind: 'ready'; rows: HealthRow[] };
+
+export default function HealthClient() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const sessionId = searchParams.get('session_id') ?? '';
+
+  const [state, setState] = useState<FetchState>({ kind: 'loading' });
+
+  useEffect(() => {
+    void fetch('/api/health', { cache: 'no-store' })
+      .then(async (r) => {
+        if (!r.ok && r.status !== 500) {
+          throw new Error(`HTTP ${r.status}`);
+        }
+        const body = (await r.json()) as HealthApiResponse;
+        setState({ kind: 'ready', rows: evaluateHealth(body) });
+      })
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        setState({ kind: 'error', message });
+      });
+  }, []);
+
+  const redFailing =
+    state.kind === 'ready'
+      ? state.rows.some((r) => r.severity === 'red' && r.status === 'fail')
+      : true;
+  const allPass =
+    state.kind === 'ready' ? state.rows.every((r) => r.status === 'pass') : false;
+  const amberFailing =
+    state.kind === 'ready'
+      ? state.rows.some((r) => r.severity === 'amber' && r.status === 'fail')
+      : false;
+
+  function handleNext() {
+    if (redFailing) return;
+    if (!sessionId) {
+      router.push('/onboarding');
+      return;
+    }
+    const raw = typeof window !== 'undefined' ? sessionStorage.getItem('kompl_connectors') : null;
+    if (!raw) {
+      router.push('/onboarding');
+      return;
+    }
+    let connectors: string[];
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      connectors = Array.isArray(parsed) ? (parsed as string[]) : [];
+    } catch {
+      connectors = [];
+    }
+    if (connectors.length === 0) {
+      router.push('/onboarding');
+      return;
+    }
+    router.push(`/onboarding/${connectors[0]}?session_id=${sessionId}`);
+  }
+
+  let nextLabel = 'Next';
+  if (state.kind === 'ready') {
+    if (allPass) nextLabel = 'Next — all clear';
+    else if (amberFailing && !redFailing) nextLabel = 'Next — amber notes acknowledged';
+  }
+
+  return (
+    <>
+      <main style={{ maxWidth: 1040, margin: '0 auto', padding: '1.5rem 40px 100px' }}>
+        {/* Header */}
+        <section style={{ display: 'flex', flexDirection: 'column', gap: 12, marginBottom: 32 }}>
+          <Link
+            href="/onboarding"
+            style={{
+              fontFamily: 'var(--font-body)',
+              fontWeight: 400,
+              fontSize: 10,
+              lineHeight: '15px',
+              letterSpacing: 3,
+              textTransform: 'uppercase',
+              color: 'var(--accent)',
+              textDecoration: 'none',
+            }}
+          >
+            ← Sources
+          </Link>
+          <h1 style={{
+            fontFamily: 'var(--font-heading)',
+            fontWeight: 700,
+            fontSize: 52,
+            lineHeight: '54px',
+            letterSpacing: '-2.6px',
+            color: 'var(--fg)',
+            margin: 0,
+          }}>
+            Pre-flight checks.
+          </h1>
+          <p style={{
+            fontFamily: 'var(--font-body)',
+            fontWeight: 400,
+            fontSize: 13,
+            lineHeight: '20px',
+            letterSpacing: '0.2px',
+            color: 'var(--fg-dim)',
+            margin: 0,
+          }}>
+            Resolve red rows before continuing. Amber rows are informational — proceed
+            only if you accept that those item types will fail at compile time.
+          </p>
+        </section>
+
+        {state.kind === 'loading' && (
+          <p style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--fg-muted)' }}>
+            Loading health checks…
+          </p>
+        )}
+
+        {state.kind === 'error' && (
+          <div style={{
+            borderLeft: '3px solid var(--danger)',
+            background: 'rgba(var(--danger-rgb),0.08)',
+            padding: 16,
+            fontFamily: 'var(--font-mono)',
+            fontSize: 12,
+            color: 'var(--danger)',
+          }}>
+            Could not reach /api/health ({state.message}). Is the app container running?
+          </div>
+        )}
+
+        {state.kind === 'ready' && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            {state.rows.map((row) => (
+              <HealthRowCard key={row.id} row={row} />
+            ))}
+          </div>
+        )}
+      </main>
+
+      {/* Inline footer nav — matches OnboardingClient.tsx pattern */}
+      <div style={{
+        position: 'fixed',
+        bottom: 32, left: 0, right: 0,
+        zIndex: 50,
+        background: 'var(--bg)',
+        borderTop: '1px solid rgba(var(--separator-rgb),0.12)',
+        padding: '16px 56px',
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+      }}>
+        <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 16 }}>
+          <span style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 10,
+            lineHeight: '15px',
+            letterSpacing: '1px',
+            textTransform: 'uppercase',
+            color: 'var(--fg-dim)',
+          }}>
+            {state.kind === 'ready'
+              ? redFailing
+                ? 'Resolve red rows to continue'
+                : allPass
+                  ? 'All checks passing'
+                  : 'Amber notes only'
+              : ' '}
+          </span>
+        </div>
+
+        <button
+          onClick={handleNext}
+          disabled={redFailing}
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 8,
+            padding: '16px 32px',
+            background: 'var(--accent)',
+            border: 'none',
+            opacity: redFailing ? 0.45 : 1,
+            cursor: redFailing ? 'not-allowed' : 'pointer',
+            fontFamily: 'var(--font-mono)',
+            fontWeight: 700,
+            fontSize: 10,
+            lineHeight: '15px',
+            letterSpacing: '1px',
+            textTransform: 'uppercase',
+            color: 'var(--accent-text)',
+          }}
+        >
+          {nextLabel}
+          <ArrowRight size={9} style={{ color: 'var(--accent-text)', flexShrink: 0 }} />
+        </button>
+      </div>
+    </>
+  );
+}
+
+function HealthRowCard({ row }: { row: HealthRow }) {
+  const failing = row.status === 'fail';
+  const remediation = failing ? getRemediation(row.code) : undefined;
+  const borderColor =
+    !failing                ? 'rgba(var(--accent-rgb),0.3)' :
+    row.severity === 'red'  ? 'var(--danger)' :
+                              'rgba(var(--warning-rgb),0.6)';
+  const labelColor =
+    !failing                ? 'var(--fg-secondary)' :
+    row.severity === 'red'  ? 'var(--danger)' :
+                              'var(--fg-secondary)';
+
+  return (
+    <div style={{
+      background: 'var(--bg-card)',
+      borderLeft: `3px solid ${borderColor}`,
+      padding: 16,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 8,
+    }}>
+      <div style={{
+        fontFamily: 'var(--font-mono)',
+        fontSize: 12,
+        letterSpacing: '0.3px',
+        color: labelColor,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+      }}>
+        <span aria-hidden="true">{failing ? '✗' : '✓'}</span>
+        <strong>{row.label}</strong>
+      </div>
+
+      {remediation && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginTop: 4 }}>
+          <p style={{
+            fontFamily: 'var(--font-body)',
+            fontSize: 13,
+            lineHeight: '20px',
+            color: 'var(--fg-secondary)',
+            margin: 0,
+          }}>
+            {remediation.title}
+          </p>
+          <p style={{
+            fontFamily: 'var(--font-body)',
+            fontSize: 12,
+            lineHeight: '18px',
+            color: 'var(--fg-dim)',
+            margin: 0,
+          }}>
+            {remediation.body}
+          </p>
+          <code style={{
+            display: 'block',
+            background: 'rgba(var(--separator-rgb),0.12)',
+            padding: '8px 10px',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 11,
+            lineHeight: '16px',
+            color: 'var(--fg)',
+            userSelect: 'text',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          }}>
+            {remediation.fix}
+          </code>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/app/onboarding/health/page.tsx
+++ b/app/src/app/onboarding/health/page.tsx
@@ -1,0 +1,25 @@
+/**
+ * /onboarding/health — pre-stage health check.
+ *
+ * Inserted between the source-selector (/onboarding) and the first
+ * connector page (/onboarding/[connector]). Renders a full-table view
+ * of deterministic configuration checks (NLP reachability, selected
+ * LLM provider key, ingest integration keys) and gates Next on red
+ * failures.
+ *
+ * dynamic = 'force-dynamic' disables static generation — the response
+ * to /api/health is per-deployment-config, not buildtime.
+ */
+
+import { Suspense } from 'react';
+import HealthClient from './HealthClient';
+
+export const dynamic = 'force-dynamic';
+
+export default function Page() {
+  return (
+    <Suspense fallback={null}>
+      <HealthClient />
+    </Suspense>
+  );
+}

--- a/app/src/lib/health-providers.ts
+++ b/app/src/lib/health-providers.ts
@@ -1,0 +1,61 @@
+/**
+ * Provider-agnostic registry of LLM providers and ingest integrations.
+ *
+ * Adding a new LLM provider or integration is one row in the relevant array.
+ * Consumed by:
+ *   - /api/health route (Phase 2): emits one boolean per envKey in
+ *     provider_keys / integration_keys.
+ *   - onboarding-health-evaluator (Phase 3): generates one HealthRow per
+ *     entry, mapped to a SERVICE_ERROR_MESSAGES code on failure.
+ *
+ * Severity policy:
+ *   - LLM_PROVIDERS rows are checked per-session (only the *selected*
+ *     compile model's provider is gated). The check is red.
+ *   - INTEGRATION_KEYS rows are always amber. A missing ingest key fails
+ *     specific item types (URLs, YouTube URLs) but does not block compile
+ *     start — the user's prerogative to skip those item types.
+ */
+
+export interface LlmProviderDef {
+  /** Stable identifier; matches getProviderForModel() output in db.ts. */
+  id: 'gemini' | 'deepseek';
+  /** Env var name read by both the app and nlp-service containers. */
+  envKey: 'GEMINI_API_KEY' | 'DEEPSEEK_API_KEY';
+  /** User-facing label rendered in the health table. */
+  displayName: string;
+}
+
+export interface IntegrationDef {
+  /** Stable identifier; matches the `${id}_key_missing` code in service-errors.ts. */
+  id: 'firecrawl' | 'youtube';
+  /** Env var name read by nlp-service. */
+  envKey: 'FIRECRAWL_API_KEY' | 'YOUTUBE_API_KEY';
+  /** Always amber — missing key gates specific ingest paths, not compile start. */
+  severity: 'amber';
+  /** One-line description of what fails when the key is missing. */
+  breaks: string;
+  /** User-facing label rendered in the health table. */
+  displayName: string;
+}
+
+export const LLM_PROVIDERS: readonly LlmProviderDef[] = [
+  { id: 'gemini',   envKey: 'GEMINI_API_KEY',   displayName: 'Gemini' },
+  { id: 'deepseek', envKey: 'DEEPSEEK_API_KEY', displayName: 'DeepSeek' },
+] as const;
+
+export const INTEGRATION_KEYS: readonly IntegrationDef[] = [
+  {
+    id: 'firecrawl',
+    envKey: 'FIRECRAWL_API_KEY',
+    severity: 'amber',
+    breaks: 'URL ingest (web pages)',
+    displayName: 'Firecrawl',
+  },
+  {
+    id: 'youtube',
+    envKey: 'YOUTUBE_API_KEY',
+    severity: 'amber',
+    breaks: 'YouTube URL ingest',
+    displayName: 'YouTube',
+  },
+] as const;

--- a/app/src/lib/onboarding-health-evaluator.ts
+++ b/app/src/lib/onboarding-health-evaluator.ts
@@ -1,0 +1,110 @@
+/**
+ * Pure-function evaluator for the /onboarding/health pre-stage table.
+ *
+ * Takes the raw /api/health JSON body and produces a stable, typed list
+ * of HealthRow records — one per check the table renders. The component
+ * layer maps each row to a remediation card via getRemediation(row.code).
+ *
+ * Severity model:
+ *   - 'red'   → blocks the page's Next button.
+ *   - 'amber' → informational only; Next remains enabled.
+ *
+ * Row contract:
+ *   - nlp                → red,   coded nlp_unreachable.
+ *   - selected_provider  → red,   coded selected_provider_key_missing.
+ *                          Resolves which provider's key matters from
+ *                          resp.selected_compile_provider.
+ *   - firecrawl          → amber, coded firecrawl_key_missing.
+ *   - youtube            → amber, coded youtube_key_missing.
+ *
+ * Provider/integration list is driven by LLM_PROVIDERS / INTEGRATION_KEYS
+ * in health-providers.ts. Adding a new provider or integration is one
+ * row there + a single switch arm here (mapping selected_compile_provider
+ * to the right *_present field on resp.provider_keys).
+ */
+
+import { INTEGRATION_KEYS, LLM_PROVIDERS } from './health-providers';
+
+export interface HealthApiResponse {
+  status: 'ok' | 'degraded';
+  nlp_ok: boolean;
+  provider_keys: { gemini_present: boolean; deepseek_present: boolean };
+  selected_compile_model: string;
+  selected_compile_provider: 'gemini' | 'deepseek';
+  integration_keys: { firecrawl_present: boolean; youtube_present: boolean };
+}
+
+export type Severity = 'red' | 'amber';
+
+export type HealthRowId = 'nlp' | 'selected_provider' | 'firecrawl' | 'youtube';
+
+export interface HealthRow {
+  id: HealthRowId;
+  severity: Severity;
+  /** SERVICE_ERROR_MESSAGES key — resolves to remediation via getRemediation(). */
+  code: string;
+  status: 'pass' | 'fail';
+  /** Table-row label (what the user sees on the left of each row). */
+  label: string;
+}
+
+function resolveProviderKeyPresent(resp: HealthApiResponse): boolean {
+  switch (resp.selected_compile_provider) {
+    case 'gemini':
+      return resp.provider_keys.gemini_present;
+    case 'deepseek':
+      return resp.provider_keys.deepseek_present;
+    default:
+      return false;
+  }
+}
+
+function providerDisplayName(provider: HealthApiResponse['selected_compile_provider']): string {
+  const def = LLM_PROVIDERS.find((p) => p.id === provider);
+  return def?.displayName ?? provider;
+}
+
+export function evaluateHealth(resp: HealthApiResponse): HealthRow[] {
+  const rows: HealthRow[] = [];
+
+  rows.push({
+    id: 'nlp',
+    severity: 'red',
+    code: 'nlp_unreachable',
+    status: resp.nlp_ok ? 'pass' : 'fail',
+    label: 'NLP service reachable',
+  });
+
+  const providerKeyPresent = resolveProviderKeyPresent(resp);
+  rows.push({
+    id: 'selected_provider',
+    severity: 'red',
+    code: 'selected_provider_key_missing',
+    status: providerKeyPresent ? 'pass' : 'fail',
+    label: `Selected model (${resp.selected_compile_model}) — ${providerDisplayName(resp.selected_compile_provider)} API key`,
+  });
+
+  // One amber row per INTEGRATION_KEYS entry. Switch on id to read the
+  // matching boolean from resp.integration_keys — typed shape keeps this
+  // exhaustive at compile time.
+  for (const intg of INTEGRATION_KEYS) {
+    let present = false;
+    switch (intg.id) {
+      case 'firecrawl':
+        present = resp.integration_keys.firecrawl_present;
+        break;
+      case 'youtube':
+        present = resp.integration_keys.youtube_present;
+        break;
+    }
+    rows.push({
+      id: intg.id,
+      severity: intg.severity,
+      code: `${intg.id}_key_missing`,
+      status: present ? 'pass' : 'fail',
+      label: `${intg.displayName} API key — ${intg.breaks}`,
+    });
+  }
+
+  return rows;
+}

--- a/app/src/lib/service-errors.ts
+++ b/app/src/lib/service-errors.ts
@@ -111,6 +111,23 @@ export const SERVICE_ERROR_MESSAGES = {
     body: 'Only one compile session per database is supported at a time.',
     fix: 'Visit the Progress page, wait for completion, or cancel the active session.',
   },
+
+  // ── Pre-stage health codes (consumed by /onboarding/health table) ──────
+  selected_provider_key_missing: {
+    title: "The API key for your selected compile model isn't set.",
+    body: 'Each compile session locks to one LLM provider at session start. If the selected provider has no API key, no LLM call in the pipeline can run.',
+    fix: 'Set the matching env var in .env (GEMINI_API_KEY=… for Gemini models, DEEPSEEK_API_KEY=… for DeepSeek), ensure it is wired through docker-compose.yml app.environment and nlp-service.environment, then `docker compose restart app nlp-service`.',
+  },
+  firecrawl_key_missing: {
+    title: "FIRECRAWL_API_KEY isn't set.",
+    body: 'URL ingest (web page → markdown via Firecrawl) will fail at compile time. Files, pasted text, Twitter bookmarks, and other connectors are unaffected.',
+    fix: 'Get a key at https://docs.firecrawl.dev/, set FIRECRAWL_API_KEY in .env, wire through docker-compose.yml nlp-service.environment, then `docker compose restart nlp-service`.',
+  },
+  youtube_key_missing: {
+    title: "YOUTUBE_API_KEY isn't set.",
+    body: 'YouTube URL ingest will hard-fail at compile time with HTTP 422 youtube_metadata_unavailable. There is no fallback. Non-YouTube URLs and other connectors still work.',
+    fix: 'Get a key at https://console.cloud.google.com/apis/library/youtube.googleapis.com, set YOUTUBE_API_KEY in .env, wire through docker-compose.yml nlp-service.environment, then `docker compose restart nlp-service`.',
+  },
 } as const;
 
 export type ServiceErrorCode = keyof typeof SERVICE_ERROR_MESSAGES;

--- a/app/src/lib/service-errors.ts
+++ b/app/src/lib/service-errors.ts
@@ -1,34 +1,135 @@
 /**
- * Error code → user-facing message registry.
+ * Error code → structured remediation registry.
  *
  * When API routes hit a downstream service failure (n8n, nlp-service, file
  * flush, polling), they return a stable `error` code string. UI code uses
  * `toUserMessage(code)` to render the human-readable form. This keeps the
  * error-text policy in one place instead of scattered inline switches.
+ *
+ * Each entry carries three layers of detail:
+ *   - title: one-line user-facing message (what every existing caller already
+ *            shows via toUserMessage). Preserved as a string so the 23 current
+ *            call sites keep working unchanged.
+ *   - body:  one-line explanation of what breaks downstream when the failure
+ *            fires. Consumed by the pre-stage health table.
+ *   - fix:   one-line operator action (env var, command). Consumed by the
+ *            pre-stage health table as a selectable code snippet.
+ *
+ * Adding a new code: pick a stable snake_case string, add the entry below,
+ * add a test row in `__tests__/service-errors.test.ts`.
  */
 
+export interface Remediation {
+  title: string;
+  body: string;
+  fix: string;
+}
+
 export const SERVICE_ERROR_MESSAGES = {
-  n8n_unreachable:      'Background worker (n8n) is unreachable. Check Docker and try again.',
-  n8n_timeout:          'Background worker (n8n) timed out. Check Docker and try again.',
-  n8n_webhook_failed:   'Background worker (n8n) rejected the request. Restart Docker and try again.',
-  n8n_not_ready:        'Background worker (n8n) is still starting up. Try again in a moment.',
-  nlp_unreachable:      'NLP service is down. Restart Docker and try again.',
-  nlp_convert_failed:   'NLP service could not convert the source. Try again or use a different URL/file.',
-  nlp_convert_timeout:  'NLP service took too long to convert this source. Try again or use a different URL/file.',
-  file_flush_pending:   'Page saved, disk flush pending. Will retry on next startup.',
-  backend_lost:         'Lost connection to backend — retrying…',
-  never_started:        'Compile did not start — background worker was unreachable. Click Retry.',
-  ingest_failed:        'Could not ingest this source. See saved-links page for details.',
-  commit_failed:        'Could not save your changes. Try again.',
-  chat_synthesis_failed:'Chat could not generate an answer. Try again.',
-  file_upload_failed:   'File upload failed. Try again.',
-  no_items_staged:      'No sources to compile. Add at least one, or uncheck fewer items.',
-  stage_insert_failed:  'Could not save your selection. Try again.',
-  session_in_progress:  'Another compile session is already running. Wait for it to finish or cancel it from the progress page.',
+  n8n_unreachable: {
+    title: 'Background worker (n8n) is unreachable. Check Docker and try again.',
+    body: 'n8n orchestrates the compile pipeline. Without it, /api/onboarding/finalize cannot dispatch the session-compile workflow.',
+    fix: 'docker compose up n8n  (or restart the whole stack: `docker compose restart`)',
+  },
+  n8n_timeout: {
+    title: 'Background worker (n8n) timed out. Check Docker and try again.',
+    body: 'n8n accepted the request but did not acknowledge within the timeout window. Usually a startup race or a stuck workflow.',
+    fix: 'docker compose restart n8n  (then retry the action)',
+  },
+  n8n_webhook_failed: {
+    title: 'Background worker (n8n) rejected the request. Restart Docker and try again.',
+    body: 'The session-compile webhook returned non-2xx. Workflow JSON may have failed to import or the webhook path was renamed.',
+    fix: 'docker compose restart n8n  (then verify the workflow is active in the n8n UI)',
+  },
+  n8n_not_ready: {
+    title: 'Background worker (n8n) is still starting up. Try again in a moment.',
+    body: 'n8n is in its boot phase and has not yet registered the webhook endpoint.',
+    fix: 'Wait ~30 seconds, then retry. If it persists, check `docker compose logs n8n`.',
+  },
+  nlp_unreachable: {
+    title: 'NLP service is down. Restart Docker and try again.',
+    body: 'The NLP service handles extraction, embeddings, and source conversion. Without it, no compile step past stage-intent can run.',
+    fix: 'docker compose up nlp-service  (verify with `curl http://localhost:8000/health`)',
+  },
+  nlp_convert_failed: {
+    title: 'NLP service could not convert the source. Try again or use a different URL/file.',
+    body: 'Conversion failed deterministically — bad URL, unsupported MIME type, or a malformed file.',
+    fix: 'Inspect the source. For URLs, try the canonical form. For files, re-export from the original tool.',
+  },
+  nlp_convert_timeout: {
+    title: 'NLP service took too long to convert this source. Try again or use a different URL/file.',
+    body: 'Conversion exceeded the per-source timeout. Common for very large PDFs or slow upstream sites.',
+    fix: 'Retry the same source. If it keeps timing out, split the input into smaller pieces.',
+  },
+  file_flush_pending: {
+    title: 'Page saved, disk flush pending. Will retry on next startup.',
+    body: 'The page was committed to the database via the outbox pattern but the markdown file did not reach disk yet. The boot reconciler will re-flush on next startup.',
+    fix: 'No action required. If the message persists across restarts, check `docker compose logs app`.',
+  },
+  backend_lost: {
+    title: 'Lost connection to backend — retrying…',
+    body: 'The browser cannot reach the Next.js server. App container may be restarting or the network bridge dropped.',
+    fix: 'Verify `docker compose ps` shows app as healthy. If not, `docker compose up app`.',
+  },
+  never_started: {
+    title: 'Compile did not start — background worker was unreachable. Click Retry.',
+    body: 'The compile session was created but n8n never received the webhook. Reconciler will clean up after 5 minutes if Retry is not clicked.',
+    fix: 'Click Retry. If it fails again, restart n8n: `docker compose restart n8n`.',
+  },
+  ingest_failed: {
+    title: 'Could not ingest this source. See saved-links page for details.',
+    body: 'A specific source failed at ingest time (URL fetch error, file parse error, blocklist hit). The compile continued with the remaining sources.',
+    fix: 'Visit the Saved Links page to see which sources failed and why.',
+  },
+  commit_failed: {
+    title: 'Could not save your changes. Try again.',
+    body: 'Page commit failed at the database or storage layer. Outbox phase 1 succeeded but phase 3a (write-page) errored.',
+    fix: 'Retry the action. If it persists, check `docker compose logs app`.',
+  },
+  chat_synthesis_failed: {
+    title: 'Chat could not generate an answer. Try again.',
+    body: 'The LLM call inside the chat synthesis step failed — provider error, rate limit, or token cap.',
+    fix: 'Retry. If repeated, check the Settings → Daily-cap section and the provider dashboard for rate-limit status.',
+  },
+  file_upload_failed: {
+    title: 'File upload failed. Try again.',
+    body: 'The browser-to-server upload errored before the file reached staging.',
+    fix: 'Retry. Confirm the file is under any size limits and a supported format.',
+  },
+  no_items_staged: {
+    title: 'No sources to compile. Add at least one, or uncheck fewer items.',
+    body: 'Finalize was called against an empty staging set.',
+    fix: 'Go back and add at least one source, or recheck items you may have toggled off.',
+  },
+  stage_insert_failed: {
+    title: 'Could not save your selection. Try again.',
+    body: 'The staging-row insert failed at the database layer.',
+    fix: 'Retry. If it persists, check `docker compose logs app` for SQLite errors.',
+  },
+  session_in_progress: {
+    title: 'Another compile session is already running. Wait for it to finish or cancel it from the progress page.',
+    body: 'Only one compile session per database is supported at a time.',
+    fix: 'Visit the Progress page, wait for completion, or cancel the active session.',
+  },
 } as const;
 
 export type ServiceErrorCode = keyof typeof SERVICE_ERROR_MESSAGES;
 
+/**
+ * Back-compat shim — returns the `title` string for the given code, or the
+ * fallback when the code is unknown. Every existing caller treats the return
+ * as a string; this contract is preserved.
+ */
 export function toUserMessage(code: string, fallback = 'Something went wrong'): string {
-  return SERVICE_ERROR_MESSAGES[code as ServiceErrorCode] ?? fallback;
+  const entry = SERVICE_ERROR_MESSAGES[code as ServiceErrorCode];
+  return entry?.title ?? fallback;
+}
+
+/**
+ * Structured-remediation accessor. Returns the full `{ title, body, fix }`
+ * object for known codes, or undefined for unknown ones. Consumed by the
+ * pre-stage health table.
+ */
+export function getRemediation(code: string): Remediation | undefined {
+  return SERVICE_ERROR_MESSAGES[code as ServiceErrorCode];
 }


### PR DESCRIPTION
## Summary
- Add `/onboarding/health` step: table of integration checks (Gemini, Firecrawl, YouTube, selected compile model) with red/green rows and Next gating.
- Extend `GET /api/health` with `selected_compile_model`, `selected_compile_provider`, `integration_keys` (additive).
- Provider registries (`LLM_PROVIDERS`, `INTEGRATION_KEYS`) + pure-function evaluator + structured `service-errors` entries.

## Why
Users hit compile failures late when keys are missing or misconfigured. Surface problems before the pipeline starts.

## Test plan
- [x] `npx vitest run` on api-health-route, health-providers, onboarding-health-evaluator, service-errors (39 tests)
- [ ] CI: unit-tests-* + integration-test + DCO