### PR TITLE
fix(security): close critical and high audit findings

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -95,6 +95,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
+      - name: Install ripgrep (stage 11d)
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
       - name: Run integration test
         run: bash scripts/integration-test.sh
         env:

--- a/app/instrumentation.ts
+++ b/app/instrumentation.ts
@@ -10,56 +10,17 @@
  * during build/dev; `getPendingFlushPages` opens SQLite which is Node-only.
  */
 
-const NLP_SERVICE_URL = process.env.NLP_SERVICE_URL ?? 'http://nlp-service:8000';
-
-type FlushResult = { ok: true; previousPath: string | null } | { ok: false };
-
-async function flushPendingPage(
-  pageId: string,
-  markdown: string
-): Promise<FlushResult> {
-  try {
-    const res = await fetch(`${NLP_SERVICE_URL}/storage/write-page`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ page_id: pageId, markdown }),
-      signal: AbortSignal.timeout(30_000),
-    });
-    if (!res.ok) {
-      console.error(
-        JSON.stringify({
-          ts: new Date().toISOString(),
-          event: 'reconciler_flush_http_error',
-          page_id: pageId,
-          status: res.status,
-        })
-      );
-      return { ok: false };
-    }
-    const body = (await res.json()) as { current_path: string; previous_path: string | null };
-    return { ok: true, previousPath: body.previous_path };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.error(
-      JSON.stringify({
-        ts: new Date().toISOString(),
-        event: 'reconciler_flush_error',
-        page_id: pageId,
-        error: msg,
-      })
-    );
-    return { ok: false };
-  }
-}
-
 async function reconcilePendingFlushes(): Promise<void> {
   // Guard here (in addition to register()) so Turbopack's edge-bundle static
   // analysis can dead-code-eliminate the dynamic import below and suppress the
   // node-module-in-edge-runtime warnings for node:crypto/fs/path/zlib in db.ts.
   if (process.env.NEXT_RUNTIME === 'edge') return;
 
-  // Dynamically import so the module only resolves in Node runtime.
+  // Dynamically import so the modules only resolve in Node runtime.
+  // flushPendingPage lives in src/lib/flush-pending.ts — shared with the
+  // commit route's post-loop durability pass.
   const { getPendingFlushPages, clearPendingContent } = await import('./src/lib/db');
+  const { flushPendingPage } = await import('./src/lib/flush-pending');
 
   const pending = getPendingFlushPages();
   if (pending.length === 0) return;

--- a/app/src/__tests__/commit-flush-durability.test.ts
+++ b/app/src/__tests__/commit-flush-durability.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Durability gate on Phase 3a flush failures (CLAUDE.md rule #5).
+ *
+ * Regression target: pre-fix, a /storage/write-page failure during commit was
+ * logged and swallowed — `committed` still incremented and run/route.ts called
+ * completeCompileProgress(), so the session read 'completed' while .md.gz
+ * files were missing from disk.
+ *
+ * Covers:
+ *   1. write-page down → commit responds flush_failures=1; the page row is
+ *      committed in DB with pending_content still populated (outbox intact).
+ *   2. Retry recovery: a second commit call (plans already 'committed' → the
+ *      empty-plans path) with NLP healthy re-flushes via the reconcile pass,
+ *      clears pending_content, and reports flush_failures=0.
+ *   3. Control: healthy write-page → flush_failures=0, pending_content NULL.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { POST as commitPOST } from '../app/api/compile/commit/route';
+import {
+  setupTestDb,
+  seedSource,
+  seedPage,
+  seedPagePlan,
+  seedCompileProgress,
+  type TestDbHandle,
+} from './helpers/test-db';
+
+let handle: TestDbHandle | null = null;
+
+afterEach(() => {
+  handle?.cleanup();
+  handle = null;
+  vi.unstubAllGlobals();
+});
+
+function commitRequest(session_id: string): Request {
+  return new Request('http://test/api/compile/commit', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ session_id }),
+  });
+}
+
+function mockNlpFetch(opts: { writePageOk: boolean; failForPageId?: string }): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = url.toString();
+      if (u.includes('/storage/write-page')) {
+        const body = JSON.parse(String(init?.body ?? '{}')) as { page_id?: string };
+        const shouldFail =
+          !opts.writePageOk ||
+          (opts.failForPageId !== undefined && body.page_id === opts.failForPageId);
+        if (shouldFail) {
+          return new Response('{"detail":"disk full"}', { status: 500 });
+        }
+        return new Response(
+          JSON.stringify({ current_path: '/data/pages/x.md.gz', previous_path: null }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      if (u.includes('/vectors/upsert')) return new Response('{}', { status: 200 });
+      throw new Error(`unexpected fetch in test: ${u}`);
+    })
+  );
+}
+
+interface CommitResp {
+  committed: number;
+  failed: number;
+  flush_failures: number;
+}
+
+function seedCommittablePlan(session_id: string): void {
+  const source_id = seedSource(handle!.db, {
+    onboarding_session_id: session_id,
+    compile_status: 'in_progress',
+  });
+  seedCompileProgress(handle!.db, session_id);
+  seedPagePlan(handle!.db, {
+    plan_id: `plan-${session_id}`,
+    session_id,
+    page_type: 'entity',
+    action: 'create',
+    source_ids: [source_id],
+    draft_status: 'crossreffed',
+    draft_content: `---\ntitle: "Durable"\n---\n${'d'.repeat(900)}`,
+  });
+}
+
+describe('commit durability gate (flush_failures)', () => {
+  it('reports flush_failures when write-page is down; DB row stays in outbox', async () => {
+    handle = setupTestDb();
+    const session_id = 'sess-flush-fail';
+    seedCommittablePlan(session_id);
+    mockNlpFetch({ writePageOk: false });
+
+    const res = await commitPOST(commitRequest(session_id));
+    const body = (await res.json()) as CommitResp;
+
+    // DB commit succeeded — the page row is durable in SQLite...
+    expect(body.committed).toBe(1);
+    expect(body.failed).toBe(0);
+    // ...but the file never reached disk, even after the reconcile pass.
+    expect(body.flush_failures).toBe(1);
+
+    const page = handle.db
+      .prepare('SELECT pending_content FROM pages LIMIT 1')
+      .get() as { pending_content: string | null };
+    expect(page.pending_content).not.toBeNull();
+  });
+
+  it('retry commit (empty-plans path) re-flushes stranded pages once NLP recovers', async () => {
+    handle = setupTestDb();
+    const session_id = 'sess-flush-retry';
+    seedCommittablePlan(session_id);
+
+    // First commit: write-page down → stranded pending_content.
+    mockNlpFetch({ writePageOk: false });
+    const res1 = await commitPOST(commitRequest(session_id));
+    expect(((await res1.json()) as CommitResp).flush_failures).toBe(1);
+
+    // Second commit: all plans 'committed' → early-return path. The
+    // reconcile pass is the only thing that can recover the file.
+    mockNlpFetch({ writePageOk: true });
+    const res2 = await commitPOST(commitRequest(session_id));
+    const body2 = (await res2.json()) as CommitResp;
+    expect(body2.committed).toBe(0); // no crossreffed plans left
+    expect(body2.flush_failures).toBe(0);
+
+    const page = handle.db
+      .prepare('SELECT pending_content FROM pages LIMIT 1')
+      .get() as { pending_content: string | null };
+    expect(page.pending_content).toBeNull();
+  });
+
+  it('session scoping: a stranded pending page from ANOTHER session never false-fails this one', async () => {
+    handle = setupTestDb();
+    const session_id = 'sess-flush-scoped';
+    seedCommittablePlan(session_id);
+
+    // Foreign stranded outbox row — e.g. a flush failure from a different
+    // session or an approve/recompile path. Its write-page keeps failing.
+    seedPage(handle.db, { page_id: 'foreign-stranded-page', title: 'Foreign' });
+    handle.db
+      .prepare('UPDATE pages SET pending_content = ? WHERE page_id = ?')
+      .run('# stranded elsewhere', 'foreign-stranded-page');
+
+    mockNlpFetch({ writePageOk: true, failForPageId: 'foreign-stranded-page' });
+
+    const res = await commitPOST(commitRequest(session_id));
+    const body = (await res.json()) as CommitResp;
+
+    // This session's own page flushed fine — the foreign failure must not
+    // gate it (flush_failures is session-scoped), though the sweep DID
+    // attempt the foreign page (and left its outbox row intact for its
+    // own session/boot reconciler to recover).
+    expect(body.committed).toBe(1);
+    expect(body.flush_failures).toBe(0);
+
+    const foreign = handle.db
+      .prepare('SELECT pending_content FROM pages WHERE page_id = ?')
+      .get('foreign-stranded-page') as { pending_content: string | null };
+    expect(foreign.pending_content).not.toBeNull();
+  });
+
+  it('control: healthy write-page → flush_failures=0 and outbox cleared', async () => {
+    handle = setupTestDb();
+    const session_id = 'sess-flush-ok';
+    seedCommittablePlan(session_id);
+    mockNlpFetch({ writePageOk: true });
+
+    const res = await commitPOST(commitRequest(session_id));
+    const body = (await res.json()) as CommitResp;
+
+    expect(body.committed).toBe(1);
+    expect(body.flush_failures).toBe(0);
+
+    const page = handle.db
+      .prepare('SELECT pending_content FROM pages LIMIT 1')
+      .get() as { pending_content: string | null };
+    expect(page.pending_content).toBeNull();
+  });
+});

