### PR TITLE
fix(cli): kompl update rebuilds stack from latest source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,6 @@ docs/launch/
 
 # Agent instruction files (local only — not for public repo)
 CLAUDE.md
-AGENTS.md
 CURSOR.md
 docs/CURSOR.md
 .cursor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,78 @@
+# AGENTS.md — Kompl operator guide
+
+**For AI agents helping a user install, update, and use Kompl.**
+
+Use [README.md](README.md) as the source of truth for prerequisites, install, day-to-day commands, updating, backup, MCP setup, data handling, security, and known limitations. Install path: `projectDir` in `~/.kompl/config.json`.
+
+## What Kompl does
+
+Kompl is a **knowledge compiler** — it turns scattered links, files, and bookmarks into an interlinked wiki at ingest time (one source may update many pages). Synthesis and cross-linking happen when sources are **compiled**, not on every browse. It also ships a minimal chat interface with basic RAG over compiled pages; most users query via MCP or their own agent.
+
+---
+
+## Agent rules — wiki safety (read before any Docker command)
+
+The user's wiki (SQLite DB, page files, vectors) lives on the Docker named volume **`kompl-data`**. **You can destroy their entire wiki with one flag.** Treat that as irreversible until they restore from a `.kompl.zip`.
+
+### NEVER without explicit user confirmation
+
+**Do not run, suggest, or script any of the following unless the user has explicitly confirmed in this conversation that they accept losing their wiki** (or are on a fresh throwaway install with nothing to lose):
+
+| Command / action | Why it wipes data |
+|------------------|-------------------|
+| `docker compose down -v` | `-v` deletes named volumes including `kompl-data` |
+| `docker volume rm …` / deleting `kompl-data` in Docker Desktop | Direct volume deletion |
+| `bash scripts/integration-test.sh` | Runs `docker compose down -v` by design |
+| Re-installing into a new clone **and** removing old volumes | Orphaned or replaced `kompl-data` |
+
+If the user has **not** clearly said they want a full wipe, **stop and ask**. Do not imply these are routine cleanup steps.
+
+### If a destructive action is going to happen anyway
+
+When the user **has** explicitly ordered a wipe **or** you must run a destructive command for a stated reason:
+
+1. **Run `kompl backup` first** — no exceptions.
+2. Confirm the backup file exists (default: `~/.kompl/backups/kompl-backup.kompl.zip`, or `--output` path they chose).
+3. Tell the user where the backup is **before** running the destructive command.
+4. Only then proceed.
+
+Do not skip backup because auto-backup-on-start exists — it is best-effort and may be stale. **Always take a fresh `kompl backup` immediately before wipe.**
+
+### Safe by default (wiki preserved)
+
+These do **not** remove `kompl-data`: `kompl update`, `kompl start`, `kompl stop`, `kompl restart`, `docker compose up --build -d` (no `-v`), `docker compose down` without `-v`. Still recommend `kompl backup` before major upgrades.
+
+**Restore after wipe:** Settings → **Import Wiki** → upload `.kompl.zip`. See [README § Backup and restore](README.md#backup-and-restore).
+
+---
+
+## Update pitfall agents miss
+
+`git pull` updates files on disk but **not** the running `app` / `nlp-service` Docker images. If the user pulled but does not see new UI, run **`kompl update`** (or `docker compose up --build -d`) — do not assume the feature is missing from `main`. Full steps: [README § Updating](README.md#updating).
+
+---
+
+## Troubleshooting (agent-specific)
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| New UI missing after `git pull` | Stale Docker image | `kompl update` — see [Updating](README.md#updating) |
+| YouTube URL on Saved Links | Missing `YOUTUBE_API_KEY`, no captions, or transcript blocked | [README prerequisites](README.md#before-you-start) |
+| `extract_llm_failed` on long PDFs (Gemini) | Known truncation — [issue #7](https://github.com/tuirk/Kompl/issues/7) | Switch to DeepSeek in Settings or split the source |
+| Wiki gone | `down -v`, integration tests, or volume delete | Restore from `.kompl.zip`; you should not have run destructive commands without explicit confirmation + `kompl backup` |
+
+For everything else: `kompl logs`, `kompl status`, and [README troubleshooting cues](README.md#after-setup).
+
+---
+
+## Querying the wiki (MCP)
+
+Once Kompl is **running**, query the compiled wiki via the MCP server. Setup and tools: [README § Use with AI agents (MCP)](README.md#use-with-ai-agents-mcp).
+
+---
+
+## Changing Kompl source code
+
+If the user wants to **modify [tuirk/Kompl](https://github.com/tuirk/Kompl)** (not just run an install), see [CONTRIBUTING.md](CONTRIBUTING.md). After pulling code changes, run `docker compose up --build -d` from **`projectDir`**.
+
+**Never run `bash scripts/integration-test.sh` on the user's live wiki** without explicit confirmation and a fresh `kompl backup`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ ship with a `migrate.py` step that runs at boot.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`kompl update`** — now runs `git pull --ff-only`, rebuilds and relinks the
+  CLI, pulls registry images, and `docker compose up --build -d` so app and
+  nlp-service pick up source changes. README adds an **Updating** section
+  documenting the stale-Docker-image gotcha.
+
 ### Removed
 
 - **Weekly Telegram digest** — removed the digest API route, n8n workflow,

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You'll also need API keys. Two are required, two are optional:
 |---|---|---|---|---|
 | **Gemini** (wiki compilation) | Required | [aistudio.google.com/apikey](https://aistudio.google.com/apikey) | 1500 req/day | Free works for the demo and your first few sources. **Paid Tier 1 is strongly recommended for real use** — Gemini's free per-minute throttle (~10 RPM) will rate-limit a normal ingest, even though daily quota is plenty. Default rate-limiter assumes Tier 1. Has a known truncation issue on dense inputs — see [issue #7](https://github.com/tuirk/Kompl/issues/7). |
 | **Firecrawl** (URL scraping) | Required | [firecrawl.dev](https://firecrawl.dev) | 500 scrapes/month | Free tier covers normal personal use. |
-| **YouTube Data API v3** (YouTube ingestion) | Optional | [console.cloud.google.com](https://console.cloud.google.com/apis/library/youtube.googleapis.com) | 10,000 units/day (1 unit per video) | Required to ingest YouTube URLs — without it, every YouTube URL hard-fails and routes to Saved Links. Restrict the key to "YouTube Data API v3" only in the GCP console. Set `YOUTUBE_API_KEY` in `.env`. |
+| **YouTube Data API v3** (YouTube ingestion) | Optional | [console.cloud.google.com](https://console.cloud.google.com/apis/library/youtube.googleapis.com) | 10,000 units/day (1 unit per video) | Needed for YouTube **metadata** at compile time (title, channel, duration). Captions use `youtube-transcript-api` (no key). Without this key, convert fails with `youtube_metadata_unavailable` and the URL lands on **Saved Links** — not a compiled source. Restrict the key to "YouTube Data API v3" only in the GCP console. Set `YOUTUBE_API_KEY` in `.env`. |
 | **DeepSeek V4 Pro** (alternative compile backend) | Optional | [api-docs.deepseek.com](https://api-docs.deepseek.com) | Pay-as-you-go | Selectable in Settings as an alternative to Gemini. Recommended for long/academic content — see [Known limitations](#known-limitations). Set `DEEPSEEK_API_KEY` in `.env`. |
 
 ## Setup
@@ -113,14 +113,49 @@ kompl restart    # stop + start in one command
 kompl open       # open in browser
 kompl status     # health check: page count, NLP service, vector backlog
 kompl logs       # stream logs if something looks wrong
-kompl update     # pull latest version and restart
+kompl update     # pull latest source, rebuild images, and restart (~5–10 min)
 kompl backup     # download a full backup to ~/.kompl/backups/kompl-backup.kompl.zip
 kompl init       # re-run the first-time setup wizard (rarely needed)
 ```
 
+## Updating
+
+Pulled latest `main` but don't see new UI (health checks, bookmark filters, etc.)? Your **Docker images are probably stale** — `git pull` updates files on disk, but the running `app` and `nlp-service` containers are built from source at install time. Only the `n8n` image updates via `docker compose pull`.
+
+**Your wiki is safe on a normal update.** Page data lives on the Docker volume `kompl-data`. `kompl update` and `docker compose up --build -d` rebuild containers but **do not** wipe that volume. Back up anyway before major upgrades:
+
+```bash
+kompl backup     # ~/.kompl/backups/kompl-backup.kompl.zip
+kompl update
+```
+
+> ⚠ **Never** run `docker compose down -v` unless you intend to delete everything. The `-v` flag removes volumes. `bash scripts/integration-test.sh` is also destructive — see [Backup and restore](#backup-and-restore).
+
+**Recommended:**
+
+```bash
+kompl update
+```
+
+This pulls source, refreshes the `kompl` CLI, pulls registry images, rebuilds `app` + `nlp-service`, and waits for `/api/health` (~5–10 min).
+
+**Manual fallback** (same steps; use if your `kompl` binary predates this fix):
+
+```bash
+cd <projectDir>    # path in ~/.kompl/config.json
+git pull --ff-only
+cd cli && npm install && npm run build && npm link
+docker compose pull
+docker compose up --build -d
+```
+
+`kompl start` and `kompl restart` restart existing images in ~15 seconds — they do **not** rebuild after a pull.
+
+**Verify:** onboarding should route through `/onboarding/health`; importing browser bookmarks should skip `x.com` / `twitter.com` URLs with a toast.
+
 ## Use with AI agents (MCP)
 
-Kompl ships an MCP server so any MCP-capable agent — Claude Code, Claude Desktop, Cursor, or a custom client built on `@modelcontextprotocol/sdk` — can query your compiled wiki. Ask *"what does my wiki say about X?"* and the agent gets pre-synthesized pages with provenance back to the originals, not raw chunks.
+Kompl ships an MCP server so any MCP-capable agent built on `@modelcontextprotocol/sdk` can query your compiled wiki. Ask *"what does my wiki say about X?"* and the agent gets pre-synthesized pages with provenance back to the originals, not raw chunks.
 
 > ⚠ **Single-tenant.** Kompl assumes you own the host. There's no multi-user auth — don't expose your instance to the public internet without putting your own auth in front.
 
@@ -130,44 +165,15 @@ Kompl ships an MCP server so any MCP-capable agent — Claude Code, Claude Deskt
 cd mcp-server && npm install && npm run build
 ```
 
-Kompl must be running (`kompl start`) for the MCP tools to respond.
-
-### Claude Code
-
-Create `.mcp.json` in the repo root with:
-
-```json
-{
-  "mcpServers": {
-    "kompl-wiki": {
-      "type": "stdio",
-      "command": "node",
-      "args": ["mcp-server/dist/index.js"],
-      "env": { "KOMPL_URL": "http://localhost:3000" }
-    }
-  }
-}
-```
-
-Claude Code picks it up automatically next session. Try: *"search my wiki for [topic]"* or *"read the relevant page from my wiki for [topic]."*
-
-### Claude Desktop
-
-| OS | Config file |
-|---|---|
-| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
-| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
-| Linux | `~/.config/Claude/claude_desktop_config.json` (no official Linux release; convention if a build is available) |
-
-Add the same `mcpServers` block as above, but with the **absolute** path to `mcp-server/dist/index.js` instead of relative.
+Configure your MCP client to run `node mcp-server/dist/index.js` with `KOMPL_URL=http://localhost:3000`. Kompl must be running (`kompl start`) for the MCP tools to respond.
 
 ### Tools
 
 The server exposes four: `search_wiki`, `read_page`, `list_pages`, `wiki_stats`.
 
-### Non-MCP / direct HTTP
+### Direct HTTP
 
-If you're not using an MCP client, hit the Next.js routes directly: `/api/pages/search`, `/api/wiki/{page_id}/data`, `/api/wiki/index`.
+If you're not using MCP, hit the Next.js routes directly: `/api/pages/search`, `/api/wiki/{page_id}/data`, `/api/wiki/index`.
 
 ## Your data
 
@@ -178,7 +184,7 @@ Your wiki content lives in Docker volumes on your machine. Outbound network call
 - **DeepSeek** (`api.deepseek.com`) — wiki compilation when the DeepSeek backend is selected. Your source text is sent to DeepSeek. Only outbound if `DEEPSEEK_API_KEY` is configured and selected as the compile model.
 - **Firecrawl** (`api.firecrawl.dev`) — URL scraping fallback. The URL you pasted is sent to Firecrawl.
 - **GitHub public API** (`api.github.com`) — when you paste a GitHub repo URL, Kompl fetches the README + metadata.
-- **YouTube** (`youtube.com` + `youtube.googleapis.com`) — when you paste a YouTube URL, transcripts are fetched via the public captions endpoint and metadata (title, channel, duration) via YouTube Data API v3. Requires `YOUTUBE_API_KEY`; without it, YouTube URLs route to Saved Links.
+- **YouTube** (`youtube.com` + `youtube.googleapis.com`) — at compile time, captions via `youtube-transcript-api`, then metadata via YouTube Data API v3 (`YOUTUBE_API_KEY` required). Missing key → `youtube_metadata_unavailable` → Saved Links. No captions or blocked transcript → Saved Links too.
 - **OG-tag preview** — pasted URLs are fetched once with `User-Agent: KomplBot/1.0` to grab title + description.
 
 **One-time, on first use:**
@@ -220,7 +226,7 @@ kompl backup --schedule                               # register a weekly backup
 
 **Known limitations:**
 - Single-tenant only — no user accounts or access control. Don't expose to the public internet without your own auth layer.
-- Two LLM providers selectable per session: Gemini 2.5 (default) and DeepSeek V4 Pro. Anthropic and OpenAI-compatible providers are planned.
+- Two LLM providers selectable per session: Gemini 2.5 (default) and DeepSeek V4 Pro.
 - **Gemini 2.5 + dense sources:** structured-output truncation on inputs above ~50K chars (commonly academic PDFs and surveys) causes `extract_llm_failed`. Workaround: switch the session to DeepSeek V4 Pro in Settings — it handles up to ~200K chars cleanly without this pathology. Kompl does **not** auto-chunk long sources; if you'd rather stay on Gemini, split the source into smaller files yourself before ingesting. Tracked in [issue #7](https://github.com/tuirk/Kompl/issues/7).
 - **Current connectors:** URLs (YouTube transcripts and GitHub READMEs included), file uploads (PDF, DOCX, PPTX, XLSX, TXT, MD, HTML), browser bookmarks, Twitter JSON export, Upnote, Apple Notes.
 - No mobile app. The web UI works on mobile browsers but isn't optimized for small screens.
@@ -228,13 +234,6 @@ kompl backup --schedule                               # register a weekly backup
 ## Security
 
 Kompl runs on a personal computer behind a loopback or LAN. The security posture is calibrated for that model.
-
-**Hardening shipped (4-commit security pass, April 2026):**
-- SSRF protection on `/metadata/peek` — DNS-resolved IP pinning via httpx `sni_hostname` extension, scheme allowlist, cloud-metadata blocklist, manual redirect revalidation.
-- Path-traversal hardening across nlp-service and Next.js — regex-validated IDs (`^[a-z0-9](?:[a-z0-9_-]{0,79})$`) + `Path.resolve().relative_to()` containment.
-- Centralized YAML frontmatter escaping with C0/C1/U+2028/U+2029/BOM stripping.
-- Log-forging protection on compile pipeline log lines.
-- nlp-service port bound to `127.0.0.1` so the LAN cannot bypass the Next.js front door.
 
 **Known security debt:**
 - Markdown HTML output is not yet sanitized — Firecrawl-scraped content can carry XSS payloads. Even on a single-user install, an ingested bookmark can deliver a payload; needs DOMPurify in the render pipeline.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,7 +40,7 @@ Kompl runs locally on your machine. The attack surface is:
 | Latest  | ✅        |
 | Older   | ❌        |
 
-We only patch the latest release. Update with `kompl update`.
+We only patch the latest release. Update with `kompl update` (pulls latest source, rebuilds locally-built Docker images, and restarts the stack).
 
 ## Disclaimer
 

--- a/cli/src/__tests__/git.test.ts
+++ b/cli/src/__tests__/git.test.ts
@@ -1,0 +1,39 @@
+import fs from 'fs'
+import path from 'path'
+import { execSync } from 'child_process'
+import { assertGitRepo, NotGitRepoError, pullFfOnly } from '../git'
+
+jest.mock('fs')
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  execSync: jest.fn(),
+}))
+
+const mockFs = fs as jest.Mocked<typeof fs>
+const mockExecSync = execSync as jest.Mock
+
+afterEach(() => jest.resetAllMocks())
+
+describe('assertGitRepo', () => {
+  it('passes when .git exists', () => {
+    mockFs.existsSync.mockReturnValue(true)
+    expect(() => assertGitRepo('/tmp/kompl')).not.toThrow()
+    expect(mockFs.existsSync).toHaveBeenCalledWith(path.join('/tmp/kompl', '.git'))
+  })
+
+  it('throws NotGitRepoError when .git is missing', () => {
+    mockFs.existsSync.mockReturnValue(false)
+    expect(() => assertGitRepo('/tmp/kompl')).toThrow(NotGitRepoError)
+  })
+})
+
+describe('pullFfOnly', () => {
+  it('runs git pull --ff-only in projectDir', () => {
+    mockExecSync.mockReturnValue(Buffer.from(''))
+    pullFfOnly('/tmp/kompl')
+    expect(mockExecSync).toHaveBeenCalledWith('git pull --ff-only', {
+      cwd: '/tmp/kompl',
+      stdio: 'inherit',
+    })
+  })
+})

--- a/cli/src/__tests__/update.test.ts
+++ b/cli/src/__tests__/update.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for update.ts — kompl update orchestration
+ */
+
+import { updateCommand } from '../commands/update'
+import { NotGitRepoError } from '../git'
+
+const mockReadConfig = jest.fn(() => ({ projectDir: '/tmp/kompl', port: 3000 }))
+const mockDockerRunning = jest.fn()
+const mockPull = jest.fn()
+const mockUpAllBuild = jest.fn()
+const mockAssertGitRepo = jest.fn()
+const mockPullFfOnly = jest.fn()
+const mockRelinkCli = jest.fn()
+const mockPollHealth = jest.fn()
+
+jest.mock('../config.js', () => ({
+  readConfig: () => mockReadConfig(),
+}))
+jest.mock('../compose.js', () => ({
+  dockerRunning: (...args: unknown[]) => mockDockerRunning(...args),
+  pull: (...args: unknown[]) => mockPull(...args),
+  upAllBuild: (...args: unknown[]) => mockUpAllBuild(...args),
+}))
+jest.mock('../git.js', () => {
+  const actual = jest.requireActual('../git.js')
+  return {
+    ...actual,
+    assertGitRepo: (...args: unknown[]) => mockAssertGitRepo(...args),
+    pullFfOnly: (...args: unknown[]) => mockPullFfOnly(...args),
+  }
+})
+jest.mock('../relink-cli.js', () => ({
+  relinkCli: (...args: unknown[]) => mockRelinkCli(...args),
+}))
+jest.mock('../health.js', () => ({
+  pollHealth: (...args: unknown[]) => mockPollHealth(...args),
+}))
+
+let exitSpy: jest.SpyInstance
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockReadConfig.mockReturnValue({ projectDir: '/tmp/kompl', port: 3000 })
+  mockDockerRunning.mockReturnValue({ ok: true })
+  mockPull.mockResolvedValue(undefined)
+  mockUpAllBuild.mockResolvedValue(undefined)
+  mockPollHealth.mockResolvedValue({ schema_version: 25, page_count: 0 })
+  mockAssertGitRepo.mockImplementation(() => undefined)
+  mockPullFfOnly.mockImplementation(() => undefined)
+  mockRelinkCli.mockImplementation(() => undefined)
+  exitSpy = jest.spyOn(process, 'exit').mockImplementation(((code: number) => {
+    throw new Error(`process.exit(${code})`)
+  }) as never)
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+  jest.spyOn(console, 'log').mockImplementation(() => {})
+})
+
+afterEach(() => jest.restoreAllMocks())
+
+function runUpdate(): Promise<void> {
+  return updateCommand()
+}
+
+it('happy path: git pull, relink CLI, pull images, rebuild, health poll', async () => {
+  await runUpdate()
+
+  expect(mockAssertGitRepo).toHaveBeenCalledWith('/tmp/kompl')
+  expect(mockPullFfOnly).toHaveBeenCalledWith('/tmp/kompl')
+  expect(mockRelinkCli).toHaveBeenCalledWith('/tmp/kompl')
+  expect(mockPull).toHaveBeenCalledWith('/tmp/kompl')
+  expect(mockUpAllBuild).toHaveBeenCalledWith('/tmp/kompl')
+  expect(mockPollHealth).toHaveBeenCalledWith(3000, 60_000)
+  expect(exitSpy).not.toHaveBeenCalled()
+})
+
+it('exits when Docker is not running', async () => {
+  mockDockerRunning.mockReturnValue({ ok: false, reason: 'not-running' })
+  await expect(runUpdate()).rejects.toThrow('process.exit(1)')
+  expect(mockPullFfOnly).not.toHaveBeenCalled()
+})
+
+it('exits when not a git repo', async () => {
+  mockAssertGitRepo.mockImplementation(() => {
+    throw new NotGitRepoError('/tmp/kompl')
+  })
+  await expect(runUpdate()).rejects.toThrow('process.exit(1)')
+  expect(mockPullFfOnly).not.toHaveBeenCalled()
+})
+
+it('exits when git pull fails', async () => {
+  mockPullFfOnly.mockImplementation(() => {
+    throw new Error('merge conflict')
+  })
+  await expect(runUpdate()).rejects.toThrow('process.exit(1)')
+  expect(mockRelinkCli).not.toHaveBeenCalled()
+})
+
+it('exits when docker compose pull fails', async () => {
+  mockPull.mockRejectedValue(new Error('registry down'))
+  await expect(runUpdate()).rejects.toThrow('process.exit(1)')
+  expect(mockUpAllBuild).not.toHaveBeenCalled()
+})
+
+it('exits when health check times out', async () => {
+  mockPollHealth.mockResolvedValue(null)
+  await expect(runUpdate()).rejects.toThrow('process.exit(1)')
+})

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -10,7 +10,7 @@ export async function initCommand(): Promise<void> {
   const { projectDir } = await prompts({
     type: 'text',
     name: 'projectDir',
-    message: 'Path to your KomplCore directory:',
+    message: 'Path to your Kompl install directory:',
     initial: process.cwd(),
     validate: (v: string) => {
       const composePath = path.join(v, 'docker-compose.yml')

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -1,13 +1,56 @@
 import pc from 'picocolors'
 import { readConfig } from '../config.js'
-import { pull, upAll } from '../compose.js'
+import { dockerRunning, pull, upAllBuild } from '../compose.js'
+import { assertGitRepo, NotGitRepoError, pullFfOnly } from '../git.js'
 import { pollHealth } from '../health.js'
 import type { HealthResponse } from '../health.js'
+import { relinkCli } from '../relink-cli.js'
 
 export async function updateCommand(): Promise<void> {
   const config = readConfig()
 
-  console.log(pc.dim('Pulling latest images...'))
+  console.log(pc.dim('Checking Docker...'))
+  const docker = dockerRunning()
+  if (!docker.ok) {
+    if (docker.reason === 'permission-denied') {
+      console.error(pc.red('✗ Docker permission denied.'))
+      console.error(pc.dim('  Add your user to the docker group and re-login:'))
+      console.error(pc.dim('    sudo usermod -aG docker $USER'))
+    } else {
+      console.error(pc.red('✗ Docker is not running. Start Docker and try again.'))
+    }
+    process.exit(1)
+  }
+
+  try {
+    assertGitRepo(config.projectDir)
+  } catch (err: unknown) {
+    if (err instanceof NotGitRepoError) {
+      console.error(pc.red(`✗ ${err.message}`))
+      process.exit(1)
+    }
+    throw err
+  }
+
+  console.log(pc.dim('Pulling latest source...'))
+  try {
+    pullFfOnly(config.projectDir)
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    console.error(pc.red(`✗ git pull failed: ${msg}`))
+    process.exit(1)
+  }
+
+  console.log(pc.dim('Refreshing kompl CLI...'))
+  try {
+    relinkCli(config.projectDir)
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    console.error(pc.red(`✗ CLI refresh failed: ${msg}`))
+    process.exit(1)
+  }
+
+  console.log(pc.dim('Pulling registry images...'))
   try {
     await pull(config.projectDir)
   } catch (err: unknown) {
@@ -16,18 +59,18 @@ export async function updateCommand(): Promise<void> {
     process.exit(1)
   }
 
-  console.log(pc.dim('Restarting stack with new images...'))
+  console.log(pc.dim('Rebuilding and restarting stack (may take 5–10 min)...'))
   try {
-    await upAll(config.projectDir)
+    await upAllBuild(config.projectDir)
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err)
-    console.error(pc.red(`✗ Restart failed: ${msg}`))
+    console.error(pc.red(`✗ Rebuild failed: ${msg}`))
     process.exit(1)
   }
 
   process.stdout.write(pc.dim('Waiting for app to be ready'))
   const timer = setInterval(() => process.stdout.write('.'), 1000)
-  let health: import('../health.js').HealthResponse | null = null
+  let health: HealthResponse | null = null
   try {
     health = await pollHealth(config.port, 60_000)
   } finally {

--- a/cli/src/compose.ts
+++ b/cli/src/compose.ts
@@ -29,6 +29,10 @@ export async function upAll(projectDir: string): Promise<void> {
   await compose.upAll({ ...composeOpts(projectDir), commandOptions: ['-d'] })
 }
 
+export async function upAllBuild(projectDir: string): Promise<void> {
+  await compose.upAll({ ...composeOpts(projectDir), commandOptions: ['-d', '--build'] })
+}
+
 export async function down(projectDir: string): Promise<void> {
   await compose.down(composeOpts(projectDir))
 }

--- a/cli/src/git.ts
+++ b/cli/src/git.ts
@@ -1,0 +1,23 @@
+import fs from 'fs'
+import path from 'path'
+import { execSync } from 'child_process'
+
+export class NotGitRepoError extends Error {
+  constructor(projectDir: string) {
+    super(
+      `No git repository at ${projectDir}. kompl update requires a git clone — re-install from README or run docker compose up --build -d manually after updating source.`
+    )
+    this.name = 'NotGitRepoError'
+  }
+}
+
+export function assertGitRepo(projectDir: string): void {
+  const gitDir = path.join(projectDir, '.git')
+  if (!fs.existsSync(gitDir)) {
+    throw new NotGitRepoError(projectDir)
+  }
+}
+
+export function pullFfOnly(projectDir: string): void {
+  execSync('git pull --ff-only', { cwd: projectDir, stdio: 'inherit' })
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -18,7 +18,7 @@ program
 
 program
   .command('init')
-  .description('First-time setup — configure the path to your KomplCore directory')
+  .description('First-time setup — configure the path to your Kompl install directory')
   .action(() => initCommand().catch(die))
 
 program
@@ -54,7 +54,7 @@ program
 
 program
   .command('update')
-  .description('Pull latest images and restart the stack')
+  .description('Pull latest source, rebuild images, and restart the stack')
   .action(() => updateCommand().catch(die))
 
 program

--- a/cli/src/relink-cli.ts
+++ b/cli/src/relink-cli.ts
@@ -1,0 +1,31 @@
+import path from 'path'
+import { execSync } from 'child_process'
+
+function run(cmd: string, cwd: string): void {
+  execSync(cmd, { cwd, stdio: 'inherit', shell: true })
+}
+
+/**
+ * Rebuild and globally link the kompl CLI after source updates.
+ * Mirrors setup.js step 4 (npm install + npm link).
+ */
+export function relinkCli(projectDir: string): void {
+  const cliDir = path.join(projectDir, 'cli')
+  run('npm install', cliDir)
+  try {
+    run('npm run build', cliDir)
+    run('npm link', cliDir)
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    if (msg.includes('EACCES') || msg.includes('permission denied')) {
+      console.error('\n  Error: npm link failed — permission denied.')
+      console.error('  Your npm global prefix requires elevated access. Fix with:')
+      console.error('    mkdir -p ~/.npm-global')
+      console.error('    npm config set prefix ~/.npm-global')
+      console.error('    echo \'export PATH="$HOME/.npm-global/bin:$PATH"\' >> ~/.bashrc  # or ~/.zshrc')
+      console.error('    source ~/.bashrc')
+      console.error('  Then re-run: kompl update\n')
+    }
+    throw err
+  }
+}


### PR DESCRIPTION
## What changed

`kompl update` now runs `git pull --ff-only`, relinks the CLI (`npm install` / build / link), pulls registry images, and `docker compose up -d --build` so `app` and `nlp-service` pick up source changes. Adds `AGENTS.md` to the public repo (wiki-safety + update pitfalls for AI agents) and documents the stale-Docker-image gotcha in README/CHANGELOG.

## Why

Users who `git pull` but skip a rebuild keep running old `app`/`nlp-service` images — the #1 support confusion after releases. The old `kompl update` only pulled/restarted and did not fix that.

## How was this tested?

- [x] Unit tests pass locally (`npm test` in `app/` and `cli/`, `pytest` in `nlp-service/`)
- [ ] Manually exercised the change end-to-end
- [ ] N/A — explain why

CLI: `cd cli && npm test` — 37 passed (includes new `git.test.ts` and `update.test.ts`).

## Anything else reviewers should know?

- `AGENTS.md` removed from `.gitignore`; `CLAUDE.md` stays local-only per existing policy.
- `git pull --ff-only` will fail on diverged local branches (intentional — avoids silent merge commits during update).
- Diff is ~380 lines but is one cohesive change (CLI fix + operator docs).