### PR TITLE
fix(app): clear orphan queued compiles after cancel

### DIFF
--- a/app/src/__tests__/supersede-orphan-queued.test.ts
+++ b/app/src/__tests__/supersede-orphan-queued.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { setupTestDb, type TestDbHandle } from './helpers/test-db';
+import {
+  getRunningCompileSession,
+  supersedeOrphanQueuedSessions,
+  updateCompileStep,
+} from '../lib/db';
+
+let handle: TestDbHandle | null = null;
+
+afterEach(() => {
+  handle?.cleanup();
+  handle = null;
+});
+
+function insertQueued(db: Database.Database, sessionId: string): void {
+  db.prepare(
+    `INSERT INTO compile_progress (session_id, status, steps, started_at, source_count)
+     VALUES (?, 'queued', '{}', NULL, 1)`,
+  ).run(sessionId);
+}
+
+describe('supersedeOrphanQueuedSessions', () => {
+  it('cancels other never-started queued sessions but not the requested one', () => {
+    handle = setupTestDb();
+    insertQueued(handle.db, 'orphan-a');
+    insertQueued(handle.db, 'orphan-b');
+    insertQueued(handle.db, 'keep-me');
+
+    const n = supersedeOrphanQueuedSessions('keep-me');
+    expect(n).toBe(2);
+
+    const orphanA = handle.db
+      .prepare('SELECT status FROM compile_progress WHERE session_id = ?')
+      .get('orphan-a') as { status: string };
+    const keep = handle.db
+      .prepare('SELECT status FROM compile_progress WHERE session_id = ?')
+      .get('keep-me') as { status: string };
+    expect(orphanA.status).toBe('cancelled');
+    expect(keep.status).toBe('queued');
+    expect(getRunningCompileSession()?.session_id).toBe('keep-me');
+  });
+
+  it('does not cancel running sessions for other ids', () => {
+    handle = setupTestDb();
+    insertQueued(handle.db, 'other-queued');
+    handle.db
+      .prepare(
+        `INSERT INTO compile_progress (session_id, status, steps, started_at, source_count)
+         VALUES ('other-running', 'running', '{}', datetime('now'), 1)`,
+      )
+      .run();
+
+    supersedeOrphanQueuedSessions('new-session');
+
+    const running = handle.db
+      .prepare('SELECT status FROM compile_progress WHERE session_id = ?')
+      .get('other-running') as { status: string };
+    expect(running.status).toBe('running');
+    expect(getRunningCompileSession()?.session_id).toBe('other-running');
+  });
+});
+
+describe('updateCompileStep on cancelled sessions', () => {
+  it('does not resurrect cancelled to running when a worker reports running', () => {
+    handle = setupTestDb();
+    handle.db
+      .prepare(
+        `INSERT INTO compile_progress (session_id, status, steps, started_at, source_count)
+         VALUES ('s1', 'cancelled', '{}', datetime('now'), 1)`,
+      )
+      .run();
+
+    updateCompileStep('s1', 'extract', 'running', '1/1 sources extracted');
+
+    const row = handle.db
+      .prepare('SELECT status FROM compile_progress WHERE session_id = ?')
+      .get('s1') as { status: string };
+    expect(row.status).toBe('cancelled');
+    expect(getRunningCompileSession()).toBeNull();
+  });
+});