--- a/app/src/__tests__/markdown-sanitize.test.ts
+++ b/app/src/__tests__/markdown-sanitize.test.ts
@@ -1,0 +1,130 @@
+/**
+ * XSS hardening in lib/markdown.ts + lib/safe-url.ts.
+ *
+ * Regression target: marked 12 passes raw HTML through by default, and
+ * renderMarkdown() output lands in dangerouslySetInnerHTML on wiki/source
+ * pages. Ingested scrapes, LLM drafts, and import zips are untrusted, so
+ * a literal <script> in page markdown executed in the reader's browser.
+ *
+ * Covers:
+ *   - raw HTML (block + inline) is escaped, not rendered
+ *   - javascript:/data:/vbscript: links render as text, no <a>
+ *   - unsafe image src renders alt text, no <img>
+ *   - safe markdown (headings, links, images, code, tables) still renders
+ *   - safeExternalUrl / safeMarkdownHref allowlists
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderMarkdown } from '../lib/markdown';
+import { safeExternalUrl, safeMarkdownHref } from '../lib/safe-url';
+
+describe('renderMarkdown — raw HTML escaping', () => {
+  it('escapes a block-level <script> tag', () => {
+    const html = renderMarkdown('hello\n\n<script>alert(1)</script>\n\nworld');
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('escapes inline HTML inside a paragraph', () => {
+    const html = renderMarkdown('before <img src=x onerror=alert(1)> after');
+    expect(html).not.toContain('<img');
+    expect(html).toContain('&lt;img');
+  });
+
+  it('escapes iframe/svg event-handler vectors', () => {
+    const html = renderMarkdown('<iframe src="https://evil.example"></iframe>\n\n<svg onload=alert(1)>');
+    expect(html).not.toContain('<iframe');
+    expect(html).not.toContain('<svg');
+  });
+});
+
+describe('renderMarkdown — link/image scheme allowlist', () => {
+  it('drops javascript: links but keeps the link text', () => {
+    const html = renderMarkdown('[click me](javascript:alert(1))');
+    expect(html).not.toContain('javascript:');
+    expect(html).not.toContain('<a ');
+    expect(html).toContain('click me');
+  });
+
+  it('drops data: links', () => {
+    const html = renderMarkdown('[x](data:text/html;base64,PHNjcmlwdD4=)');
+    expect(html).not.toContain('data:');
+    expect(html).not.toContain('<a ');
+  });
+
+  it('drops unsafe image src and renders alt text', () => {
+    const html = renderMarkdown('![alt text](javascript:alert(1))');
+    expect(html).not.toContain('<img');
+    expect(html).not.toContain('javascript:');
+    expect(html).toContain('alt text');
+  });
+
+  it('keeps https links and images', () => {
+    const html = renderMarkdown('[ok](https://example.org/a) ![pic](https://example.org/p.png "cap")');
+    expect(html).toContain('<a href="https://example.org/a">ok</a>');
+    expect(html).toContain('<img src="https://example.org/p.png" alt="pic" title="cap">');
+  });
+
+  it('keeps anchors and relative links', () => {
+    const html = renderMarkdown('[toc](#section) and [wiki](/wiki/some-page)');
+    expect(html).toContain('href="#section"');
+    expect(html).toContain('href="/wiki/some-page"');
+  });
+
+  it('escapes quotes in titles so attributes cannot be broken out of', () => {
+    const html = renderMarkdown('[t](https://example.org "x\" onmouseover=\"alert(1)")');
+    expect(html).not.toContain('onmouseover="alert');
+  });
+});
+
+describe('renderMarkdown — sane markdown still renders', () => {
+  it('renders headings with slug ids, bold, code, and tables', () => {
+    const html = renderMarkdown(
+      '## My Heading\n\n**bold** and `code`\n\n| a | b |\n| - | - |\n| 1 | 2 |'
+    );
+    expect(html).toContain('<h2 id="my-heading">');
+    expect(html).toContain('<strong>bold</strong>');
+    expect(html).toContain('<code>code</code>');
+    expect(html).toContain('<table>');
+  });
+});
+
+describe('safeExternalUrl', () => {
+  it.each([
+    ['https://example.org/x', 'https://example.org/x'],
+    ['http://example.org', 'http://example.org'],
+    ['  https://padded.example  ', 'https://padded.example'],
+  ])('allows %s', (input, expected) => {
+    expect(safeExternalUrl(input)).toBe(expected);
+  });
+
+  it.each([
+    'javascript:alert(1)',
+    'data:text/html,<script>alert(1)</script>',
+    'vbscript:msgbox',
+    'file:///etc/passwd',
+    '//protocol-relative.example',
+    '/relative/path',
+    '',
+    null,
+    undefined,
+    42,
+  ])('rejects %s', (input) => {
+    expect(safeExternalUrl(input)).toBeNull();
+  });
+});
+
+describe('safeMarkdownHref', () => {
+  it('additionally allows anchors and relative paths', () => {
+    expect(safeMarkdownHref('#anchor')).toBe('#anchor');
+    expect(safeMarkdownHref('/wiki/page')).toBe('/wiki/page');
+    expect(safeMarkdownHref('./sibling')).toBe('./sibling');
+    expect(safeMarkdownHref('../up')).toBe('../up');
+  });
+
+  it('still rejects script schemes and protocol-relative', () => {
+    expect(safeMarkdownHref('javascript:alert(1)')).toBeNull();
+    expect(safeMarkdownHref('//evil.example')).toBeNull();
+    expect(safeMarkdownHref('data:x')).toBeNull();
+  });
+});

--- a/app/src/__tests__/page-hash.test.ts
+++ b/app/src/__tests__/page-hash.test.ts
@@ -1,0 +1,64 @@
+/**
+ * getCurrentPageHash must hash decompressed markdown (same basis as commit),
+ * not raw gzip bytes.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { createHash } from 'node:crypto';
+import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { gzipSync } from 'node:zlib';
+import { getCurrentPageHash, DATA_ROOT } from '../lib/db';
+import { setupTestDb, seedPage, type TestDbHandle } from './helpers/test-db';
+
+let handle: TestDbHandle | null = null;
+
+afterEach(() => {
+  handle?.cleanup();
+  handle = null;
+});
+
+function writePageGzip(pageId: string, markdown: string): void {
+  const pagesDir = join(DATA_ROOT, 'pages');
+  if (!existsSync(pagesDir)) mkdirSync(pagesDir, { recursive: true });
+  writeFileSync(join(pagesDir, `${pageId}.md.gz`), gzipSync(Buffer.from(markdown, 'utf-8')));
+}
+
+describe('getCurrentPageHash', () => {
+  it('hashes decompressed markdown, not gzip bytes', () => {
+    handle = setupTestDb();
+    const page_id = 'test-page';
+    const markdown = '---\ntitle: Test\n---\n\nBody content.';
+    seedPage(handle.db, { page_id });
+    writePageGzip(page_id, markdown);
+
+    const expected = createHash('sha256').update(markdown).digest('hex');
+    expect(getCurrentPageHash(page_id)).toBe(expected);
+
+    const gzipBytes = gzipSync(Buffer.from(markdown, 'utf-8'));
+    const gzipHash = createHash('sha256').update(gzipBytes).digest('hex');
+    expect(getCurrentPageHash(page_id)).not.toBe(gzipHash);
+  });
+
+  it('returns empty string when no file and no pending_content', () => {
+    handle = setupTestDb();
+    const page_id = seedPage(handle.db);
+    expect(getCurrentPageHash(page_id)).toBe('');
+  });
+
+  it('hashes pending_content when file not yet flushed', () => {
+    handle = setupTestDb();
+    const page_id = 'pending-only';
+    const markdown = '# Pending draft body';
+    handle.db
+      .prepare(
+        `INSERT INTO pages
+           (page_id, title, page_type, content_path, source_count, pending_content)
+         VALUES (?, 'T', 'entity', ?, 1, ?)`
+      )
+      .run(page_id, `/data/pages/${page_id}.md.gz`, markdown);
+
+    const expected = createHash('sha256').update(markdown).digest('hex');
+    expect(getCurrentPageHash(page_id)).toBe(expected);
+  });
+});

--- a/app/src/__tests__/previous-path-containment.test.ts
+++ b/app/src/__tests__/previous-path-containment.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Path containment for previous_content_path (arbitrary-file-read fix).
+ *
+ * Regression target: GET /api/wiki/[page_id]/previous read whatever absolute
+ * path sat in pages.previous_content_path. The column round-trips through
+ * .kompl import zips, so a crafted zip could point it at /data/db/kompl.db
+ * (or any readable host file) and the route would gunzip + return it.
+ *
+ * Covers:
+ *   - safePreviousContentPath unit cases (valid archive, wrong dir,
+ *     traversal, wrong page_id prefix, non-archive filenames)
+ *   - previous route 404s on a malicious path, serves a legit archive
+ *   - import route nulls out non-conforming previous_content_path values
+ *     and rejects zips with unsafe page/source ids
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import zlib from 'node:zlib';
+import JSZip from 'jszip';
+import { GET as previousGET } from '../app/api/wiki/[page_id]/previous/route';
+import { POST as importPOST } from '../app/api/import/route';
+import { DATA_ROOT, safePreviousContentPath } from '../lib/db';
+import { setupTestDb, seedPage, type TestDbHandle } from './helpers/test-db';
+
+const PAGES_DIR = path.join(DATA_ROOT, 'pages');
+
+let handle: TestDbHandle | null = null;
+
+afterEach(() => {
+  handle?.cleanup();
+  handle = null;
+});
+
+describe('safePreviousContentPath', () => {
+  const valid = path.join(PAGES_DIR, 'my-page.20260101-120000-000123.md.gz');
+  const validNoUsec = path.join(PAGES_DIR, 'my-page.20260101-120000.md.gz');
+
+  it('accepts the archive shapes file_store.py writes', () => {
+    expect(safePreviousContentPath('my-page', valid)).toBe(path.resolve(valid));
+    expect(safePreviousContentPath('my-page', validNoUsec)).toBe(path.resolve(validNoUsec));
+  });
+
+  it.each([
+    ['outside pages dir', path.join(DATA_ROOT, 'db', 'kompl.db')],
+    ['system file', '/etc/passwd'],
+    ['traversal escaping pages', path.join(PAGES_DIR, '..', 'db', 'kompl.db')],
+    ['current (non-archive) page file', path.join(PAGES_DIR, 'my-page.md.gz')],
+    ['archive of a DIFFERENT page', path.join(PAGES_DIR, 'other-page.20260101-120000.md.gz')],
+    ['non-gz extension', path.join(PAGES_DIR, 'my-page.20260101-120000.md')],
+  ])('rejects %s', (_label, p) => {
+    expect(safePreviousContentPath('my-page', p)).toBeNull();
+  });
+
+  it('rejects null and unsafe page ids', () => {
+    expect(safePreviousContentPath('my-page', null)).toBeNull();
+    expect(safePreviousContentPath('../evil', valid)).toBeNull();
+  });
+});
+
+describe('GET /api/wiki/[page_id]/previous', () => {
+  function getPrevious(page_id: string) {
+    return previousGET(new Request('http://test'), {
+      params: Promise.resolve({ page_id }),
+    });
+  }
+
+  it('404s (invalid_path) when previous_content_path points outside pages dir', async () => {
+    handle = setupTestDb();
+    const page_id = seedPage(handle.db, { title: 'Victim' });
+    handle.db
+      .prepare('UPDATE pages SET previous_content_path = ? WHERE page_id = ?')
+      .run(path.join(DATA_ROOT, 'db', 'kompl.db'), page_id);
+
+    const res = await getPrevious(page_id);
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as { error: string }).error).toBe('invalid_path');
+  });
+
+  it('serves a legitimate archive of the same page', async () => {
+    handle = setupTestDb();
+    const page_id = seedPage(handle.db, { title: 'Versioned' });
+    const archivePath = path.join(PAGES_DIR, `${page_id}.20260101-120000-000001.md.gz`);
+    fs.mkdirSync(PAGES_DIR, { recursive: true });
+    fs.writeFileSync(archivePath, zlib.gzipSync('# old version'));
+    handle.db
+      .prepare('UPDATE pages SET previous_content_path = ? WHERE page_id = ?')
+      .run(archivePath, page_id);
+
+    const res = await getPrevious(page_id);
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { content: string }).content).toBe('# old version');
+    fs.unlinkSync(archivePath);
+  });
+});
+
+describe('POST /api/import — id and path validation', () => {
+  async function buildZip(pages: Record<string, unknown>[], sources: Record<string, unknown>[] = []) {
+    const zip = new JSZip();
+    zip.file('manifest.json', JSON.stringify({ format: 'kompl', version: 1 }));
+    zip.file('db/pages.json', JSON.stringify(pages));
+    zip.file('db/sources.json', JSON.stringify(sources));
+    const buf = await zip.generateAsync({ type: 'nodebuffer' });
+    const form = new FormData();
+    form.set('file', new File([new Uint8Array(buf)], 'export.kompl.zip'));
+    return new Request('http://test/api/import', { method: 'POST', body: form });
+  }
+
+  const basePage = {
+    title: 'Page',
+    page_type: 'entity',
+    content_path: '/data/pages/x.md.gz',
+    last_updated: '2026-01-01T00:00:00Z',
+    created_at: '2026-01-01T00:00:00Z',
+    source_count: 0,
+  };
+
+  it('rejects a zip whose page_id contains traversal segments', async () => {
+    handle = setupTestDb();
+    const res = await importPOST(await buildZip([{ ...basePage, page_id: '../../evil' }]));
+    expect(res.status).toBe(422);
+    expect(((await res.json()) as { error: string }).error).toBe('invalid_ids');
+  });
+
+  it('nulls out a previous_content_path pointing at the DB file', async () => {
+    handle = setupTestDb();
+    const res = await importPOST(
+      await buildZip([
+        {
+          ...basePage,
+          page_id: 'imported-page',
+          previous_content_path: '/data/db/kompl.db',
+        },
+      ])
+    );
+    expect(res.status).toBe(200);
+
+    const row = handle.db
+      .prepare('SELECT previous_content_path FROM pages WHERE page_id = ?')
+      .get('imported-page') as { previous_content_path: string | null };
+    expect(row.previous_content_path).toBeNull();
+  });
+});

--- a/app/src/__tests__/resolve-disambiguate-cap.test.ts
+++ b/app/src/__tests__/resolve-disambiguate-cap.test.ts
@@ -1,0 +1,147 @@
+/**
+ * App-side mirror of the nlp-service DISAMBIGUATE_MAX_PAIRS cap
+ * (CLAUDE.md rule #7 — every LLM loop needs a hard iteration cap).
+ *
+ * Regression target: /api/compile/resolve forwarded EVERY ambiguous pair
+ * from Layer 2 to /resolve/disambiguate. A dense session (N entities in the
+ * 0.7–0.9 cosine band) produces O(N²) pairs → unbounded LLM calls and spend.
+ *
+ * Asserts that the resolve route slices ambiguous pairs to 120 before
+ * calling disambiguate, and that overflow pairs degrade safely to separate
+ * singleton entities (never an over-merge).
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { POST as resolvePOST } from '../app/api/compile/resolve/route';
+import { setupTestDb, seedSource, seedExtraction, type TestDbHandle } from './helpers/test-db';
+
+const MAX_PAIRS = 120; // mirror of the route-private MAX_DISAMBIGUATE_PAIRS
+
+let handle: TestDbHandle | null = null;
+
+afterEach(() => {
+  handle?.cleanup();
+  handle = null;
+  vi.unstubAllGlobals();
+});
+
+function makeRequest(session_id: string): Request {
+  return new Request('http://test/api/compile/resolve', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ session_id }),
+  });
+}
+
+it('slices ambiguous pairs to the cap and keeps overflow as singletons', async () => {
+  handle = setupTestDb();
+  const session_id = 'sess-cap';
+  const source_id = seedSource(handle.db, {
+    onboarding_session_id: session_id,
+    compile_status: 'extracted',
+  });
+
+  // 2 entities are enough input — the (mocked) embedding layer is what
+  // fabricates the oversized ambiguous-pair list.
+  seedExtraction(handle.db, {
+    source_id,
+    llm_output: {
+      entities: [
+        { name: 'Entity A', type: 'ORG', context: 'ctx' },
+        { name: 'Entity B', type: 'ORG', context: 'ctx' },
+      ],
+      concepts: [],
+      relationships: [],
+    },
+  });
+
+  const PAIR_COUNT = MAX_PAIRS + 17;
+  const ambiguous = Array.from({ length: PAIR_COUNT }, (_, i) => ({
+    entity_a: { name: `Amb${i}A`, type: 'ORG', source_id, context: '' },
+    entity_b: { name: `Amb${i}B`, type: 'ORG', source_id, context: '' },
+    similarity: 0.8,
+  }));
+
+  let disambiguateCalls = 0;
+  let disambiguatePairsSent = -1;
+
+  const mockFetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+
+    if (url.endsWith('/resolve/fuzzy')) {
+      return Response.json({ resolved: [], unresolved: body.entities });
+    }
+    if (url.endsWith('/resolve/embedding')) {
+      return Response.json({ resolved: [], ambiguous, unresolved: [] });
+    }
+    if (url.endsWith('/resolve/disambiguate')) {
+      disambiguateCalls++;
+      const pairs = body.pairs as typeof ambiguous;
+      disambiguatePairsSent = pairs.length;
+      return Response.json({
+        results: pairs.map((p) => ({
+          entity_a: p.entity_a.name,
+          entity_b: p.entity_b.name,
+          decision: 'different',
+          canonical: null,
+          reason: 'mock',
+        })),
+      });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+  vi.stubGlobal('fetch', mockFetch);
+
+  const res = await resolvePOST(makeRequest(session_id));
+  expect(res.status).toBe(200);
+
+  // The LLM layer saw exactly the cap, never the full pair list.
+  expect(disambiguateCalls).toBe(1);
+  expect(disambiguatePairsSent).toBe(MAX_PAIRS);
+
+  // Overflow pairs degraded to separate singletons — both sides present,
+  // nothing merged.
+  const json = (await res.json()) as {
+    canonical_entities: Array<{ canonical: string; method: string }>;
+  };
+  const names = new Set(json.canonical_entities.map((e) => e.canonical));
+  expect(names.has(`Amb${MAX_PAIRS}A`)).toBe(true);
+  expect(names.has(`Amb${MAX_PAIRS}B`)).toBe(true);
+  expect(names.has(`Amb${PAIR_COUNT - 1}A`)).toBe(true);
+  expect(names.has(`Amb${PAIR_COUNT - 1}B`)).toBe(true);
+});
+
+it('does not call disambiguate at all when every pair is overflow-free and empty', async () => {
+  handle = setupTestDb();
+  const session_id = 'sess-nopairs';
+  const source_id = seedSource(handle.db, {
+    onboarding_session_id: session_id,
+    compile_status: 'extracted',
+  });
+  seedExtraction(handle.db, {
+    source_id,
+    llm_output: {
+      entities: [{ name: 'Solo', type: 'ORG', context: '' }],
+      concepts: [],
+      relationships: [],
+    },
+  });
+
+  const mockFetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    if (url.endsWith('/resolve/fuzzy')) {
+      return Response.json({ resolved: [], unresolved: body.entities });
+    }
+    if (url.endsWith('/resolve/embedding')) {
+      return Response.json({ resolved: [], ambiguous: [], unresolved: body.entities });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+  vi.stubGlobal('fetch', mockFetch);
+
+  const res = await resolvePOST(makeRequest(session_id));
+  expect(res.status).toBe(200);
+  expect(mockFetch.mock.calls.some(([u]) => String(u).includes('disambiguate'))).toBe(false);
+});

--- a/app/src/app/api/compile/commit/route.ts
+++ b/app/src/app/api/compile/commit/route.ts
@@ -22,7 +22,12 @@
  *
  * Request:  { session_id: string }
  * Response: { session_id, committed, failed, thin_drafts_skipped,
- *             pages_created, pages_updated, sources_activated, wikilink_warnings }
+ *             pages_created, pages_updated, sources_activated,
+ *             wikilink_warnings, flush_failures }
+ *
+ * flush_failures counts pages whose DB rows committed but whose .md.gz file
+ * could not be written even after the post-loop reconcile pass. Non-zero →
+ * run/route.ts fails the session (never 'completed' with files missing).
  */
 
 import { createHash } from 'node:crypto';
