### PR TITLE
feat(llm): add DeepSeek V4 Flash compile/chat model

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,14 @@ You'll need three things on your machine:
 - **[Node.js](https://nodejs.org/) ≥ 24** — to install and run the `kompl` CLI.
 - **~5 GB free disk and 4 GB free RAM** — Kompl runs three containers (app, NLP service, n8n) plus pulls a ~90 MB embedding model on first compile.
 
-You'll also need two API keys, both free to get:
+You'll also need API keys. Two are required, two are optional:
 
-| | Get key | Free tier | Notes |
-|---|---|---|---|
-| **Gemini** (wiki compilation) | [aistudio.google.com/apikey](https://aistudio.google.com/apikey) | 1500 req/day | Free works for the demo and your first few sources. **Paid Tier 1 is strongly recommended for real use** — Gemini's free per-minute throttle (~10 RPM) will rate-limit a normal ingest, even though daily quota is plenty. Default rate-limiter assumes Tier 1. Has a known truncation issue on dense inputs — see [issue #7](https://github.com/tuirk/Kompl/issues/7). |
-| **DeepSeek V4 Pro** (alternative compile backend, optional) | [api-docs.deepseek.com](https://api-docs.deepseek.com) | Pay-as-you-go | Selectable in Settings as an alternative to Gemini. Recommended for long/academic content — see [Known limitations](#known-limitations). Set `DEEPSEEK_API_KEY` in `.env`. |
-| **Firecrawl** (URL scraping) | [firecrawl.dev](https://firecrawl.dev) | 500 scrapes/month | Free tier covers normal personal use. |
+| | Required? | Get key | Free tier | Notes |
+|---|---|---|---|---|
+| **Gemini** (wiki compilation) | Required | [aistudio.google.com/apikey](https://aistudio.google.com/apikey) | 1500 req/day | Free works for the demo and your first few sources. **Paid Tier 1 is strongly recommended for real use** — Gemini's free per-minute throttle (~10 RPM) will rate-limit a normal ingest, even though daily quota is plenty. Default rate-limiter assumes Tier 1. Has a known truncation issue on dense inputs — see [issue #7](https://github.com/tuirk/Kompl/issues/7). |
+| **Firecrawl** (URL scraping) | Required | [firecrawl.dev](https://firecrawl.dev) | 500 scrapes/month | Free tier covers normal personal use. |
+| **YouTube Data API v3** (YouTube ingestion) | Optional | [console.cloud.google.com](https://console.cloud.google.com/apis/library/youtube.googleapis.com) | 10,000 units/day (1 unit per video) | Required to ingest YouTube URLs — without it, every YouTube URL hard-fails and routes to Saved Links. Restrict the key to "YouTube Data API v3" only in the GCP console. Set `YOUTUBE_API_KEY` in `.env`. |
+| **DeepSeek V4 Pro** (alternative compile backend) | Optional | [api-docs.deepseek.com](https://api-docs.deepseek.com) | Pay-as-you-go | Selectable in Settings as an alternative to Gemini. Recommended for long/academic content — see [Known limitations](#known-limitations). Set `DEEPSEEK_API_KEY` in `.env`. |
 
 ## Setup
 
@@ -68,7 +69,7 @@ cd kompl
 node setup.js
 ```
 
-Either path: the script handles everything — creates your config, asks for the two API keys, installs the `kompl` CLI, and starts the stack. No other steps needed. Your system timezone is detected and written to `.env` as `KOMPL_TIMEZONE` automatically.
+Either path: the script handles everything — creates your config, asks for the two required API keys (and offers prompts for the two optional ones), installs the `kompl` CLI, and starts the stack. No other steps needed. Your system timezone is detected and written to `.env` as `KOMPL_TIMEZONE` automatically.
 
 > Your API keys land in `.env` at the repo root. That file is gitignored — never commit it.
 
@@ -177,7 +178,7 @@ Your wiki content lives in Docker volumes on your machine. Outbound network call
 - **DeepSeek** (`api.deepseek.com`) — wiki compilation when the DeepSeek backend is selected. Your source text is sent to DeepSeek. Only outbound if `DEEPSEEK_API_KEY` is configured and selected as the compile model.
 - **Firecrawl** (`api.firecrawl.dev`) — URL scraping fallback. The URL you pasted is sent to Firecrawl.
 - **GitHub public API** (`api.github.com`) — when you paste a GitHub repo URL, Kompl fetches the README + metadata.
-- **YouTube** (`youtube.com`) — when you paste a YouTube URL, transcripts are fetched via the public captions endpoint.
+- **YouTube** (`youtube.com` + `youtube.googleapis.com`) — when you paste a YouTube URL, transcripts are fetched via the public captions endpoint and metadata (title, channel, duration) via YouTube Data API v3. Requires `YOUTUBE_API_KEY`; without it, YouTube URLs route to Saved Links.
 - **OG-tag preview** — pasted URLs are fetched once with `User-Agent: KomplBot/1.0` to grab title + description.
 - **Telegram** (`api.telegram.org`) — wired for the weekly digest, but the Settings UI is currently locked until two known issues are resolved. No outbound Telegram calls happen on a default install.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,7 +22,7 @@ Include:
 Kompl runs locally on your machine. The attack surface is:
 
 - **Local network exposure.** Kompl binds to `localhost:3000` by default. If you expose it to your network or the internet, you are responsible for adding authentication — Kompl has none.
-- **API key handling.** Gemini and Firecrawl keys are stored in `.env` on disk. They are never logged, never sent to Kompl's own services, and excluded from `.kompl.zip` exports.
+- **API key handling.** Gemini, Firecrawl, YouTube, and (optional) DeepSeek keys are stored in `.env` on disk. They are never logged, never sent to Kompl's own services, and excluded from `.kompl.zip` exports.
 - **Docker container isolation.** Kompl's containers run with default Docker security. No `--privileged`, no host network mode, no volume mounts outside the project directory.
 - **n8n webhooks.** Internal webhooks between services are unauthenticated. This is safe when running locally. If exposed to the internet, n8n's webhook endpoints could be triggered by anyone.
 

--- a/app/src/app/api/settings/route.ts
+++ b/app/src/app/api/settings/route.ts
@@ -207,7 +207,7 @@ export async function POST(request: Request) {
   if (body.chat_model !== undefined) {
     if (!isChatModel(body.chat_model)) {
       return NextResponse.json(
-        { error: 'chat_model must be one of: gemini-2.5-flash-lite, gemini-2.5-flash, gemini-2.5-pro, deepseek-v4-pro' },
+        { error: 'chat_model must be one of: gemini-2.5-flash-lite, gemini-2.5-flash, gemini-2.5-pro, deepseek-v4-pro, deepseek-v4-flash' },
         { status: 422 },
       );
     }
@@ -217,7 +217,7 @@ export async function POST(request: Request) {
   if (body.compile_model !== undefined) {
     if (!isChatModel(body.compile_model)) {
       return NextResponse.json(
-        { error: 'compile_model must be one of: gemini-2.5-flash-lite, gemini-2.5-flash, gemini-2.5-pro, deepseek-v4-pro' },
+        { error: 'compile_model must be one of: gemini-2.5-flash-lite, gemini-2.5-flash, gemini-2.5-pro, deepseek-v4-pro, deepseek-v4-flash' },
         { status: 422 },
       );
     }

--- a/app/src/app/settings/page.tsx
+++ b/app/src/app/settings/page.tsx
@@ -1090,6 +1090,13 @@ export default function SettingsPage() {
                       ? 'Set DEEPSEEK_API_KEY in your environment to enable'
                       : undefined}
                   >V4 Pro</option>
+                  <option
+                    value="deepseek-v4-flash"
+                    disabled={providerKeys ? !providerKeys.deepseek_present : false}
+                    title={providerKeys && !providerKeys.deepseek_present
+                      ? 'Set DEEPSEEK_API_KEY in your environment to enable'
+                      : undefined}
+                  >V4 Flash</option>
                 </optgroup>
               </select>
             </div>
@@ -1184,6 +1191,13 @@ export default function SettingsPage() {
                       ? 'Set DEEPSEEK_API_KEY in your environment to enable'
                       : undefined}
                   >V4 Pro</option>
+                  <option
+                    value="deepseek-v4-flash"
+                    disabled={providerKeys ? !providerKeys.deepseek_present : false}
+                    title={providerKeys && !providerKeys.deepseek_present
+                      ? 'Set DEEPSEEK_API_KEY in your environment to enable'
+                      : undefined}
+                  >V4 Flash</option>
                 </optgroup>
               </select>
             </div>

--- a/app/src/lib/db.ts
+++ b/app/src/lib/db.ts
@@ -2794,6 +2794,7 @@ export const CHAT_MODELS = [
   'gemini-2.5-flash',
   'gemini-2.5-pro',
   'deepseek-v4-pro',
+  'deepseek-v4-flash',
 ] as const;
 export type ChatModel = typeof CHAT_MODELS[number];
 export const DEFAULT_CHAT_MODEL: ChatModel = 'gemini-2.5-flash-lite';

--- a/install.ps1
+++ b/install.ps1
@@ -91,6 +91,6 @@ Write-Ok "Cloned"
 # ── Hand off to setup.js ────────────────────────────────────────────────────
 Set-Location $target
 Write-Host ""
-Write-Host "  Handing off to setup.js (interactive — needs your Gemini + Firecrawl API keys and a deployment-mode choice)."
+Write-Host "  Handing off to setup.js (interactive — needs your Gemini + Firecrawl API keys; YouTube + DeepSeek prompts are optional)."
 Write-Host ""
 & node setup.js

--- a/install.sh
+++ b/install.sh
@@ -112,5 +112,5 @@ ok "Cloned"
 
 # ── Hand off to setup.js ────────────────────────────────────────────────────
 cd "$TARGET"
-printf "\n  Handing off to setup.js (interactive — needs your Gemini + Firecrawl API keys and a deployment-mode choice).\n\n"
+printf "\n  Handing off to setup.js (interactive — needs your Gemini + Firecrawl API keys; YouTube + DeepSeek prompts are optional).\n\n"
 exec node setup.js

--- a/nlp-service/routers/chat.py
+++ b/nlp-service/routers/chat.py
@@ -22,6 +22,8 @@ ChatModel = Literal[
     "gemini-2.5-flash-lite",
     "gemini-2.5-flash",
     "gemini-2.5-pro",
+    "deepseek-v4-pro",
+    "deepseek-v4-flash",
 ]
 
 from services.llm_client import (

--- a/nlp-service/routers/pipeline.py
+++ b/nlp-service/routers/pipeline.py
@@ -53,6 +53,7 @@ GeminiModel = Literal[
     "gemini-2.5-flash",
     "gemini-2.5-pro",
     "deepseek-v4-pro",
+    "deepseek-v4-flash",
 ]
 
 

--- a/nlp-service/routers/resolution.py
+++ b/nlp-service/routers/resolution.py
@@ -32,6 +32,7 @@ GeminiModel = Literal[
     "gemini-2.5-flash",
     "gemini-2.5-pro",
     "deepseek-v4-pro",
+    "deepseek-v4-flash",
 ]
 
 logger = logging.getLogger(__name__)

--- a/nlp-service/services/providers/deepseek.py
+++ b/nlp-service/services/providers/deepseek.py
@@ -49,10 +49,10 @@ _DEEPSEEK_RPM = int(os.environ.get("DEEPSEEK_RPM", "60"))
 
 
 # ---------------------------------------------------------------------------
-# Pricing (DeepSeek V4 Pro, $/M tokens)
+# Pricing (DeepSeek V4 family, $/M tokens)
 # ---------------------------------------------------------------------------
 #
-# List prices per api-docs.deepseek.com/quick_start/pricing (2026-05-09 read).
+# List prices per api-docs.deepseek.com/quick_start/pricing (2026-05-22 read).
 # We deliberately do NOT model the promotional 75%-off discount window — when
 # DeepSeek runs a discount, our cap counter overestimates real spend, which is
 # the safe side to err on (cap fires earlier than necessary, never later than
@@ -61,16 +61,30 @@ _DEEPSEEK_RPM = int(os.environ.get("DEEPSEEK_RPM", "60"))
 # truth, and treat any V5/V4-Lite/etc. switch as a reason to revisit this dict.
 # Operators can override per-rate via DEEPSEEK_INPUT_USD_PER_M /
 # DEEPSEEK_OUTPUT_USD_PER_M / DEEPSEEK_CACHE_USD_PER_M without touching code.
+# Env overrides apply to all DeepSeek models (matching gemini.py's escape-
+# hatch convention) — emergency-use-only when DeepSeek changes pricing before
+# we ship a code update.
 
-_PRICES = {"input": 1.74, "output": 3.48, "cache": 0.0145}
+_MODEL_PRICES: dict[str, dict[str, float]] = {
+    "deepseek-v4-pro":   {"input": 1.74, "output": 3.48, "cache": 0.0145},
+    "deepseek-v4-flash": {"input": 0.14, "output": 0.28, "cache": 0.0028},
+}
 
 
-def _prices_now() -> dict[str, float]:
-    """Per-million-token list prices, with optional env-var overrides."""
+def _get_model_prices(model: str) -> dict[str, float]:
+    """Per-million-token list prices for ``model``, with env-var overrides.
+
+    Unknown model names raise KeyError. By design — every model name reaching
+    this function passed through the Settings dropdown allowlist
+    (app/src/lib/db.ts CHAT_MODELS) and the Pydantic Literal at the route
+    boundary. An unknown name here means a developer added a SKU to the
+    Literals/dropdown but forgot to add its price; fail loud in tests.
+    """
+    base = _MODEL_PRICES[model]
     return {
-        "input":  float(os.environ.get("DEEPSEEK_INPUT_USD_PER_M",  _PRICES["input"])),
-        "output": float(os.environ.get("DEEPSEEK_OUTPUT_USD_PER_M", _PRICES["output"])),
-        "cache":  float(os.environ.get("DEEPSEEK_CACHE_USD_PER_M",  _PRICES["cache"])),
+        "input":  float(os.environ.get("DEEPSEEK_INPUT_USD_PER_M",  base["input"])),
+        "output": float(os.environ.get("DEEPSEEK_OUTPUT_USD_PER_M", base["output"])),
+        "cache":  float(os.environ.get("DEEPSEEK_CACHE_USD_PER_M",  base["cache"])),
     }
 
 
@@ -280,7 +294,7 @@ class DeepSeekProvider:
         (prompt_token_count, cached_content_token_count, candidates_token_count,
         thoughts_token_count) — translate to DeepSeek's pricing formula.
         """
-        prices = _prices_now()
+        prices = _get_model_prices(model)
         prompt = usage.get("prompt_token_count", 0)
         cached = usage.get("cached_content_token_count", 0)
         # DeepSeek folds reasoning into completion_tokens; the dispatcher's

--- a/nlp-service/services/providers/test_providers.py
+++ b/nlp-service/services/providers/test_providers.py
@@ -110,6 +110,7 @@ def test_get_provider_dispatches_deepseek_prefix(monkeypatch):
     assert isinstance(p, DeepSeekProvider)
     assert p.name == "deepseek"
     # Singleton cache: same instance on repeat lookup.
+    assert get_provider("deepseek-v4-flash") is p
     assert get_provider("deepseek-v5-future") is p
 
     P._REGISTRY.clear()
@@ -444,8 +445,8 @@ def test_deepseek_emits_log_line_with_cache_hit(monkeypatch, capsys):
 # ---------------------------------------------------------------------------
 
 
-def test_deepseek_prices_default_to_list(monkeypatch):
-    """Without env overrides, _prices_now returns the published list prices.
+def test_deepseek_pro_prices_default_to_list(monkeypatch):
+    """Without env overrides, _get_model_prices returns the published list prices.
 
     Discount-window code was removed 2026-05-09 — the cap counter intentionally
     over-estimates during DeepSeek promotional periods (safe side: cap fires
@@ -457,21 +458,71 @@ def test_deepseek_prices_default_to_list(monkeypatch):
     monkeypatch.delenv("DEEPSEEK_OUTPUT_USD_PER_M", raising=False)
     monkeypatch.delenv("DEEPSEEK_CACHE_USD_PER_M", raising=False)
 
-    prices = D._prices_now()
-    assert prices["input"] == D._PRICES["input"]
-    assert prices["output"] == D._PRICES["output"]
-    assert prices["cache"] == D._PRICES["cache"]
+    prices = D._get_model_prices("deepseek-v4-pro")
+    assert prices["input"] == D._MODEL_PRICES["deepseek-v4-pro"]["input"]
+    assert prices["output"] == D._MODEL_PRICES["deepseek-v4-pro"]["output"]
+    assert prices["cache"] == D._MODEL_PRICES["deepseek-v4-pro"]["cache"]
+
+
+def test_deepseek_flash_prices_match_list_rates(monkeypatch):
+    """V4-Flash list prices (2026-05-22): $0.14 / $0.28 / $0.0028 per M tokens."""
+    from services.providers import deepseek as D
+    monkeypatch.delenv("DEEPSEEK_INPUT_USD_PER_M", raising=False)
+    monkeypatch.delenv("DEEPSEEK_OUTPUT_USD_PER_M", raising=False)
+    monkeypatch.delenv("DEEPSEEK_CACHE_USD_PER_M", raising=False)
+
+    prices = D._get_model_prices("deepseek-v4-flash")
+    assert prices["input"] == 0.14
+    assert prices["output"] == 0.28
+    assert prices["cache"] == 0.0028
+
+
+def test_deepseek_pro_and_flash_prices_differ(monkeypatch):
+    """Regression guard: Pro is ~12x more expensive than Flash on input.
+
+    If this assertion fires, _MODEL_PRICES probably got accidentally
+    overwritten or the two model entries got their values swapped.
+    """
+    from services.providers import deepseek as D
+    monkeypatch.delenv("DEEPSEEK_INPUT_USD_PER_M", raising=False)
+    monkeypatch.delenv("DEEPSEEK_OUTPUT_USD_PER_M", raising=False)
+    monkeypatch.delenv("DEEPSEEK_CACHE_USD_PER_M", raising=False)
+
+    pro = D._get_model_prices("deepseek-v4-pro")
+    flash = D._get_model_prices("deepseek-v4-flash")
+    assert pro["input"] >= 10 * flash["input"]
+    assert pro["output"] >= 10 * flash["output"]
+
+
+def test_deepseek_unknown_model_raises_keyerror():
+    """No fallback by design. Unknown names mean a developer added a SKU to
+    the Literals/dropdown but forgot to add its price — fail loud.
+    """
+    from services.providers import deepseek as D
+    with pytest.raises(KeyError):
+        D._get_model_prices("deepseek-v5-future")
+
+
+def test_deepseek_env_override_applies_to_both_models(monkeypatch):
+    """Env-var overrides apply globally to all DeepSeek models — matches the
+    Gemini precedent (gemini.py GEMINI_INPUT_PRICE_PER_M). Per-model env vars
+    would explode the surface area for an emergency-only escape hatch.
+    """
+    monkeypatch.setenv("DEEPSEEK_INPUT_USD_PER_M", "99.0")
+    from services.providers import deepseek as D
+    assert D._get_model_prices("deepseek-v4-pro")["input"] == 99.0
+    assert D._get_model_prices("deepseek-v4-flash")["input"] == 99.0
 
 
 def test_deepseek_prices_env_override_wins(monkeypatch):
     monkeypatch.setenv("DEEPSEEK_INPUT_USD_PER_M", "0.99")
     from services.providers import deepseek as D
-    prices = D._prices_now()
+    prices = D._get_model_prices("deepseek-v4-pro")
     assert prices["input"] == 0.99
 
 
-def test_deepseek_cost_usd_formula(monkeypatch):
-    """Sanity-check the cost arithmetic on a known usage dict."""
+def test_deepseek_pro_cost_usd_formula(monkeypatch):
+    """Sanity-check the cost arithmetic on a known usage dict (V4-Pro)."""
     monkeypatch.setenv("DEEPSEEK_INPUT_USD_PER_M",  "1.00")
     monkeypatch.setenv("DEEPSEEK_OUTPUT_USD_PER_M", "10.00")
     monkeypatch.setenv("DEEPSEEK_CACHE_USD_PER_M",  "0.10")
@@ -490,6 +541,33 @@ def test_deepseek_cost_usd_formula(monkeypatch):
     })
     # fresh = 900_000 -> 0.9; cached = 100_000 -> 0.01; output = 500_000 -> 5.00
     assert abs(cost - (0.9 + 0.01 + 5.0)) < 1e-9
+    P._REGISTRY.clear()
+
+
+def test_deepseek_flash_cost_usd_formula(monkeypatch):
+    """Cost arithmetic at V4-Flash list rates ($0.14 / $0.28 / $0.0028)."""
+    monkeypatch.delenv("DEEPSEEK_INPUT_USD_PER_M", raising=False)
+    monkeypatch.delenv("DEEPSEEK_OUTPUT_USD_PER_M", raising=False)
+    monkeypatch.delenv("DEEPSEEK_CACHE_USD_PER_M", raising=False)
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+    from services import providers as P
+    P._REGISTRY.clear()
+    from services.providers import get_provider
+
+    p = get_provider("deepseek-v4-flash")
+    # 1M prompt tokens, 100K cached, 500K output (Gemini-shape keys).
+    cost = p.cost_usd("deepseek-v4-flash", {
+        "prompt_token_count":         1_000_000,
+        "cached_content_token_count": 100_000,
+        "candidates_token_count":     500_000,
+        "thoughts_token_count":       0,
+    })
+    # fresh = 900_000 -> $0.126 (0.14 * 0.9); cached = 100_000 -> $0.00028
+    # (0.0028 * 0.1); output = 500_000 -> $0.14 (0.28 * 0.5)
+    expected = (900_000 / 1_000_000) * 0.14 \
+             + (100_000 / 1_000_000) * 0.0028 \
+             + (500_000 / 1_000_000) * 0.28
+    assert abs(cost - expected) < 1e-9
     P._REGISTRY.clear()
 
 

--- a/setup.js
+++ b/setup.js
@@ -6,7 +6,7 @@
  * Does everything:
  *   1. Checks Docker Desktop is running
  *   2. Creates .env from .env.example (if not already present)
- *   3. Prompts for Gemini + Firecrawl API keys and writes them to .env
+ *   3. Prompts for Gemini + Firecrawl (required) and YouTube + DeepSeek (optional) API keys and writes them to .env
  *   4. Installs and globally links the kompl CLI (npm link)
  *   5. Writes ~/.kompl/config.json so `kompl` commands work immediately
  *   6. Runs `docker compose up --build -d` to start the full stack
@@ -73,13 +73,18 @@ async function main() {
 
   const alreadyHasGemini     = /^GEMINI_API_KEY=.+$/m.test(env)
   const alreadyHasFirecrawl  = /^FIRECRAWL_API_KEY=.+$/m.test(env)
+  const alreadyHasYoutube    = /^YOUTUBE_API_KEY=.+$/m.test(env)
+  const alreadyHasDeepSeek   = /^DEEPSEEK_API_KEY=.+$/m.test(env)
 
-  if (alreadyHasGemini && alreadyHasFirecrawl) {
+  if (alreadyHasGemini && alreadyHasFirecrawl && alreadyHasYoutube && alreadyHasDeepSeek) {
     console.log('  API keys already set in .env — skipping prompts')
   } else {
-    console.log('\n  You need two API keys (both have free tiers):')
+    console.log('\n  Two required keys (both have free tiers):')
     console.log(dim('    Gemini:    https://aistudio.google.com/apikey   (free works for the demo; paid Tier 1 strongly recommended for real use)'))
-    console.log(dim('    Firecrawl: https://firecrawl.dev                (500 scrapes/month free)\n'))
+    console.log(dim('    Firecrawl: https://firecrawl.dev                (500 scrapes/month free)'))
+    console.log('\n  Two optional keys (press Enter to skip):')
+    console.log(dim('    YouTube:   https://console.cloud.google.com/apis/library/youtube.googleapis.com  (10K units/day free; required for YouTube URL ingestion)'))
+    console.log(dim('    DeepSeek:  https://api-docs.deepseek.com        (pay-as-you-go; alternative compile backend for long/dense sources)\n'))
 
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
 
@@ -93,6 +98,24 @@ async function main() {
       const key = (await ask(rl, '  Firecrawl API key: ')).trim()
       if (!key) { console.error('  Error: Firecrawl API key is required.'); rl.close(); process.exit(1) }
       env = env.replace(/^FIRECRAWL_API_KEY=.*$/m, `FIRECRAWL_API_KEY=${key}`)
+    }
+
+    if (!alreadyHasYoutube) {
+      const key = (await ask(rl, '  YouTube API key (optional, Enter to skip): ')).trim()
+      if (key) {
+        env = env.replace(/^YOUTUBE_API_KEY=.*$/m, `YOUTUBE_API_KEY=${key}`)
+      } else {
+        console.log(dim('    Skipped — YouTube URLs will route to Saved Links until you add a key to .env'))
+      }
+    }
+
+    if (!alreadyHasDeepSeek) {
+      const key = (await ask(rl, '  DeepSeek API key (optional, Enter to skip): ')).trim()
+      if (key) {
+        env = env.replace(/^DEEPSEEK_API_KEY=.*$/m, `DEEPSEEK_API_KEY=${key}`)
+      } else {
+        console.log(dim('    Skipped — only Gemini will be selectable as the compile backend'))
+      }
     }
 
     rl.close()

--- a/validation/2026-05-22-deepseek-flash/REPORT.md
+++ b/validation/2026-05-22-deepseek-flash/REPORT.md
@@ -1,0 +1,75 @@
+# Phase 8 — DeepSeek V4-Flash validation report
+
+**Date:** 2026-05-22
+**Branch:** `feat/deepseek-v4-flash`
+**Sibling run:** [validation/2026-05-05-multi-provider-corpus/REPORT.md](../2026-05-05-multi-provider-corpus/REPORT.md) — Pro + Gemini baselines on the same 7-source corpus.
+
+## Goal
+
+Validate `deepseek-v4-flash` against the same Phase 7 bar that V4-Pro cleared:
+
+1. 7/7 corpus sources extract `ok=true`.
+2. Zero `salvaged truncated response via json-repair` events in nlp-service logs.
+3. The 95K-char Open Standards source extracts on first pass within the 600s adapter timeout.
+
+If Flash fails ≥1 source, **still ship** — Flash is opt-in, not the default. Note the failing source here so users know to pick Pro for known-difficult content.
+
+## Results
+
+> _Pending run — populate after `python runner.py` completes._
+
+| Source | chars | entities | concepts | claims | relationships | summary chars | latency |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| _to fill in_ | | | | | | | |
+
+## Salvage / parse failure check
+
+```
+$ docker compose logs nlp-service --since 4h | grep -c "salvaged truncated response via json-repair"
+<fill in after run>
+```
+
+Phase 7 bar: **0** salvage events.
+
+## Spend
+
+V4-Flash list rates (no current promotion):
+
+- Uncached input: $0.14/M
+- Cached input: $0.0028/M
+- Output: $0.28/M
+
+| Run | Calls | Input tok | Cache hit tok | Output tok | Cost |
+|---|---:|---:|---:|---:|---:|
+| _to fill in_ | | | | | |
+
+Expected total at corpus scale: ~$0.01-0.02 (vs $0.10 list for Pro on the same corpus, ~10x cheaper).
+
+## Quality vs Pro
+
+Spot-check 2-3 sources against the [2026-05-05 results.json](../2026-05-05-multi-provider-corpus/results.json) for Pro on the same source — count deltas and a qualitative read of the extracted entities/relationships.
+
+- _to fill in_
+
+## Reproducing
+
+```bash
+# 1. Stack up with DEEPSEEK_API_KEY set in .env
+docker compose up -d
+
+# 2. Verify health
+curl -s :8000/health | python -m json.tool   # expect provider_keys.deepseek: true
+
+# 3. Run corpus
+python validation/2026-05-22-deepseek-flash/runner.py
+
+# 4. Verify zero salvage events
+docker compose logs nlp-service --since 4h | grep -c "salvaged truncated response via json-repair"
+# expect: 0
+```
+
+## Files
+
+- `runner.py` — Flash-only corpus walker (600s timeout)
+- `results.json` — per-source counts (this run)
+- `REPORT.md` — this document

--- a/validation/2026-05-22-deepseek-flash/runner.py
+++ b/validation/2026-05-22-deepseek-flash/runner.py
@@ -1,0 +1,142 @@
+"""Phase 8 V4-Flash validation runner.
+
+Walks nlp-service/test_corpus/ and posts each source to /pipeline/extract-llm
+with compile_model=deepseek-v4-flash. Captures entity/concept/claim/
+relationship counts, finish_reason, latency, http_status into results.json
+for the REPORT.md table.
+
+Flash-only by design — V4-Pro and Gemini-2.5-Flash were validated against
+the same corpus on 2026-05-05; this run validates the new Flash SKU at the
+same Phase 7 bar (7/7 ok, 0 salvage events).
+
+Run with the docker compose stack up (nlp-service on 127.0.0.1:8000):
+
+    python validation/2026-05-22-deepseek-flash/runner.py
+
+Cost: 7 sources x 1 provider = 7 LLM calls. At V4-Flash list rates
+($0.14 input / $0.28 output / $0.0028 cache) the corpus should cost
+~$0.01-0.02 total. Daily LLM cap is $5.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+CORPUS = Path(__file__).resolve().parents[2] / "nlp-service" / "test_corpus"
+NLP_BASE = "http://localhost:8000"
+PROVIDERS = ["deepseek-v4-flash"]
+
+
+def _git_head() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"], cwd=Path(__file__).resolve().parent
+        ).decode().strip()
+    except Exception:
+        return "unknown"
+
+
+def _post_extract(source_id: str, markdown: str, model: str) -> tuple[int, dict | None]:
+    payload = json.dumps(
+        {
+            "source_id": source_id,
+            "markdown": markdown,
+            "ner_output": {"entities": []},
+            "keyphrase_output": None,
+            "tfidf_output": None,
+            "compile_model": model,
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        f"{NLP_BASE}/pipeline/extract-llm",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    # 600s timeout — Phase 7 settled on this after the 240s v1 runner caught
+    # successful DeepSeek calls mid-flight; the 95K Open Standards source
+    # peaks ~290s on Pro and Flash may need similar headroom.
+    try:
+        with urllib.request.urlopen(req, timeout=600) as r:
+            return r.status, json.loads(r.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")
+        try:
+            return e.code, json.loads(body)
+        except Exception:
+            return e.code, {"raw": body[:1000]}
+    except Exception as e:
+        return -1, {"error": str(e)}
+
+
+def _summarize(resp: dict) -> dict:
+    if not isinstance(resp, dict):
+        return {"ok": False, "raw": str(resp)[:300]}
+    if "entities" in resp and "concepts" in resp:
+        return {
+            "ok": True,
+            "entity_count":       len(resp.get("entities", []) or []),
+            "concept_count":      len(resp.get("concepts", []) or []),
+            "claim_count":        len(resp.get("claims", []) or []),
+            "relationship_count": len(resp.get("relationships", []) or []),
+            "contradiction_count": len(resp.get("contradictions", []) or []),
+            "summary_chars":      len(resp.get("summary", "") or ""),
+        }
+    return {"ok": False, "detail": resp.get("detail", "")[:500] if isinstance(resp.get("detail"), str) else str(resp)[:500]}
+
+
+def main() -> int:
+    sources = sorted(p for p in CORPUS.glob("*.md") if p.name != "_manifest.json")
+    if not sources:
+        print(f"[runner] no sources found in {CORPUS}", file=sys.stderr)
+        return 1
+
+    out: dict = {
+        "run_at": datetime.now(timezone.utc).isoformat(),
+        "branch": "feat/deepseek-v4-flash",
+        "head_commit": _git_head(),
+        "providers": PROVIDERS,
+        "nlp_service_url": NLP_BASE,
+        "sources": [],
+    }
+
+    for src in sources:
+        markdown = src.read_text(encoding="utf-8")
+        chars = len(markdown)
+        print(f"[runner] {src.name} ({chars} chars)", flush=True)
+        entry: dict = {"name": src.name, "markdown_chars": chars, "results": {}}
+
+        for model in PROVIDERS:
+            t0 = time.time()
+            status, body = _post_extract(src.stem, markdown, model)
+            elapsed = time.time() - t0
+            summary = _summarize(body)
+            summary["http_status"] = status
+            summary["elapsed_s"] = round(elapsed, 2)
+            entry["results"][model] = summary
+            ok_str = "ok" if summary.get("ok") else "FAIL"
+            counts = (
+                f"e={summary.get('entity_count')} c={summary.get('concept_count')} "
+                f"cl={summary.get('claim_count')} r={summary.get('relationship_count')}"
+                if summary.get("ok") else summary.get("detail", "")[:120]
+            )
+            print(f"  [{model}] HTTP {status} {ok_str} ({elapsed:.1f}s) {counts}", flush=True)
+
+        out["sources"].append(entry)
+
+    out_path = Path(__file__).resolve().parent / "results.json"
+    out_path.write_text(json.dumps(out, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(f"[runner] wrote {out_path}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add `deepseek-v4-flash` as a third selectable compile/chat model (Settings UI, API validation, NLP provider registry, session model lock).
- Fix chat routes to allow DeepSeek SKUs on `/chat/select-pages` and `/chat/synthesize`.
- Phase 8 validation harness + report under `validation/2026-05-22-deepseek-flash/`.
- Docs/setup: optional YouTube + DeepSeek keys in README, SECURITY, install scripts, `setup.js`.

## Why
V4 Flash is a lower-latency/cost DeepSeek tier for compile and chat; users need it alongside V4 Pro and Gemini.

## Test plan
- [x] `python -m pytest services/providers/test_providers.py` (37 passed)
- [ ] CI: unit-tests-* + integration-test + DCO