--- a/app/src/app/api/compile/run/route.ts
+++ b/app/src/app/api/compile/run/route.ts
@@ -589,6 +589,9 @@ export async function POST(request: Request) {
   const progress = getCompileProgress(session_id);
   if (!progress) return NextResponse.json({ error: 'no_progress_record' }, { status: 404 });
   if (progress.status === 'completed') return NextResponse.json({ session_id, status: 'already_completed' }, { status: 409 });
+  if (progress.status === 'cancelled') {
+    return NextResponse.json({ error: 'session_cancelled' }, { status: 409 });
+  }
 
   if (progress.status === 'running') {
     // Per-session adaptive cleanup (60 min floor + 6 min/source) — see

--- a/app/src/app/api/onboarding/finalize/route.ts
+++ b/app/src/app/api/onboarding/finalize/route.ts
@@ -24,6 +24,7 @@ import {
   getStagingBySession,
   logActivity,
   setSetting,
+  supersedeOrphanQueuedSessions,
 } from '../../../../lib/db';
 import { triggerSessionCompile } from '@/lib/trigger-n8n';
 
@@ -62,6 +63,10 @@ export async function POST(request: Request) {
       { status: 400 }
     );
   }
+
+  // Clear orphan queued rows (failed n8n trigger, abandoned tab) so they
+  // do not hold the global gate while the user starts a fresh session.
+  supersedeOrphanQueuedSessions(session_id);
 
   // Global concurrency gate: only one compile session at a time. Two
   // concurrent pipelines collide on the Gemini rate limiter singleton,

--- a/app/src/app/onboarding/review/page.tsx
+++ b/app/src/app/onboarding/review/page.tsx
@@ -172,6 +172,7 @@ function ReviewPageInner() {
         queued?: number;
         error?: string;
         error_code?: string;
+        active_session_id?: string;
       };
       if (!res.ok) {
         // n8n_* errors still navigate to progress so the retry button lives there.
@@ -182,7 +183,15 @@ function ReviewPageInner() {
           );
           return;
         }
-        showToast(toUserMessage(body.error_code ?? 'commit_failed'), 'error');
+        if (body.error_code === 'session_in_progress' && body.active_session_id) {
+          const short = body.active_session_id.slice(0, 8);
+          showToast(
+            `${toUserMessage('session_in_progress')} Open Progress for session ${short}… or cancel it there first.`,
+            'error',
+          );
+        } else {
+          showToast(toUserMessage(body.error_code ?? 'commit_failed'), 'error');
+        }
         setConfirming(false);
         return;
       }

--- a/app/src/lib/db.ts
+++ b/app/src/lib/db.ts
@@ -1666,12 +1666,16 @@ export function updateCompileStep(
 
   let overallStatus = row.status;
   let setStartedAt = '';
-  if (status === 'running' && row.status === 'queued') {
-    overallStatus = 'running';
-    setStartedAt = ", started_at = CURRENT_TIMESTAMP";
-  }
-  if (status === 'failed') {
-    overallStatus = 'failed';
+  // In-flight workers may still report step progress after cancel; never
+  // resurrect the session gate (queued → running) from a cancelled row.
+  if (row.status !== 'cancelled') {
+    if (status === 'running' && row.status === 'queued') {
+      overallStatus = 'running';
+      setStartedAt = ", started_at = CURRENT_TIMESTAMP";
+    }
+    if (status === 'failed') {
+      overallStatus = 'failed';
+    }
   }
 
   db.prepare(
@@ -1723,6 +1727,29 @@ export function cancelCompileProgress(sessionId: string, reason: string): void {
         WHERE session_id = ?`
     )
     .run(reason, sessionId);
+}
+
+/**
+ * Cancel never-started queued sessions for other session_ids.
+ *
+ * Orphan rows are left when /api/onboarding/finalize created compile_progress
+ * but the n8n trigger failed (row stays queued, started_at NULL). They hold
+ * the global concurrency gate until the user manually cancels — blocking a
+ * new onboarding run with "Another compile session is already running."
+ */
+export function supersedeOrphanQueuedSessions(exceptSessionId: string): number {
+  const result = openDb()
+    .prepare(
+      `UPDATE compile_progress
+          SET status = 'cancelled',
+              error = 'Superseded by new compile session',
+              completed_at = CURRENT_TIMESTAMP
+        WHERE session_id != ?
+          AND status = 'queued'
+          AND started_at IS NULL`
+    )
+    .run(exceptSessionId);
+  return result.changes as number;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Auto-cancel other never-started `queued` compile sessions when starting a new onboarding finalize (orphans left after failed n8n triggers no longer block the global gate).
- Keep cancelled sessions cancelled: pipeline step updates cannot resurrect `cancelled` → `running`.
- Reject `/api/compile/run` on already-cancelled rows; review UI names the blocking `active_session_id` on 409.

## Root cause
Cancelling one session only flips that `session_id` to `cancelled`. A different session still `queued` or `running` holds the single-compile gate — common after `n8n_unreachable` orphans or starting a new run right after cancel.

## Test plan
- [x] `cd app && npm test -- src/__tests__/supersede-orphan-queued.test.ts` (3/3)
- [ ] CI integration + unit jobs green
- [ ] Manual: cancel compile → new onboarding finalize without manual orphan cancel