@@ -47,13 +52,70 @@ import {
   incrementPageSourceCount,
   setPendingContent,
   clearPendingContent,
+  getPendingFlushPages,
   backfillAliasCanonicalPageId,
 } from '../../../../lib/db';
+import { flushPendingPage } from '../../../../lib/flush-pending';
 import { upsertVectorWithRetry } from '../../../../lib/vector-upsert';
 import { syncPageWikilinks } from '../../../../lib/wikilinks';
 import { extractFrontmatterField } from '../../../../lib/yaml-frontmatter';
 
-const NLP_SERVICE_URL = process.env.NLP_SERVICE_URL ?? 'http://nlp-service:8000';
+// Derive the page_id a plan commits to. Single source of truth for the
+// slug algorithm — used by the commit loop, the wikilink pass, and the
+// durability scoping below. 'update' plans reuse the existing page;
+// 'create' plans get a title slug + plan_id suffix.
+function derivePlanPageId(plan: {
+  plan_id: string;
+  title: string;
+  action: string;
+  existing_page_id: string | null;
+}): string {
+  if (plan.action === 'update' && plan.existing_page_id) return plan.existing_page_id;
+  const suffix = plan.plan_id.replace(/-/g, '').slice(0, 8);
+  const base = plan.title
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .slice(0, 56)
+    .replace(/^-+|-+$/g, '');
+  return `${base || 'page'}-${suffix}`;
+}
+
+// Page ids this session's committed content plans wrote (current run AND
+// prior runs — plan rows keep draft_status='committed' across retries).
+// Provenance-only plans never write files, so they are excluded.
+function getSessionCommittedPageIds(session_id: string): Set<string> {
+  return new Set(
+    getPagePlansByStatus(session_id, 'committed')
+      .filter((p) => p.action !== 'provenance-only')
+      .map((p) => derivePlanPageId(p))
+  );
+}
+
+// Durability reconcile pass — re-attempt Phase 3a for every page still
+// holding pending_content (this session's flush failures AND any stranded
+// rows from other commit paths — flushing them is idempotent, so we sweep
+// globally as good citizenship). The returned count is SESSION-SCOPED:
+// only pages this session committed gate its success, so a stranded row
+// from another session/path can never false-fail this compile. The
+// orchestrator fails the session on a non-zero count so 'completed'
+// always means "all files durable" (CLAUDE.md rule #5). Runs on the
+// empty-plans path too: a retry after a flush failure finds all plans
+// already 'committed', so this pass is the only thing that recovers the
+// stranded files without a server restart.
+async function reconcileSessionFlushes(sessionPageIds: ReadonlySet<string>): Promise<number> {
+  let remaining = 0;
+  for (const row of getPendingFlushPages()) {
+    const result = await flushPendingPage(row.page_id, row.pending_content);
+    if (result.ok) {
+      clearPendingContent(row.page_id, result.previousPath);
+    } else if (sessionPageIds.has(row.page_id)) {
+      remaining++;
+    }
+  }
+  return remaining;
+}
 
 // Strip YAML frontmatter (--- ... ---) from the top of a markdown string.
 // Used to measure actual content length before the thin-draft gate check.
@@ -77,8 +139,11 @@ async function commitSession(session_id: string): Promise<Response> {
   const plans = getPagePlansByStatus(session_id, 'crossreffed');
 
   if (plans.length === 0) {
+    // Retry-after-flush-failure lands here (all plans already 'committed').
+    // The reconcile pass is what actually re-flushes the stranded files.
+    const flushFailures = await reconcileSessionFlushes(getSessionCommittedPageIds(session_id));
     return NextResponse.json(
-      { session_id, committed: 0, failed: 0, pages_created: 0, pages_updated: 0, sources_activated: 0 },
+      { session_id, committed: 0, failed: 0, pages_created: 0, pages_updated: 0, sources_activated: 0, flush_failures: flushFailures },
       { status: 200 }
     );
   }
@@ -213,22 +278,7 @@ async function commitSession(session_id: string): Promise<Response> {
       continue;
     }
 
-    let page_id: string;
-
-    if (plan.action === 'update' && plan.existing_page_id) {
-      page_id = plan.existing_page_id;
-    } else {
-      // Generate slug-based page_id from title + plan_id suffix
-      const suffix = plan.plan_id.replace(/-/g, '').slice(0, 8);
-      const base = plan.title
-        .toLowerCase()
-        .replace(/[^a-z0-9\s-]/g, '')
-        .replace(/\s+/g, '-')
-        .replace(/-+/g, '-')
-        .slice(0, 56)
-        .replace(/^-+|-+$/g, '');
-      page_id = `${base || 'page'}-${suffix}`;
-    }
+    const page_id = derivePlanPageId(plan);
 
     // Extract frontmatter fields (category, summary) from YAML envelope only.
     // Scoping to the `---\n...\n---` block prevents body content (which can
@@ -321,21 +371,15 @@ async function commitSession(session_id: string): Promise<Response> {
     // Phase 3a (awaited): flush pending_content to disk via nlp-service.
     // pending_content stays populated until this succeeds, so the boot reconciler
     // can re-attempt if Phase 3a crashes before clearPendingContent runs.
-    try {
-      const res = await fetch(`${NLP_SERVICE_URL}/storage/write-page`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ page_id, markdown }),
-        signal: AbortSignal.timeout(30_000),
-      });
-      if (!res.ok) throw new Error(`write_page_failed: ${res.status}`);
-      const wr = await res.json() as { current_path: string; previous_path: string | null };
-      clearPendingContent(page_id, wr.previous_path);
-    } catch (flushErr) {
-      const flushMsg = flushErr instanceof Error ? flushErr.message : String(flushErr);
-      console.error(JSON.stringify({ ts: new Date().toISOString(), event: 'file_flush_failed', context: 'session_commit', plan_id: plan.plan_id, page_id, session_id, error: flushMsg }));
-      // Plan is already committed in DB. pending_content stays for reconciler.
-      // Do not mark as failed — the page row is durable; only the file is missing.
+    const flushResult = await flushPendingPage(page_id, markdown);
+    if (flushResult.ok) {
+      clearPendingContent(page_id, flushResult.previousPath);
+    } else {
+      console.error(JSON.stringify({ ts: new Date().toISOString(), event: 'file_flush_failed', context: 'session_commit', plan_id: plan.plan_id, page_id, session_id }));
+      // Plan is already committed in DB. pending_content stays populated —
+      // the post-loop reconcileSessionFlushes() pass re-attempts it, and
+      // whatever still fails is surfaced as flush_failures so the
+      // orchestrator fails the session instead of marking it 'completed'.
     }
 
     // Phase 3b: backfill alias canonical_page_id for entity + concept pages
@@ -375,27 +419,15 @@ async function commitSession(session_id: string): Promise<Response> {
   // skips and failures — pages that were never inserted into `pages`).
   // Without this guard, a thin-draft plan with [[wikilinks]] causes an FK
   // violation that aborts the entire loop, leaving subsequent pages with no links.
-  const committedPlans = plans.filter((p) => {
-    if (!p.draft_content || p.action === 'provenance-only') return false;
-    const pid = p.action === 'update' && p.existing_page_id
-      ? p.existing_page_id
-      : (() => {
-          const suffix = p.plan_id.replace(/-/g, '').slice(0, 8);
-          const base = p.title.toLowerCase().replace(/[^a-z0-9\s-]/g, '')
-            .replace(/\s+/g, '-').replace(/-+/g, '-').slice(0, 56).replace(/^-+|-+$/g, '');
-          return `${base || 'page'}-${suffix}`;
-        })();
-    return committedPageIds.has(pid);
-  });
+  const committedPlans = plans.filter(
+    (p) =>
+      p.draft_content !== null &&
+      p.action !== 'provenance-only' &&
+      committedPageIds.has(derivePlanPageId(p))
+  );
 
   for (const plan of committedPlans) {
-    const fromPageId = plan.action === 'update' && plan.existing_page_id
-      ? plan.existing_page_id
-      : (() => {
-          const suffix = plan.plan_id.replace(/-/g, '').slice(0, 8);
-          const base = plan.title.toLowerCase().replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-').slice(0, 56).replace(/^-+|-+$/g, '');
-          return `${base || 'page'}-${suffix}`;
-        })();
+    const fromPageId = derivePlanPageId(plan);
 
     try {
       syncPageWikilinks(db, fromPageId, plan.draft_content!, titleMap);
@@ -423,6 +455,15 @@ async function commitSession(session_id: string): Promise<Response> {
     markSourcesActive(eligibleSourceIds);
   }
 
+  // ── Durability pass (CLAUDE.md rule #5) ─────────────────────────────────────
+  // Re-attempt any Phase 3a flush that failed during the loop above. Session
+  // pages still pending after this are reported as flush_failures — the
+  // orchestrator (run/route.ts) fails the session on a non-zero count so
+  // 'completed' is never signalled while .md.gz files are missing from disk.
+  // getSessionCommittedPageIds is read AFTER the loop so it includes plans
+  // committed in this run as well as prior runs of the same session.
+  const flushFailures = await reconcileSessionFlushes(getSessionCommittedPageIds(session_id));
+
   return NextResponse.json(
     {
       session_id,
@@ -435,6 +476,7 @@ async function commitSession(session_id: string): Promise<Response> {
       sources_activated: sourcesActivated,
       wikilink_warnings: wikilinkWarnings,
       auto_approve: autoApprove,
+      flush_failures: flushFailures,
     },
     { status: 200 }
   );

--- a/app/src/app/api/compile/resolve/route.ts
+++ b/app/src/app/api/compile/resolve/route.ts
@@ -52,6 +52,12 @@ const NLP_SERVICE_URL = process.env.NLP_SERVICE_URL ?? 'http://nlp-service:8000'
 // into real source_ids.
 const EXISTING_PAGE_SENTINEL = '__existing_page__';
 
+// Must match nlp-service/routers/resolution.py DISAMBIGUATE_MAX_PAIRS.
+// Hard bound on Layer-3 LLM pairs per resolve (CLAUDE.md rule #7); overflow
+// pairs are kept as separate singletons instead of being sent to the LLM.
+// (Not exported — Next.js route files may only export route handlers.)
+const MAX_DISAMBIGUATE_PAIRS = 120;
+
 // ── Type definitions (mirror nlp-service Pydantic models) ─────────────────────
 
 interface EntityInput {
@@ -263,13 +269,30 @@ export async function POST(request: Request) {
     const resolved3: ResolvedGroup[] = [];
     const ambiguousRemaining: EntityInput[] = [];
 
-    if (ambiguous2.length > 0) {
-      const disambResult = await callDisambiguate(ambiguous2, getEffectiveCompileModel(session_id));
+    // App-side mirror of the nlp-service DISAMBIGUATE_MAX_PAIRS cap
+    // (CLAUDE.md rule #7): never ask for more LLM pairs than the service
+    // will process. Overflow pairs take the same path as an 'ambiguous'
+    // LLM verdict — entities stay separate singletons, a safe degradation.
+    const cappedAmbiguous = ambiguous2.slice(0, MAX_DISAMBIGUATE_PAIRS);
+    const overflowAmbiguous = ambiguous2.slice(MAX_DISAMBIGUATE_PAIRS);
+    if (overflowAmbiguous.length > 0) {
+      console.warn(
+        `[resolve] ${ambiguous2.length} ambiguous pairs exceed cap ${MAX_DISAMBIGUATE_PAIRS}; ` +
+          `${overflowAmbiguous.length} pairs kept separate without LLM disambiguation`
+      );
+      for (const pair of overflowAmbiguous) {
+        if (pair.entity_a.source_id !== EXISTING_PAGE_SENTINEL) ambiguousRemaining.push(pair.entity_a);
+        if (pair.entity_b.source_id !== EXISTING_PAGE_SENTINEL) ambiguousRemaining.push(pair.entity_b);
+      }
+    }
+
+    if (cappedAmbiguous.length > 0) {
+      const disambResult = await callDisambiguate(cappedAmbiguous, getEffectiveCompileModel(session_id));
       const disambMap = new Map(
         disambResult.results.map((r) => [`${r.entity_a}|||${r.entity_b}`, r])
       );
 
-      for (const pair of ambiguous2) {
+      for (const pair of cappedAmbiguous) {
         const key = `${pair.entity_a.name}|||${pair.entity_b.name}`;
         const result = disambMap.get(key);
         // Cross-session ambiguous pairs have entity_b carrying the sentinel

--- a/app/src/app/api/compile/run/route.ts
+++ b/app/src/app/api/compile/run/route.ts
@@ -192,7 +192,7 @@ async function callCrossref(sessionId: string, planCount: number): Promise<{ wik
   return res.json() as Promise<{ wikilinks_added: number }>;
 }
 
-async function callCommit(sessionId: string, planCount: number): Promise<{ committed: number; thin_drafts_skipped: number; sources_activated: number }> {
+async function callCommit(sessionId: string, planCount: number): Promise<{ committed: number; thin_drafts_skipped: number; sources_activated: number; flush_failures: number }> {
   // Dynamic timeout sized to planCount × per-plan (DB tx + write-page +
   // vector-upsert) cost. See compile-timeouts.ts:computeCommitMs.
   const timeoutMs = computeCommitMs(planCount);
@@ -205,7 +205,7 @@ async function callCommit(sessionId: string, planCount: number): Promise<{ commi
     dispatcher: makeDispatcher(timeoutMs),
   });
   await throwOnError('commit', res, sessionId);
-  return res.json() as Promise<{ committed: number; thin_drafts_skipped: number; sources_activated: number }>;
+  return res.json() as Promise<{ committed: number; thin_drafts_skipped: number; sources_activated: number; flush_failures: number }>;
 }
 
 async function callSchema(sessionId: string): Promise<unknown> {
@@ -565,6 +565,24 @@ async function runCompilePipeline(sessionId: string): Promise<void> {
   // the route level once this step is 'running'. No mid-transaction abort.
   updateCompileStep(sessionId, 'commit', 'running');
   const commitResult = await timed(sessionId, 'commit', () => callCommit(sessionId, planCount));
+
+  // Durability gate (CLAUDE.md rule #5): never signal completion while page
+  // files are missing from disk. DB rows ARE committed (pages remain readable
+  // via pending_content + boot reconciler), but the session must end 'failed'
+  // so the UI/n8n don't treat it as fully durable. Retry recovers: commit
+  // re-runs, finds 0 crossreffed plans, and its reconcile pass re-flushes.
+  if (commitResult.flush_failures > 0) {
+    updateCompileStep(
+      sessionId,
+      'commit',
+      'failed',
+      `${commitResult.committed} pages committed to DB, but ${commitResult.flush_failures} page file(s) failed to flush to disk — retry to re-attempt`
+    );
+    throw new Error(
+      `commit failed: ${commitResult.flush_failures} page file(s) pending disk flush (DB rows are durable; retry re-flushes)`
+    );
+  }
+
   const thinMsg = commitResult.thin_drafts_skipped > 0 ? `, ${commitResult.thin_drafts_skipped} thin drafts skipped` : '';
   updateCompileStep(sessionId, 'commit', 'done', `${commitResult.committed} pages, ${commitResult.sources_activated} sources committed${thinMsg}`);
 

--- a/app/src/app/api/import/route.ts
+++ b/app/src/app/api/import/route.ts
@@ -6,7 +6,8 @@ import path from 'path';
 import zlib from 'zlib';
 import { NextResponse } from 'next/server';
 
-import { getDb, DATA_ROOT, logActivity } from '@/lib/db';
+import { getDb, DATA_ROOT, logActivity, safePreviousContentPath } from '@/lib/db';
+import { isSafeId } from '@/lib/safe-paths';
 
 // System-generated pages that don't count as "user data" for the import
 // emptiness check. The Saved Links overview page is rebuilt any time an
@@ -91,6 +92,25 @@ export async function POST(request: Request) {
   const settings    = JSON.parse((await zip.file('db/settings.json')?.async('string')) ?? '[]') as Record<string, string>[];
   const schemaContent = (await zip.file('schema.md')?.async('string')) ?? null;
 
+  // Validate ids before any write. page_id/source_id flow into file paths
+  // and routes (readPageMarkdown asserts and THROWS on bad ids — a row with
+  // page_id '../../evil' would 500 every /wiki visit), and a crafted zip
+  // could smuggle traversal segments. Reject the whole zip on any offender.
+  const badIds = [
+    ...sources.filter((s) => !isSafeId(s.source_id)).map((s) => `source:${String(s.source_id)}`),
+    ...pages.filter((p) => !isSafeId(p.page_id)).map((p) => `page:${String(p.page_id)}`),
+  ];
+  if (badIds.length > 0) {
+    return NextResponse.json(
+      {
+        error: 'invalid_ids',
+        message: 'Import zip contains source/page ids that are not valid Kompl ids.',
+        invalid: badIds.slice(0, 20),
+      },
+      { status: 422 }
+    );
+  }
+
   // Pre-read all .gz buffers into Maps (async, before the sync transaction)
   const rawBuffers  = new Map<string, Buffer>();
   const pageBuffers = new Map<string, Buffer>();
@@ -173,7 +193,10 @@ export async function POST(request: Request) {
         (p.category as string | null) ?? null,
         (p.summary as string | null) ?? null,
         p.content_path as string,
-        (p.previous_content_path as string | null) ?? null,
+        // Untrusted column from the zip: only /data/pages archives of this
+        // page_id survive; anything else (e.g. /data/db/kompl.db) is nulled
+        // so the previous-version route can never read outside PAGES_DIR.
+        safePreviousContentPath(p.page_id as string, (p.previous_content_path as string | null) ?? null),
         p.last_updated as string,
         (p.source_count as number | null) ?? 0,
         p.created_at as string

--- a/app/src/app/api/wiki/[page_id]/previous/route.ts
+++ b/app/src/app/api/wiki/[page_id]/previous/route.ts
@@ -11,7 +11,7 @@
 import { NextResponse } from 'next/server';
 import fs from 'node:fs';
 import zlib from 'node:zlib';
-import { getPage } from '../../../../../lib/db';
+import { getPage, safePreviousContentPath } from '../../../../../lib/db';
 
 interface RouteContext {
   params: Promise<{ page_id: string }>;
@@ -29,12 +29,20 @@ export async function GET(_request: Request, { params }: RouteContext) {
     return NextResponse.json({ error: 'no_previous_version' }, { status: 404 });
   }
 
-  if (!fs.existsSync(page.previous_content_path)) {
+  // Containment check: the DB value round-trips through import zips, so it
+  // must be re-validated before any fs read. Only /data/pages archives of
+  // THIS page_id are readable; anything else is treated as not found.
+  const safePath = safePreviousContentPath(page_id, page.previous_content_path);
+  if (!safePath) {
+    return NextResponse.json({ error: 'invalid_path' }, { status: 404 });
+  }
+
+  if (!fs.existsSync(safePath)) {
     return NextResponse.json({ error: 'file_missing' }, { status: 404 });
   }
 
   try {
-    const gzipped = fs.readFileSync(page.previous_content_path);
+    const gzipped = fs.readFileSync(safePath);
     const content = zlib.gunzipSync(gzipped).toString('utf-8');
     return NextResponse.json({ content });
   } catch {

--- a/app/src/app/source/[source_id]/page.tsx
+++ b/app/src/app/source/[source_id]/page.tsx
@@ -6,12 +6,10 @@
  * renders it as HTML via the `marked` wrapper in lib/markdown.ts.
  *
  * Security note: we use dangerouslySetInnerHTML on markdown output.
- * `marked` is configured to not emit raw HTML from markdown input
- * (lib/markdown.ts, commit 3), so the most dangerous vectors are closed.
- * However, `marked` does not strip malicious URLs in links/images. For
- * commit 3 the trust model is "user chose to ingest this source, they
- * trust it." A proper sanitizer (DOMPurify or rehype-sanitize) can be
- * wired in when multi-user support lands.
+ * lib/markdown.ts escapes raw HTML tokens and allowlists link/image URL
+ * schemes (http(s)/anchor/relative), so script injection and
+ * javascript:/data: links from ingested content do not execute. Direct
+ * href renders of DB-sourced URLs go through safeExternalUrl().
  *
  * Server components in Next.js 16 receive `params` as a Promise that
  * must be awaited. Do NOT add "use client" to this file — it reads
@@ -23,6 +21,7 @@ import { notFound } from 'next/navigation';
 
 import { getSource, getSourceProvenanceMap, readRawMarkdown, type SourceRow } from '../../../lib/db';
 import { renderMarkdown } from '../../../lib/markdown';
+import { safeExternalUrl } from '../../../lib/safe-url';
 import SourceActions from './SourceActions';
 
 interface PageProps {
@@ -106,8 +105,8 @@ export default async function SourcePage({ params }: PageProps) {
             {source.source_type}
           </span>
           <span>{formatDate(source.date_ingested)}</span>
-          {source.source_url && (
-            <a href={source.source_url} target="_blank" rel="noopener noreferrer">
+          {safeExternalUrl(source.source_url) && (
+            <a href={safeExternalUrl(source.source_url)!} target="_blank" rel="noopener noreferrer">
               {source.source_url}
             </a>
           )}

--- a/app/src/app/wiki/[page_id]/SavedLinksInteractive.tsx
+++ b/app/src/app/wiki/[page_id]/SavedLinksInteractive.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { SavedLinkRow } from '../../../lib/db';
 import { LocalDayMonth } from '../../../components/LocalDate';
+import { safeExternalUrl } from '../../../lib/safe-url';
 
 interface ParsedMetadata {
   title?: string | null;
@@ -315,18 +316,20 @@ export default function SavedLinksInteractive({
               </div>
 
               <div style={{ padding: '20px 0', display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 8 }}>
-                <a
-                  href={link.source_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{
-                    fontFamily: 'var(--font-body)', fontWeight: 700, fontSize: 10,
-                    letterSpacing: '1px', textTransform: 'uppercase',
-                    color: 'var(--accent)', textDecoration: 'none',
-                  }}
-                >
-                  View
-                </a>
+                {safeExternalUrl(link.source_url) && (
+                  <a
+                    href={safeExternalUrl(link.source_url)!}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{
+                      fontFamily: 'var(--font-body)', fontWeight: 700, fontSize: 10,
+                      letterSpacing: '1px', textTransform: 'uppercase',
+                      color: 'var(--accent)', textDecoration: 'none',
+                    }}
+                  >
+                    View
+                  </a>
+                )}
                 {isLoading ? (
                   <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--fg-dim)', minWidth: 60, textAlign: 'right' }}>
                     …

--- a/app/src/app/wiki/[page_id]/page.tsx
+++ b/app/src/app/wiki/[page_id]/page.tsx
@@ -38,6 +38,7 @@ import WikiSidebar from '../../../components/WikiSidebar';
 import SavedLinksInteractive from './SavedLinksInteractive';
 import { PAGE_TYPE_VAR, PAGE_TYPE_LABELS, type PageType } from '../../../lib/page-type-palette';
 import { renderInlineWikilinks } from '../../../lib/wikilink-render';
+import { safeExternalUrl } from '../../../lib/safe-url';
 
 const SAVED_LINKS_PAGE_ID = 'saved-links';
 
@@ -389,11 +390,11 @@ export default async function WikiPageDetail({ params }: PageProps) {
             {provRows.map((r) => (
               <div key={r.source_id} style={{ marginBottom: '0.25rem' }}>
                 <Link href={`/source/${r.source_id}`}>{r.source_title}</Link>
-                {r.source_url && (
+                {safeExternalUrl(r.source_url) && (
                   <>
                     {' '}
                     &mdash;{' '}
-                    <a href={r.source_url} target="_blank" rel="noopener noreferrer">
+                    <a href={safeExternalUrl(r.source_url)!} target="_blank" rel="noopener noreferrer">
                       original
                     </a>
                   </>

--- a/app/src/lib/db.ts
+++ b/app/src/lib/db.ts
@@ -32,7 +32,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import zlib from 'node:zlib';
 import { COMPILE_STEP_KEYS, type CompileStepKey } from './compile-steps';
-import { assertSafeId } from './safe-paths';
+import { assertSafeId, isSafeId } from './safe-paths';
 import type { ActivityEventType } from './activity-events';
 
 const DB_PATH = process.env.DB_PATH ?? '/data/db/kompl.db';
@@ -2112,16 +2112,32 @@ export function incrementPageSourceCount(pageId: string, increment: number): voi
 }
 
 /**
- * Read the current gzipped page file and return its SHA-256 hex hash.
- * Returns '' if the file does not exist (first-write path — caller handles).
- * Synchronous so it can be called inside a db.transaction() callback.
+ * Validate a previous_content_path value against the only shape
+ * file_store.py ever writes: {PAGES_DIR}/{page_id}.{YYYYMMDD-HHMMSS}[-usec].md.gz
+ * for THIS page_id. The column round-trips through export/import zips, so
+ * it is untrusted — a crafted zip could point it at /data/db/kompl.db or
+ * any host file and the previous-version route would happily gunzip it.
+ * Returns the resolved path when valid, null otherwise.
+ */
+export function safePreviousContentPath(pageId: string, p: string | null): string | null {
+  if (!p || !isSafeId(pageId)) return null;
+  const resolved = path.resolve(p);
+  if (path.dirname(resolved) !== path.resolve(PAGES_DIR)) return null;
+  // pageId is a safe id ([a-z0-9_-]) — no regex metacharacters to escape.
+  const archiveRe = new RegExp(`^${pageId}\\.\\d{8}-\\d{6}(?:-\\d{6})?\\.md\\.gz$`);
+  return archiveRe.test(path.basename(resolved)) ? resolved : null;
+}
+
+/**
+ * SHA-256 of the page's decompressed markdown — same basis as commit/route.ts
+ * content_hash. Uses readPageMarkdown (file + pending_content fallback).
+ * Returns '' when no content exists (first-write / provenance-only path).
+ * Sync filesystem read; call outside db.transaction().
  */
 export function getCurrentPageHash(pageId: string): string {
-  assertSafeId(pageId, 'page');
-  const filePath = path.join(PAGES_DIR, `${pageId}.md.gz`);
-  if (!fs.existsSync(filePath)) return '';
-  const data = fs.readFileSync(filePath);
-  return createHash('sha256').update(data).digest('hex');
+  const markdown = readPageMarkdown(pageId);
+  if (!markdown) return '';
+  return createHash('sha256').update(markdown).digest('hex');
 }
 
 // ============================================================================

--- a/app/src/lib/flush-pending.ts
+++ b/app/src/lib/flush-pending.ts
@@ -1,0 +1,58 @@
+/**
+ * Phase 3a flush helper — POST /storage/write-page for a single page.
+ *
+ * Shared by:
+ *   - the boot reconciler (app/instrumentation.ts), which re-flushes any
+ *     page where pending_content IS NOT NULL after a crash mid-Phase-3a
+ *   - the commit route's post-loop durability pass
+ *     (app/api/compile/commit/route.ts), which re-attempts stranded
+ *     flushes so /api/compile/retry can recover without a server restart
+ *
+ * Never throws — failures are logged and reported as { ok: false } so the
+ * caller decides whether to fail the session or leave the row for the
+ * next reconcile pass. Deliberately does NOT import db.ts: callers own
+ * the clearPendingContent() call, and keeping this module Node-API-free
+ * lets instrumentation.ts import it without edge-runtime guards.
+ */
+
+const NLP_SERVICE_URL = process.env.NLP_SERVICE_URL ?? 'http://nlp-service:8000';
+
+export type FlushResult = { ok: true; previousPath: string | null } | { ok: false };
+
+export async function flushPendingPage(
+  pageId: string,
+  markdown: string
+): Promise<FlushResult> {
+  try {
+    const res = await fetch(`${NLP_SERVICE_URL}/storage/write-page`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ page_id: pageId, markdown }),
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!res.ok) {
+      console.error(
+        JSON.stringify({
+          ts: new Date().toISOString(),
+          event: 'flush_pending_http_error',
+          page_id: pageId,
+          status: res.status,
+        })
+      );
+      return { ok: false };
+    }
+    const body = (await res.json()) as { current_path: string; previous_path: string | null };
+    return { ok: true, previousPath: body.previous_path };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        event: 'flush_pending_error',
+        page_id: pageId,
+        error: msg,
+      })
+    );
+    return { ok: false };
+  }
+}

--- a/app/src/lib/markdown.ts
+++ b/app/src/lib/markdown.ts
@@ -5,14 +5,32 @@
  * renderer is overridden to inject `id` attributes using the same slug
  * logic as `extractHeadings()` in the wiki page, so TOC anchor links work.
  *
- * Sanitization: raw HTML in markdown input is not rendered — n8n / Firecrawl /
- * MarkItDown output is not guaranteed to be HTML-safe.
+ * Sanitization (output goes into dangerouslySetInnerHTML):
+ *   - Raw HTML tokens (block + inline) are HTML-escaped, never passed
+ *     through. marked 12 renders raw HTML verbatim by default, and page
+ *     content comes from scrapes, LLM output, and import zips — none of
+ *     which are HTML-safe. A literal `<script>` in a source now renders
+ *     as visible text instead of executing.
+ *   - Link/image targets go through the safe-url allowlist (http(s),
+ *     anchors, relative paths). `javascript:`/`data:` links render as
+ *     plain text.
  */
 
 import { marked, Renderer } from 'marked';
 
+import { safeMarkdownHref } from './safe-url';
+
 function slugify(text: string): string {
   return text.toLowerCase().replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-');
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 const renderer = new Renderer();
@@ -22,6 +40,24 @@ renderer.heading = (text: string, level: number, raw: string) => {
   // produce garbled ids like `strongboldstrong-heading` and break TOC jumps.
   const id = slugify(raw);
   return `<h${level} id="${id}">${text}</h${level}>\n`;
+};
+// Raw HTML (block and inline tokens both land here in marked 12) — escape,
+// never pass through.
+renderer.html = (html: string) => escapeHtml(html);
+renderer.link = (href: string, title: string | null | undefined, text: string) => {
+  const safe = safeMarkdownHref(href);
+  // Unsafe target → keep the link text (already-rendered inline HTML),
+  // drop the anchor entirely.
+  if (!safe) return text;
+  const titleAttr = title ? ` title="${escapeHtml(title)}"` : '';
+  return `<a href="${escapeHtml(safe)}"${titleAttr}>${text}</a>`;
+};
+renderer.image = (href: string, title: string | null | undefined, text: string) => {
+  const safe = safeMarkdownHref(href);
+  // Unsafe src → render the alt text only.
+  if (!safe) return escapeHtml(text);
+  const titleAttr = title ? ` title="${escapeHtml(title)}"` : '';
+  return `<img src="${escapeHtml(safe)}" alt="${escapeHtml(text)}"${titleAttr}>`;
 };
 
 marked.setOptions({

--- a/app/src/lib/safe-url.ts
+++ b/app/src/lib/safe-url.ts
@@ -1,0 +1,36 @@
+/**
+ * URL scheme allowlisting for anything rendered into href/src attributes.
+ *
+ * DB-sourced URLs (provenance source_url, saved-link source_url, imported
+ * metadata) and markdown link targets are untrusted: scraped content, LLM
+ * output, or a crafted import zip can carry `javascript:`/`data:` URLs.
+ * Browsers execute those on click — classic stored XSS adjacent vector.
+ *
+ * Kept dependency-free so client components can import it without pulling
+ * the marked bundle in.
+ */
+
+/** External links only: http(s). Returns null for anything else. */
+export function safeExternalUrl(url: unknown): string | null {
+  if (typeof url !== 'string') return null;
+  const trimmed = url.trim();
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  return null;
+}
+
+/**
+ * Markdown link/image targets: http(s), in-page anchors, and same-origin
+ * relative paths. Protocol-relative (`//host`) is rejected — it silently
+ * changes origin. Everything else (javascript:, data:, vbscript:, file:)
+ * is rejected.
+ */
+export function safeMarkdownHref(href: unknown): string | null {
+  if (typeof href !== 'string') return null;
+  const trimmed = href.trim();
+  if (trimmed === '') return null;
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  if (trimmed.startsWith('#')) return trimmed;
+  if (trimmed.startsWith('/') && !trimmed.startsWith('//')) return trimmed;
+  if (/^\.{1,2}\//.test(trimmed)) return trimmed;
+  return null;
+}

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -562,9 +562,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -579,9 +579,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -596,9 +596,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -613,9 +613,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -630,9 +630,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -647,9 +647,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -664,9 +664,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -681,9 +681,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -698,9 +698,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -715,9 +715,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -732,9 +732,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -749,9 +749,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -766,9 +766,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -783,9 +783,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -800,9 +800,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -817,9 +817,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -834,9 +834,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -851,9 +851,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -868,9 +868,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -885,9 +885,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -902,9 +902,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -919,9 +919,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -936,9 +936,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -953,9 +953,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -970,9 +970,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -987,9 +987,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -3089,9 +3089,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3102,32 +3102,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -36,5 +36,8 @@
     "ts-jest": "^29.4.11",
     "tsup": "^8.3.0",
     "typescript": "^6.0.0"
+  },
+  "overrides": {
+    "esbuild": "0.28.1"
   }
 }

--- a/cli/src/__tests__/health.test.ts
+++ b/cli/src/__tests__/health.test.ts
@@ -2,7 +2,7 @@
  * Tests for health.ts — checkHealth / pollHealth
  */
 
-import { checkHealth, pollHealth } from '../health'
+import { checkHealth, pollHealth, isAppReady } from '../health'
 
 let fetchMock: jest.Mock
 
@@ -64,4 +64,54 @@ describe('pollHealth', () => {
     expect(result).toEqual(health)
     expect(fetchMock).toHaveBeenCalledTimes(3)
   }, 2000)
+
+  it('accepts degraded when db is writable and schema is ready', async () => {
+    const health = {
+      status: 'degraded',
+      db_writable: true,
+      schema_version: 25,
+      table_count: 20,
+      page_count: 3,
+      nlp_ok: false,
+    }
+    fetchMock.mockResolvedValue({ ok: true, json: async () => health })
+
+    const result = await pollHealth(3000, 5000, 10)
+    expect(result).toEqual(health)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects degraded when db is not writable', async () => {
+    const health = {
+      status: 'degraded',
+      db_writable: false,
+      schema_version: 25,
+      table_count: 20,
+      page_count: 0,
+    }
+    fetchMock.mockResolvedValue({ ok: true, json: async () => health })
+
+    const result = await pollHealth(3000, 50, 10)
+    expect(result).toBeNull()
+  }, 2000)
+})
+
+describe('isAppReady', () => {
+  it('returns true for ok', () => {
+    expect(
+      isAppReady({ status: 'ok', db_writable: true, schema_version: 25, table_count: 1, page_count: 0 })
+    ).toBe(true)
+  })
+
+  it('returns true for degraded with db ready', () => {
+    expect(
+      isAppReady({ status: 'degraded', db_writable: true, schema_version: 25, table_count: 1, page_count: 0 })
+    ).toBe(true)
+  })
+
+  it('returns false for degraded without schema', () => {
+    expect(
+      isAppReady({ status: 'degraded', db_writable: true, schema_version: 0, table_count: 0, page_count: 0 })
+    ).toBe(false)
+  })
 })

--- a/cli/src/commands/start.ts
+++ b/cli/src/commands/start.ts
@@ -55,6 +55,9 @@ export async function startCommand(): Promise<void> {
   }
 
   console.log(pc.green(`✓ Kompl is running at ${pc.bold(`http://localhost:${config.port}`)}`))
+  if (health.status === 'degraded') {
+    console.log(pc.yellow('  Note: NLP still warming — compile may retry until models load.'))
+  }
   console.log(pc.dim(`  DB: schema v${health.schema_version}, ${health.page_count} pages`))
 
   // Fire-and-forget — does not block the prompt returning.

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -42,4 +42,7 @@ export async function updateCommand(): Promise<void> {
   }
 
   console.log(pc.green(`✓ Kompl updated and running at ${pc.bold(`http://localhost:${config.port}`)}`))
+  if (health.status === 'degraded') {
+    console.log(pc.yellow('  Note: NLP still warming — compile may retry until models load.'))
+  }
 }

--- a/cli/src/health.ts
+++ b/cli/src/health.ts
@@ -19,6 +19,16 @@ export async function checkHealth(port: number): Promise<HealthResponse | null> 
   }
 }
 
+/** App is serving when ok, or degraded but DB/schema are ready (NLP warming). */
+export function isAppReady(health: HealthResponse): boolean {
+  if (health.status === 'ok') return true
+  return (
+    health.status === 'degraded' &&
+    health.db_writable &&
+    health.schema_version > 0
+  )
+}
+
 export async function pollHealth(
   port: number,
   timeoutMs = 60_000,
@@ -27,7 +37,7 @@ export async function pollHealth(
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
     const health = await checkHealth(port)
-    if (health?.status === 'ok') return health
+    if (health && isAppReady(health)) return health
     await new Promise(r => setTimeout(r, intervalMs))
   }
   return null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,13 @@ services:
       dockerfile: app/Dockerfile
     restart: unless-stopped
     ports:
-      - "3000:3000"
+      # Loopback-only, matching nlp-service/n8n below and the localhost-only
+      # model documented in SECURITY.md. The /api/* surface is unauthenticated
+      # by design (single-tenant sidecar) — binding to 0.0.0.0 would expose
+      # destructive routes (/api/import, /api/admin/*, /api/compile/run) to
+      # the LAN. Front with an authenticating reverse proxy to expose beyond
+      # this machine.
+      - "127.0.0.1:3000:3000"
     environment:
       DB_PATH: /data/db/kompl.db
       NODE_ENV: production

--- a/nlp-service/routers/conversion.py
+++ b/nlp-service/routers/conversion.py
@@ -45,6 +45,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from services._safe_paths import safe_join
 from services.http_client import HttpClient, HttpClientError
+from services.url_safety import validate_outbound_url
 
 
 # ---------------------------------------------------------------------------
@@ -684,6 +685,32 @@ def convert_url(req: UrlConvertRequest) -> ConvertResponse:
     # for transcript-less videos, which silently passes our quality gate).
     if _YOUTUBE_URL_RE.match(req.url):
         return _convert_youtube(req.source_id, req.url)
+
+    # SSRF guard (CWE-918): resolve and validate the target before the
+    # generic fetch layers (MarkItDown, Firecrawl) touch it. Blocks
+    # non-http(s) schemes, cloud-metadata hosts, literal private IPs, and
+    # hostnames that resolve to private/loopback/link-local ranges —
+    # including Docker DNS names like `app` / `n8n` / `nlp-service`.
+    # 422 (not 502) so the app-side onFailure handler routes the URL to
+    # Saved Links like other unconvertible inputs.
+    #
+    # Placed AFTER the GitHub/YouTube pre-checks: those only call fixed
+    # public API hosts (api.github.com / googleapis) with IDs extracted
+    # from the URL — they never fetch the user URL itself — and keeping
+    # them above preserves their network-free unit tests.
+    #
+    # Residual risk: MarkItDown re-resolves DNS internally, so an
+    # attacker-controlled authoritative nameserver could rebind between
+    # this check and the fetch (TOCTOU). Eliminating that requires
+    # replacing MarkItDown's fetcher with the IP-pinned httpx client used
+    # by metadata_peek — accepted residual risk for now.
+    try:
+        validate_outbound_url(req.url)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=422,
+            detail=f"url_blocked: {e} — URL does not resolve to a fetchable public address",
+        ) from e
 
     # Layer 1: MarkItDown (free, local). YouTube URLs are handled above and
     # never reach this layer.

--- a/nlp-service/routers/resolution.py
+++ b/nlp-service/routers/resolution.py
@@ -605,6 +605,16 @@ def resolve_embedding(req: EmbeddingResolveRequest) -> EmbeddingResolveResponse:
 # ---------------------------------------------------------------------------
 
 
+# LLM iteration cap (CLAUDE.md rule #7): hard bound on pairs per
+# /resolve/disambiguate request. At 10 pairs per LLM call this caps a single
+# request at 12 batched calls. Excess pairs come back decision='ambiguous'
+# (the app keeps ambiguous entities separate — safe degradation, never an
+# over-merge). Rule #7's default-off feature flag targets expansion loops;
+# disambiguation is a core resolve layer, so a hard cap bounds spend without
+# silently disabling every compile.
+DISAMBIGUATE_MAX_PAIRS = 120
+
+
 class DisambiguateRequest(BaseModel):
     model_config = ConfigDict(extra='forbid')
     pairs: list[AmbiguousPair]
@@ -643,13 +653,24 @@ def resolve_disambiguate(req: DisambiguateRequest) -> DisambiguateResponse:
     if not req.pairs:
         return DisambiguateResponse(results=[])
 
+    # Enforce the LLM call cap. Truncated pairs are answered without an LLM
+    # call as 'ambiguous' so callers always get one result per pair.
+    capped_pairs = req.pairs[:DISAMBIGUATE_MAX_PAIRS]
+    overflow_pairs = req.pairs[DISAMBIGUATE_MAX_PAIRS:]
+    if overflow_pairs:
+        logger.warning(
+            "disambiguate: %d pairs requested exceeds cap %d — "
+            "%d pairs returned as 'ambiguous' without LLM calls",
+            len(req.pairs), DISAMBIGUATE_MAX_PAIRS, len(overflow_pairs),
+        )
+
     # Partition pairs by kind: concept pairs (either side CONCEPT) get the
     # stricter concept-disambiguation prompt; the rest use the entity prompt.
     # Concepts have fuzzier boundaries — share vocabulary across distinct
     # ideas — so the concept prompt errs toward "different" in the gray band.
     concept_pairs: list[dict[str, Any]] = []
     entity_pairs: list[dict[str, Any]] = []
-    for p in req.pairs:
+    for p in capped_pairs:
         pair_dict = {
             "entity_a": {"name": p.entity_a.name, "type": p.entity_a.type, "context": p.entity_a.context},
             "entity_b": {"name": p.entity_b.name, "type": p.entity_b.type, "context": p.entity_b.context},
@@ -686,5 +707,15 @@ def resolve_disambiguate(req: DisambiguateRequest) -> DisambiguateResponse:
         _call_in_batches(entity_pairs, "entity")
     if concept_pairs:
         _call_in_batches(concept_pairs, "concept")
+
+    for p in overflow_pairs:
+        all_results.append(DisambiguateResponseItem(
+            entity_a=p.entity_a.name,
+            entity_b=p.entity_b.name,
+            decision="ambiguous",
+            canonical=None,
+            reason=f"cap_exceeded: request had more than {DISAMBIGUATE_MAX_PAIRS} pairs; "
+                   "pair not sent to LLM, entities kept separate",
+        ))
 
     return DisambiguateResponse(results=all_results)

--- a/nlp-service/services/llm_client.py
+++ b/nlp-service/services/llm_client.py
@@ -27,11 +27,14 @@ This module NEVER opens kompl.db. rule #1 in CLAUDE.md.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import sys
+import tempfile
+import threading
 import time
-from datetime import date
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -299,8 +302,18 @@ class Entity(BaseModel):
 # Daily spend tracker — file-based, survives restarts, resets at midnight UTC
 # ---------------------------------------------------------------------------
 
+logger = logging.getLogger(__name__)
+
 _CAP_FILE = Path(os.environ.get("DATA_ROOT", "/data")) / "llm-cap.json"
 _CONFIG_FILE = Path(os.environ.get("DATA_ROOT", "/data")) / "llm-config.json"
+
+# Serializes the read→check→increment→write critical section in
+# _check_and_record_cost. The service runs a single uvicorn worker by design
+# (Dockerfile --workers 1; single-writer SQLite), so every request thread
+# shares this interpreter and a threading.Lock fully closes the TOCTOU race —
+# no cross-process flock needed. Concurrent extract/disambiguate threads used
+# to read the same baseline and lose each other's spend increments.
+_cap_lock = threading.Lock()
 
 # Cache the daily cap for 30 s to avoid a filesystem read on every LLM call.
 # 30 s is short enough that a Settings UI change takes effect quickly without
@@ -356,24 +369,48 @@ def _read_daily_cap_usd() -> float:
     return cap
 
 
+def _utc_today() -> str:
+    """Day key for the spend file. UTC, matching the user-facing 'resets at
+    midnight UTC' message — date.today() was container-local and skewed the
+    reset boundary."""
+    return str(datetime.now(timezone.utc).date())
+
+
 def _read_cap() -> dict:
     """Read today's spend from disk. Reset automatically when the date changes."""
     try:
         data = json.loads(_CAP_FILE.read_text())
-        today = str(date.today())
+        today = _utc_today()
         if data.get("date") != today:
             return {"date": today, "total_usd": 0.0, "call_count": 0}
         return data
     except (FileNotFoundError, json.JSONDecodeError, KeyError):
-        return {"date": str(date.today()), "total_usd": 0.0, "call_count": 0}
+        return {"date": _utc_today(), "total_usd": 0.0, "call_count": 0}
 
 
 def _write_cap(data: dict) -> None:
-    """Persist current spend to disk. Non-fatal on I/O failure."""
+    """Persist current spend to disk. Non-fatal on I/O failure.
+
+    Atomic tmp + os.replace so a crash mid-write can't leave a truncated
+    JSON file (which _read_cap would treat as 'no spend today' — silently
+    resetting the cap).
+    """
     try:
-        _CAP_FILE.write_text(json.dumps(data))
-    except OSError:
-        pass  # cap still enforced in-memory for this call
+        fd, tmp_path = tempfile.mkstemp(dir=str(_CAP_FILE.parent), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write(json.dumps(data))
+            os.replace(tmp_path, _CAP_FILE)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+    except OSError as e:
+        # Cap still enforced in-memory for this call; next successful write
+        # catches up because spend is re-read before every increment.
+        logger.warning("llm-cap.json write failed (%s) — spend not persisted", e)
 
 
 def _check_and_record_cost(
@@ -406,17 +443,18 @@ def _check_and_record_cost(
     }
     cost_usd = provider.cost_usd(model, usage)
 
-    cap_data = _read_cap()
-    daily_cap = _read_daily_cap_usd()
-    if daily_cap > 0 and cap_data["total_usd"] + cost_usd > daily_cap:
-        raise CostCeilingError(
-            f"Daily LLM spend limit (${daily_cap:.2f}) reached. "
-            f"Today's spend: ${cap_data['total_usd']:.4f}. "
-            f"Resets at midnight UTC."
-        )
-    cap_data["total_usd"] = round(cap_data["total_usd"] + cost_usd, 6)
-    cap_data["call_count"] = cap_data.get("call_count", 0) + 1
-    _write_cap(cap_data)
+    with _cap_lock:
+        cap_data = _read_cap()
+        daily_cap = _read_daily_cap_usd()
+        if daily_cap > 0 and cap_data["total_usd"] + cost_usd > daily_cap:
+            raise CostCeilingError(
+                f"Daily LLM spend limit (${daily_cap:.2f}) reached. "
+                f"Today's spend: ${cap_data['total_usd']:.4f}. "
+                f"Resets at midnight UTC."
+            )
+        cap_data["total_usd"] = round(cap_data["total_usd"] + cost_usd, 6)
+        cap_data["call_count"] = cap_data.get("call_count", 0) + 1
+        _write_cap(cap_data)
 
 
 def _salvage_extraction(raw_text: str) -> "LLMExtractionResponse | None":

--- a/nlp-service/tests/test_conversion_url_safety.py
+++ b/nlp-service/tests/test_conversion_url_safety.py
@@ -1,0 +1,162 @@
+"""SSRF guard tests for POST /convert/url (routers/conversion.py).
+
+The guard calls services.url_safety.validate_outbound_url() before the
+generic fetch layers (MarkItDown / Firecrawl). These tests assert that
+internal / non-public targets are rejected with 422 url_blocked BEFORE any
+converter runs, and that public URLs pass the guard and reach the
+MarkItDown layer.
+
+No network: DNS resolution (socket.getaddrinfo) is monkeypatched inside
+services.url_safety for every case that needs name resolution, and
+_try_markitdown_url is stubbed so nothing fetches.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from routers import conversion as conv
+from routers.conversion import router as conversion_router
+from services import url_safety
+
+
+# ─── Test client ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(conversion_router)
+    return TestClient(app)
+
+
+def _post(client: TestClient, url: str):
+    return client.post(
+        "/convert/url",
+        json={"source_id": "src-ssrf-test", "url": url},
+    )
+
+
+def _fail_if_fetched(monkeypatch):
+    """Stub the fetch layers so a guard bypass fails loudly, not over the network."""
+
+    def _boom(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("fetch layer reached — SSRF guard did not block the URL")
+
+    monkeypatch.setattr(conv, "_try_markitdown_url", _boom)
+
+
+def _stub_dns(monkeypatch, ip: str):
+    """Make every hostname resolve to a single fixed IP (no real DNS)."""
+
+    def _fake_getaddrinfo(host, port, *args, **kwargs):  # noqa: ANN002, ANN003
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, port))]
+
+    monkeypatch.setattr(url_safety.socket, "getaddrinfo", _fake_getaddrinfo)
+
+
+# ─── Blocked: literal private / loopback / link-local IPs ────────────────────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://169.254.169.254/latest/meta-data/",  # AWS metadata (link-local)
+        "http://127.0.0.1:8000/storage/write-page",  # nlp-service itself
+        "http://10.0.0.5/",                          # RFC1918
+        "http://172.18.0.3:3000/api/import",         # Docker bridge range
+        "http://[::1]:5678/",                        # IPv6 loopback
+        "http://0.0.0.0/",                           # unspecified
+    ],
+)
+def test_literal_private_ip_blocked(client, monkeypatch, url):
+    _fail_if_fetched(monkeypatch)
+    resp = _post(client, url)
+    assert resp.status_code == 422
+    assert "url_blocked" in resp.json()["detail"]
+
+
+# ─── Blocked: cloud metadata hostnames ───────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://metadata.google.internal/computeMetadata/v1/",
+        "http://metadata/latest/",
+        "http://instance-data/latest/meta-data/",
+    ],
+)
+def test_metadata_host_blocked(client, monkeypatch, url):
+    _fail_if_fetched(monkeypatch)
+    resp = _post(client, url)
+    assert resp.status_code == 422
+    assert "url_blocked" in resp.json()["detail"]
+
+
+# ─── Blocked: non-http(s) schemes ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "ftp://example.org/file.txt",
+        "file:///etc/passwd",
+        "gopher://example.org/",
+    ],
+)
+def test_non_http_scheme_blocked(client, monkeypatch, url):
+    _fail_if_fetched(monkeypatch)
+    resp = _post(client, url)
+    assert resp.status_code == 422
+    assert "url_blocked" in resp.json()["detail"]
+
+
+# ─── Blocked: hostname resolving to a private address (Docker DNS names) ────
+
+
+def test_hostname_resolving_private_blocked(client, monkeypatch):
+    """`http://app:3000` style Docker service names resolve to bridge-network
+    private IPs — the guard must reject after resolution."""
+    _fail_if_fetched(monkeypatch)
+    _stub_dns(monkeypatch, "172.18.0.2")
+    resp = _post(client, "http://app:3000/api/import")
+    assert resp.status_code == 422
+    assert "url_blocked" in resp.json()["detail"]
+
+
+def test_dns_failure_blocked(client, monkeypatch):
+    _fail_if_fetched(monkeypatch)
+
+    def _fail_getaddrinfo(host, port, *args, **kwargs):  # noqa: ANN002, ANN003
+        raise socket.gaierror("Name or service not known")
+
+    monkeypatch.setattr(url_safety.socket, "getaddrinfo", _fail_getaddrinfo)
+    resp = _post(client, "http://does-not-resolve.kompl-test.org/")
+    assert resp.status_code == 422
+    assert "url_blocked" in resp.json()["detail"]
+
+
+# ─── Pass-through: public URL reaches the MarkItDown layer ───────────────────
+
+
+def test_public_url_passes_guard(client, monkeypatch):
+    """A publicly-resolving URL must get PAST the guard and into layer 1.
+
+    We stub _try_markitdown_url to return None and ensure no Firecrawl key,
+    so the request fails later with conversion_failed — proving the 422 did
+    NOT come from the SSRF guard.
+    """
+    _stub_dns(monkeypatch, "93.184.215.14")  # public address
+    monkeypatch.setattr(conv, "_try_markitdown_url", lambda source_id, url: None)
+    monkeypatch.setattr(conv, "_FIRECRAWL_API_KEY", "")
+
+    resp = _post(client, "https://public-site.org/article")
+    assert resp.status_code == 422
+    detail = resp.json()["detail"]
+    assert "url_blocked" not in detail
+    assert "conversion_failed" in detail

--- a/nlp-service/tests/test_llm_cap.py
+++ b/nlp-service/tests/test_llm_cap.py
@@ -1,0 +1,57 @@
+"""Tests for llm_client daily cost-cap persistence and locking."""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from services import llm_client
+
+
+@pytest.fixture
+def cap_dir(tmp_path, monkeypatch):
+    """Isolate llm-cap.json / llm-config.json under a temp DATA_ROOT."""
+    data_root = tmp_path / "data"
+    data_root.mkdir()
+    monkeypatch.setenv("DATA_ROOT", str(data_root))
+    monkeypatch.setattr(llm_client, "_CAP_FILE", data_root / "llm-cap.json")
+    monkeypatch.setattr(llm_client, "_CONFIG_FILE", data_root / "llm-config.json")
+    monkeypatch.setattr(llm_client, "_cap_cache", {"value": None, "read_at": 0.0})
+    (data_root / "llm-config.json").write_text(json.dumps({"daily_cap_usd": 100.0}))
+    return data_root
+
+
+def test_utc_today_matches_utc_date():
+    expected = str(datetime.now(timezone.utc).date())
+    assert llm_client._utc_today() == expected
+
+
+def test_check_and_record_cost_concurrent_increments_exact(cap_dir, monkeypatch):
+    """Thread lock must serialize increments — total spend equals sum of costs."""
+    mock_provider = MagicMock()
+    mock_provider.cost_usd.return_value = 0.01
+    monkeypatch.setattr(llm_client, "get_provider", lambda _model: mock_provider)
+
+    errors: list[Exception] = []
+
+    def record_once() -> None:
+        try:
+            llm_client._check_and_record_cost("gemini-2.5-flash", 10, 0, 5, 0)
+        except Exception as e:  # noqa: BLE001 — collect for assertion
+            errors.append(e)
+
+    threads = [threading.Thread(target=record_once) for _ in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors
+    cap_data = json.loads((cap_dir / "llm-cap.json").read_text())
+    assert cap_data["call_count"] == 20
+    assert cap_data["total_usd"] == pytest.approx(0.2, abs=1e-6)

--- a/nlp-service/tests/test_resolution.py
+++ b/nlp-service/tests/test_resolution.py
@@ -434,3 +434,98 @@ class TestDisambiguateConceptPromptRouting:
         assert len(captured) == 2
         kinds = sorted(c["pair_kind"] for c in captured)
         assert kinds == ["concept", "entity"]
+
+
+# ---------------------------------------------------------------------------
+# /resolve/disambiguate — DISAMBIGUATE_MAX_PAIRS cap (CLAUDE.md rule #7)
+# ---------------------------------------------------------------------------
+
+
+class TestDisambiguatePairCap:
+    """Hard bound on LLM pairs per request. Overflow pairs must come back as
+    decision='ambiguous' (entities kept separate — safe degradation) without
+    any LLM call being made for them.
+    """
+
+    @staticmethod
+    def _make_pairs(n: int) -> list[dict[str, Any]]:
+        return [
+            {
+                "entity_a": {"name": f"Amb{i}A", "type": "ORG", "source_id": "s1", "context": ""},
+                "entity_b": {"name": f"Amb{i}B", "type": "ORG", "source_id": "s2", "context": ""},
+                "similarity": 0.8,
+            }
+            for i in range(n)
+        ]
+
+    def test_overflow_pairs_returned_ambiguous_without_llm_calls(
+        self, resolution_client, monkeypatch
+    ):
+        from routers.resolution import DISAMBIGUATE_MAX_PAIRS  # noqa: PLC0415
+        from services import llm_client as llm_client_mod  # noqa: PLC0415
+        from services.llm_client import (  # noqa: PLC0415
+            DisambiguationResponse,
+            DisambiguationResult,
+        )
+
+        llm_pair_count = 0
+
+        def fake_disambiguate(pairs, model, pair_kind="entity"):
+            nonlocal llm_pair_count
+            llm_pair_count += len(pairs)
+            return DisambiguationResponse(results=[
+                DisambiguationResult(
+                    entity_a=p["entity_a"]["name"],
+                    entity_b=p["entity_b"]["name"],
+                    decision="different",
+                    canonical=None,
+                    reason="mock",
+                )
+                for p in pairs
+            ])
+
+        monkeypatch.setattr(llm_client_mod, "disambiguate_entities", fake_disambiguate)
+
+        overflow = 15
+        total = DISAMBIGUATE_MAX_PAIRS + overflow
+        resp = resolution_client.post(
+            "/resolve/disambiguate", json={"pairs": self._make_pairs(total)}
+        )
+        assert resp.status_code == 200
+
+        # LLM saw exactly the cap.
+        assert llm_pair_count == DISAMBIGUATE_MAX_PAIRS
+
+        # One result per requested pair — overflow answered as ambiguous.
+        results = resp.json()["results"]
+        assert len(results) == total
+        capped = [r for r in results if r["decision"] == "different"]
+        overflowed = [r for r in results if r["decision"] == "ambiguous"]
+        assert len(capped) == DISAMBIGUATE_MAX_PAIRS
+        assert len(overflowed) == overflow
+        for r in overflowed:
+            assert "cap_exceeded" in r["reason"]
+            assert r["canonical"] is None
+
+    def test_at_cap_no_truncation(self, resolution_client, monkeypatch):
+        from routers.resolution import DISAMBIGUATE_MAX_PAIRS  # noqa: PLC0415
+        from services import llm_client as llm_client_mod  # noqa: PLC0415
+        from services.llm_client import DisambiguationResponse  # noqa: PLC0415
+
+        llm_pair_count = 0
+
+        def fake_disambiguate(pairs, model, pair_kind="entity"):
+            nonlocal llm_pair_count
+            llm_pair_count += len(pairs)
+            return DisambiguationResponse(results=[])
+
+        monkeypatch.setattr(llm_client_mod, "disambiguate_entities", fake_disambiguate)
+
+        resp = resolution_client.post(
+            "/resolve/disambiguate",
+            json={"pairs": self._make_pairs(DISAMBIGUATE_MAX_PAIRS)},
+        )
+        assert resp.status_code == 200
+        assert llm_pair_count == DISAMBIGUATE_MAX_PAIRS
+        # No cap_exceeded entries when exactly at the cap.
+        assert all("cap_exceeded" not in r["reason"] for r in resp.json()["results"])

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -52,6 +52,11 @@ if ! python3 --version 2>&1 | grep -q "Python 3"; then
     export -f python3
 fi
 
+# UUID helper — python3 is already required; avoid relying on node on PATH (WSL often lacks it).
+random_uuid() {
+    python3 -c "import uuid; print(uuid.uuid4())"
+}
+
 # Compose command: prefer v2 plugin (`docker compose`), fall back to v1 standalone (`docker-compose`)
 # In CI, COMPOSE_FILE is set by the workflow (docker-compose.yml:docker-compose.ci.yml) —
 # do NOT pass --file flags or they will override COMPOSE_FILE.
@@ -74,6 +79,49 @@ else
     exit 1
 fi
 unset _COMPOSE_FILES
+
+# Stage 11d needs ripgrep. ubuntu-latest CI ships rg; Git Bash on Windows often
+# does not, even when Cursor/VS Code bundle @vscode/ripgrep. Probe common install
+# paths once — still fail-closed if nothing is found (H8).
+bootstrap_rg_path() {
+  command -v rg >/dev/null 2>&1 && return 0
+  command -v rg.exe >/dev/null 2>&1 && return 0
+  local cand dir
+  for cand in \
+    "${LOCALAPPDATA:-}/Programs/Cursor/resources/app/node_modules/@vscode/ripgrep/bin/rg.exe" \
+    "/d/cursor/resources/app/node_modules/@vscode/ripgrep/bin/rg.exe" \
+    "/d/Cursor/resources/app/node_modules/@vscode/ripgrep/bin/rg.exe" \
+    "/mnt/d/cursor/resources/app/node_modules/@vscode/ripgrep/bin/rg.exe" \
+    "/mnt/d/Cursor/resources/app/node_modules/@vscode/ripgrep/bin/rg.exe" \
+    "${ProgramFiles:-}/Cursor/resources/app/node_modules/@vscode/ripgrep/bin/rg.exe" \
+    "${LOCALAPPDATA:-}/Programs/Microsoft VS Code/resources/app/node_modules/@vscode/ripgrep/bin/rg.exe" \
+    "${ProgramFiles:-}/Microsoft VS Code/resources/app/node_modules/@vscode/ripgrep/bin/rg.exe" \
+    "${USERPROFILE:-}/scoop/shims/rg.exe" \
+    "/c/ProgramData/chocolatey/bin/rg.exe"
+  do
+    [ -n "$cand" ] || continue
+    if [ -f "$cand" ]; then
+      dir=$(dirname "$cand")
+      export PATH="$dir:$PATH"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Return the ripgrep binary name on PATH after bootstrap (rg or rg.exe on WSL).
+resolve_rg_bin() {
+  bootstrap_rg_path || true
+  if command -v rg >/dev/null 2>&1; then
+    echo rg
+    return 0
+  fi
+  if command -v rg.exe >/dev/null 2>&1; then
+    echo rg.exe
+    return 0
+  fi
+  return 1
+}
 
 # Track which stages ran and their outcomes, printed as a summary at the end.
 STAGE_RESULTS=()
@@ -735,9 +783,16 @@ except Exception:
 # ──────────────────────────────────────────────────────────────────────────
 stage_11d_insertactivity_guard() {
   echo "=== Stage 11d: insertActivity writer discipline ==="
+  local rg_bin
+  rg_bin=$(resolve_rg_bin) || {
+    echo "FAIL: ripgrep (rg) is required for stage 11d but was not found on PATH."
+    echo "  Install: apt install ripgrep / brew install ripgrep / scoop install ripgrep"
+    record_stage 11d REAL FAIL
+    return 1
+  }
   local hits
   # -U --multiline-dotall: let . match newlines so we catch multi-line callsites.
-  hits=$(rg -U --multiline-dotall -n \
+  hits=$("$rg_bin" -U --multiline-dotall -n \
     'insertActivity\s*\(\s*\{[^}]*action_type\s*:' \
     app/src/ \
     --glob '!app/src/app/api/activity/**' \
@@ -1148,7 +1203,7 @@ stage_16_full_pipeline() {
     fi
 
     local SESSION_ID
-    SESSION_ID=$(node -e "console.log(require('crypto').randomUUID())")
+    SESSION_ID=$(random_uuid)
 
     local base_page_count
     base_page_count=$(curl -sf --max-time 10 http://localhost:3000/api/health | python3 -c "
@@ -1233,7 +1288,7 @@ stage_17_session_compile() {
     fi
 
     local SESSION_ID
-    SESSION_ID=$(node -e "console.log(require('crypto').randomUUID())")
+    SESSION_ID=$(random_uuid)
 
     echo "  staging 2 text sources..."
     curl -sf --max-time 15 -X POST http://localhost:3000/api/onboarding/stage \
@@ -1740,7 +1795,7 @@ stage_22_original_source_gate2() {
     fi
 
     local SESSION_ID
-    SESSION_ID=$(node -e "console.log(require('crypto').randomUUID())")
+    SESSION_ID=$(random_uuid)
 
     local base_orig_count
     base_orig_count=$(curl -sf --max-time 10 "http://localhost:3000/api/wiki/index" | python3 -c "
@@ -1885,7 +1940,7 @@ stage_24_staging_crud() {
     echo "--- stage 24: collect_staging CRUD ---"
 
     local SESSION_ID
-    SESSION_ID=$(node -e "console.log(require('crypto').randomUUID())")
+    SESSION_ID=$(random_uuid)
 
     # 1. Stage 2 URL rows
     local stage_response
@@ -2015,7 +2070,7 @@ stage_25_finalize_end_to_end() {
     fi
 
     local SESSION_ID
-    SESSION_ID=$(node -e "console.log(require('crypto').randomUUID())")
+    SESSION_ID=$(random_uuid)
 
     local TEST_MARKDOWN='# Stage 25 canary
 
@@ -2177,11 +2232,11 @@ stage_26_finalize_accepts_ingested() {
     echo "--- stage 26: /finalize accepts 'ingested' rows (legacy-lifted safety) ---"
 
     local SESSION_ID
-    SESSION_ID=$(node -e "console.log(require('crypto').randomUUID())")
+    SESSION_ID=$(random_uuid)
     local SOURCE_ID
-    SOURCE_ID=$(node -e "console.log(require('crypto').randomUUID())")
+    SOURCE_ID=$(random_uuid)
     local STAGE_ID
-    STAGE_ID=$(node -e "console.log(require('crypto').randomUUID())")
+    STAGE_ID=$(random_uuid)
 
     # The app container ships python3 (migrate.py runs on boot) but not the
     # sqlite3 CLI. Use python3 -c with the stdlib sqlite3 module to seed.
@@ -2274,7 +2329,7 @@ stage_27_patch_excludes_from_finalize() {
     echo "--- stage 27: PATCH included=false excludes from /finalize ---"
 
     local SESSION_ID
-    SESSION_ID=$(node -e "console.log(require('crypto').randomUUID())")
+    SESSION_ID=$(random_uuid)
 
     local stage_response
     stage_response=$(curl -sf --max-time 10 -X POST \

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -628,8 +628,14 @@ def migrate():
         # expand-to-reveal progress UI (Phase C). Pre-v23 rows stay NULL — no
         # backfill possible (we have no way to recover the original session/step
         # for events written before this column existed).
-        conn.execute("ALTER TABLE activity_log ADD COLUMN session_id TEXT")
-        conn.execute("ALTER TABLE activity_log ADD COLUMN step_key TEXT")
+        activity_cols = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(activity_log)").fetchall()
+        }
+        if "session_id" not in activity_cols:
+            conn.execute("ALTER TABLE activity_log ADD COLUMN session_id TEXT")
+        if "step_key" not in activity_cols:
+            conn.execute("ALTER TABLE activity_log ADD COLUMN step_key TEXT")
         conn.execute("CREATE INDEX IF NOT EXISTS idx_activity_session ON activity_log(session_id)")
         conn.execute("CREATE INDEX IF NOT EXISTS idx_activity_session_step ON activity_log(session_id, step_key)")
 
@@ -642,7 +648,12 @@ def migrate():
         # 30+ min of debugging because the actual error was swallowed by the
         # pLimit worker pool in /api/compile/draft. Nullable; pre-v24 rows
         # stay NULL — no backfill possible.
-        conn.execute("ALTER TABLE page_plans ADD COLUMN draft_error TEXT")
+        plan_cols = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(page_plans)").fetchall()
+        }
+        if "draft_error" not in plan_cols:
+            conn.execute("ALTER TABLE page_plans ADD COLUMN draft_error TEXT")
 
     if current < 25:
         print("  applying migration v25 (sources.title_source + title_rescued_at)...")

--- a/scripts/test_migrate_v21.sh
+++ b/scripts/test_migrate_v21.sh
@@ -31,6 +31,16 @@ detect_python() {
 }
 PY=$(detect_python)
 
+# Current schema version from migrate.py (avoid hardcoding stale v21).
+SCHEMA_VERSION=$("$PY" -c "
+import re
+text = open('scripts/migrate.py', encoding='utf-8').read()
+m = re.search(r'^SCHEMA_VERSION = (\d+)', text, re.M)
+if not m:
+    raise SystemExit('SCHEMA_VERSION not found in scripts/migrate.py')
+print(m.group(1))
+")
+
 # Workdir + cleanup
 WORKDIR=$(mktemp -d -t kompl-migrate-test-XXXXXX)
 trap "rm -rf $WORKDIR" EXIT
@@ -59,18 +69,24 @@ conn.close()
 PY
 }
 
-# ── Build a V20-shaped DB ──────────────────────────────────────────────────
+# ── Build a V20-labelled DB on the current schema ───────────────────────────
+# The old fixture only created `settings`, which breaks v23+ migrations that
+# ALTER real tables. Bootstrap to SCHEMA_VERSION first, then rewind the version
+# marker and re-insert deployment_mode so v21's purge is still exercised.
 "$PY" - <<PY
+import os
 import sqlite3
-conn = sqlite3.connect(r'''$DB_FILE_PY''')
-conn.executescript("""
-CREATE TABLE IF NOT EXISTS settings (
-  key TEXT PRIMARY KEY,
-  value TEXT NOT NULL
-);
-INSERT INTO settings (key, value) VALUES ('schema_version', '20');
-INSERT INTO settings (key, value) VALUES ('deployment_mode', 'always-on');
-""")
+import subprocess
+import sys
+
+db_path = r'''$DB_FILE_PY'''
+repo_root = os.getcwd()
+env = {**os.environ, 'DB_PATH': db_path}
+subprocess.run([sys.executable, 'scripts/migrate.py'], env=env, check=True, cwd=repo_root)
+
+conn = sqlite3.connect(db_path)
+conn.execute("INSERT OR REPLACE INTO settings (key, value) VALUES ('deployment_mode', 'always-on')")
+conn.execute("INSERT OR REPLACE INTO settings (key, value) VALUES ('schema_version', '20')")
 conn.commit()
 conn.close()
 PY
@@ -97,22 +113,22 @@ POST_VER=$(sql "SELECT value FROM settings WHERE key='schema_version'")
   cat "$WORKDIR/migrate.log"
   exit 1
 }
-[[ "$POST_VER" == "21" ]] || {
-  echo "FAIL: schema_version is $POST_VER after migration, expected 21"
+[[ "$POST_VER" == "$SCHEMA_VERSION" ]] || {
+  echo "FAIL: schema_version is $POST_VER after migration, expected $SCHEMA_VERSION"
   cat "$WORKDIR/migrate.log"
   exit 1
 }
 
-# ── Idempotency: re-run on a V21 DB is a no-op ─────────────────────────────
+# ── Idempotency: re-run on a fully migrated DB is a no-op ───────────────────
 DB_PATH="$DB_FILE_PY" "$PY" scripts/migrate.py >"$WORKDIR/migrate2.log" 2>&1 || {
   echo "FAIL: second migrate.py run exited non-zero. Log:"
   cat "$WORKDIR/migrate2.log"
   exit 1
 }
-grep -qE "already at version 21" "$WORKDIR/migrate2.log" || {
+grep -qE "already at version ${SCHEMA_VERSION}" "$WORKDIR/migrate2.log" || {
   echo "FAIL: second migrate.py run did not print early-return message. Log:"
   cat "$WORKDIR/migrate2.log"
   exit 1
 }
 
-echo "PASS: migration v21 purges deployment_mode row, bumps schema_version to 21, idempotent on re-run"
+echo "PASS: migration v21 purges deployment_mode row, bumps schema_version to ${SCHEMA_VERSION}, idempotent on re-run"


### PR DESCRIPTION
## Summary
- **Critical:** SSRF guard on URL conversion, loopback bind for app port, compile flush durability gate (`flush_failures` / boot reconciler).
- **High:** XSS hardening in markdown rendering, path traversal fixes on import/previous routes, disambiguate LLM cap, cost-cap lock + UTC date, degraded health polling for `kompl start`, provenance hash consistency, migration v23/v24 guards, integration-test stage 11d fail-closed.
- **Tooling:** esbuild 0.28.1 pin in cli; integration-test ripgrep bootstrap and python3 UUID helper for local/WSL runs.

## Test plan
- [x] app vitest (559) + tsc
- [x] cli jest + build
- [x] nlp-service pytest (283)
- [x] migrate smoke script
- [x] `scripts/integration-test.sh` locally (Gemini-keyed stages skipped without API key)
- [ ] CI integration job on this PR

## Notes
- Supersedes a separate `fix/audit-critical` PR — this branch includes both commits (`14d90132` + `d94da3cc`).