### PR TITLE
docs: Gemini or DeepSeek compile requirement (either or both)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@
 DB_PATH=/data/db/kompl.db
 
 # ---- LLM providers (live in commit 4) ----
+#
+# At least one of GEMINI_API_KEY or DEEPSEEK_API_KEY is required for wiki
+# compilation. Firecrawl is also required for URL ingest. The selected
+# compile model in Settings determines which provider key is checked at
+# session start (default: Gemini when both keys are set).
 
 # Gemini 2.5 Flash via the `google-genai` SDK (NOT the deprecated
 # `google-generativeai` package).
@@ -25,7 +30,7 @@ GEMINI_RPM=800
 GEMINI_INPUT_TOKEN_CAP=128000
 GEMINI_DAILY_USD_CAP=5.00
 
-# DeepSeek V4 Pro as a second selectable backend (Phase 4 multi-provider).
+# DeepSeek V4 Pro / Flash as a second selectable compile/chat backend.
 # Get key at: https://api-docs.deepseek.com
 # Default DEEPSEEK_RPM=60 matches DeepSeek's documented per-minute cap.
 # Pricing follows DeepSeek's published list rates; promotional discount

--- a/README.md
+++ b/README.md
@@ -32,14 +32,16 @@ You'll need three things on your machine:
 - **[Node.js](https://nodejs.org/) ≥ 24** — to install and run the `kompl` CLI.
 - **~5 GB free disk and 4 GB free RAM** — Kompl runs three containers (app, NLP service, n8n) plus pulls a ~90 MB embedding model on first compile.
 
-You'll also need API keys. Two are required, two are optional:
+You'll also need API keys. **Firecrawl** and **at least one compile LLM** (Gemini or DeepSeek) are required; **YouTube** is optional:
 
 | | Required? | Get key | Free tier | Notes |
 |---|---|---|---|---|
-| **Gemini** (wiki compilation) | Required | [aistudio.google.com/apikey](https://aistudio.google.com/apikey) | 1500 req/day | Free works for the demo and your first few sources. **Paid Tier 1 is strongly recommended for real use** — Gemini's free per-minute throttle (~10 RPM) will rate-limit a normal ingest, even though daily quota is plenty. Default rate-limiter assumes Tier 1. Has a known truncation issue on dense inputs — see [issue #7](https://github.com/tuirk/Kompl/issues/7). |
 | **Firecrawl** (URL scraping) | Required | [firecrawl.dev](https://firecrawl.dev) | 500 scrapes/month | Free tier covers normal personal use. |
+| **Gemini** (wiki compilation) | One of two* | [aistudio.google.com/apikey](https://aistudio.google.com/apikey) | 1500 req/day | Default compile backend if both keys are set. Free works for the demo and your first few sources. **Paid Tier 1 is strongly recommended for real use** — Gemini's free per-minute throttle (~10 RPM) will rate-limit a normal ingest, even though daily quota is plenty. Default rate-limiter assumes Tier 1. Has a known truncation issue on dense inputs — see [issue #7](https://github.com/tuirk/Kompl/issues/7). |
+| **DeepSeek V4 Pro / Flash** (wiki compilation) | One of two* | [api-docs.deepseek.com](https://api-docs.deepseek.com) | Pay-as-you-go | Selectable in Settings alongside Gemini. Recommended for long/academic content — see [Known limitations](#known-limitations). Set `DEEPSEEK_API_KEY` in `.env` and pick a DeepSeek compile model to run without Gemini. |
 | **YouTube Data API v3** (YouTube ingestion) | Optional | [console.cloud.google.com](https://console.cloud.google.com/apis/library/youtube.googleapis.com) | 10,000 units/day (1 unit per video) | Needed for YouTube **metadata** at compile time (title, channel, duration). Captions use `youtube-transcript-api` (no key). Without this key, convert fails with `youtube_metadata_unavailable` and the URL lands on **Saved Links** — not a compiled source. Restrict the key to "YouTube Data API v3" only in the GCP console. Set `YOUTUBE_API_KEY` in `.env`. |
-| **DeepSeek V4 Pro** (alternative compile backend) | Optional | [api-docs.deepseek.com](https://api-docs.deepseek.com) | Pay-as-you-go | Selectable in Settings as an alternative to Gemini. Recommended for long/academic content — see [Known limitations](#known-limitations). Set `DEEPSEEK_API_KEY` in `.env`. |
+
+\*At least one of Gemini or DeepSeek is required for wiki compilation.
 
 ## Setup
 
@@ -69,7 +71,7 @@ cd kompl
 node setup.js
 ```
 
-Either path: the script handles everything — creates your config, asks for the two required API keys (and offers prompts for the two optional ones), installs the `kompl` CLI, and starts the stack. No other steps needed. Your system timezone is detected and written to `.env` as `KOMPL_TIMEZONE` automatically.
+Either path: the script handles everything — creates your config, asks for Firecrawl plus at least one compile API key (Gemini or DeepSeek), offers an optional YouTube prompt, installs the `kompl` CLI, and starts the stack. No other steps needed. Your system timezone is detected and written to `.env` as `KOMPL_TIMEZONE` automatically.
 
 > Your API keys land in `.env` at the repo root. That file is gitignored — never commit it.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,7 +22,7 @@ Include:
 Kompl runs locally on your machine. The attack surface is:
 
 - **Local network exposure.** Kompl binds to `localhost:3000` by default. If you expose it to your network or the internet, you are responsible for adding authentication — Kompl has none.
-- **API key handling.** Gemini, Firecrawl, YouTube, and (optional) DeepSeek keys are stored in `.env` on disk. They are never logged, never sent to Kompl's own services, and excluded from `.kompl.zip` exports.
+- **API key handling.** Gemini, DeepSeek, Firecrawl, and YouTube keys are stored in `.env` on disk (at least one of Gemini or DeepSeek is required for compilation). They are never logged, never sent to Kompl's own services, and excluded from `.kompl.zip` exports.
 - **Docker container isolation.** Kompl's containers run with default Docker security. No `--privileged`, no host network mode, no volume mounts outside the project directory.
 - **n8n webhooks.** Internal webhooks between services are unauthenticated. This is safe when running locally. If exposed to the internet, n8n's webhook endpoints could be triggered by anyone.
 

--- a/install.ps1
+++ b/install.ps1
@@ -91,6 +91,6 @@ Write-Ok "Cloned"
 # ── Hand off to setup.js ────────────────────────────────────────────────────
 Set-Location $target
 Write-Host ""
-Write-Host "  Handing off to setup.js (interactive — needs your Gemini + Firecrawl API keys; YouTube + DeepSeek prompts are optional)."
+Write-Host "  Handing off to setup.js (interactive — needs Firecrawl plus Gemini or DeepSeek; YouTube prompt is optional)."
 Write-Host ""
 & node setup.js

--- a/install.sh
+++ b/install.sh
@@ -112,5 +112,5 @@ ok "Cloned"
 
 # ── Hand off to setup.js ────────────────────────────────────────────────────
 cd "$TARGET"
-printf "\n  Handing off to setup.js (interactive — needs your Gemini + Firecrawl API keys; YouTube + DeepSeek prompts are optional).\n\n"
+printf "\n  Handing off to setup.js (interactive — needs Firecrawl plus Gemini or DeepSeek; YouTube prompt is optional).\n\n"
 exec node setup.js

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -57,6 +57,54 @@ random_uuid() {
     python3 -c "import uuid; print(uuid.uuid4())"
 }
 
+# Cancel one compile session and wait for a terminal status.
+cancel_compile_session() {
+    local session_id="$1"
+    curl -sf -X POST \
+        -H "content-type: application/json" \
+        -d "{\"session_id\":\"$session_id\"}" \
+        "http://localhost:3000/api/compile/cancel" >/dev/null 2>&1 || true
+    local status=""
+    for _ in $(seq 1 30); do
+        status=$(curl -sf --max-time 5 \
+            "http://localhost:3000/api/compile/progress?session_id=$session_id" 2>/dev/null \
+            | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null || echo "")
+        case "$status" in
+            cancelled|completed|failed|'') return 0 ;;
+        esac
+        sleep 2
+    done
+}
+
+# Full-key runs start multiple partial pipelines; release the global gate
+# before a stage calls /finalize (otherwise 409 session_in_progress).
+release_compile_gate() {
+    local also_id="${1:-}"
+    if [ -n "$also_id" ]; then
+        cancel_compile_session "$also_id"
+    fi
+    local running_id
+    while true; do
+        running_id=$(curl -sf --max-time 5 "http://localhost:3000/api/compile/sessions?limit=20" 2>/dev/null \
+            | python3 -c "
+import sys, json
+try:
+    for it in json.load(sys.stdin).get('items', []):
+        if it.get('status') in ('queued', 'running'):
+            print(it['session_id'])
+            raise SystemExit
+except Exception:
+    pass
+print('')
+" 2>/dev/null || echo "")
+        if [ -z "$running_id" ]; then
+            break
+        fi
+        echo "  releasing compile gate (cancelling $running_id)..."
+        cancel_compile_session "$running_id"
+    done
+}
+
 # Compose command: prefer v2 plugin (`docker compose`), fall back to v1 standalone (`docker-compose`)
 # In CI, COMPOSE_FILE is set by the workflow (docker-compose.yml:docker-compose.ci.yml) —
 # do NOT pass --file flags or they will override COMPOSE_FILE.
@@ -443,6 +491,34 @@ stage_11_onboarding_api() {
         return 0
     fi
 
+    # Stage 1 starts app-only (nlp_ok:false path); n8n is torn down with
+    # down -v and not recreated until a later stage needs it.
+    echo "  ensuring n8n is up for finalize webhook..."
+    if ! $COMPOSE up -d n8n; then
+        echo "  FAIL: docker compose up -d n8n returned non-zero"
+        record_stage 11 REAL FAIL
+        return 1
+    fi
+    if ! wait_for_http_200 "http://localhost:5678/healthz" 120; then
+        echo "  FAIL: n8n /healthz not ready within 120s"
+        record_stage 11 REAL FAIL
+        return 1
+    fi
+    echo "  waiting for n8n webhook registration..."
+    for i in $(seq 1 90); do
+        probe_body=$(curl -s --max-time 3 -X GET \
+            "http://localhost:5678/webhook/session-compile" 2>/dev/null || echo "")
+        case "$probe_body" in
+            *POST*)
+                echo "    webhook ready after ${i}s"
+                break
+                ;;
+            *)
+                sleep 1
+                ;;
+        esac
+    done
+
     local SESSION_ID
     SESSION_ID=$(python3 -c "import uuid; print(uuid.uuid4())")
     echo "  session_id: $SESSION_ID"
@@ -508,6 +584,8 @@ stage_11_onboarding_api() {
         return 1
     fi
     echo "  compile_progress status=$status (entered pipeline) OK"
+
+    release_compile_gate "$SESSION_ID"
 
     echo "  PASS"
     record_stage 11 REAL PASS
@@ -1103,6 +1181,8 @@ except Exception:
     fi
     echo "  extract step status=done OK"
 
+    release_compile_gate "$SESSION_ID"
+
     echo "  PASS"
     record_stage 14 REAL PASS
     return 0
@@ -1127,6 +1207,8 @@ stage_15_resolution() {
         record_stage 15 REAL SKIPPED
         return 0
     fi
+
+    release_compile_gate
 
     local SESSION_ID
     SESSION_ID=$(python3 -c "import uuid; print(uuid.uuid4())" 2>/dev/null || uuidgen)
@@ -1179,6 +1261,8 @@ except Exception:
     fi
     echo "  resolve step complete OK"
 
+    release_compile_gate "$SESSION_ID"
+
     echo "  PASS"
     record_stage 15 REAL PASS
     return 0
@@ -1201,6 +1285,8 @@ stage_16_full_pipeline() {
         record_stage 16 REAL SKIPPED
         return 0
     fi
+
+    release_compile_gate
 
     local SESSION_ID
     SESSION_ID=$(random_uuid)
@@ -1286,6 +1372,8 @@ stage_17_session_compile() {
         record_stage 17 REAL SKIPPED
         return 0
     fi
+
+    release_compile_gate
 
     local SESSION_ID
     SESSION_ID=$(random_uuid)
@@ -1410,6 +1498,8 @@ stage_18_wiki_aware_update() {
         return 0
     fi
     echo "  page_count before: $PAGE_COUNT_BEFORE"
+
+    release_compile_gate
 
     # Stage 1 text source that overlaps with existing wiki content
     SESSION_ID="stage18-returning-$(date +%s)"

--- a/setup.js
+++ b/setup.js
@@ -6,7 +6,8 @@
  * Does everything:
  *   1. Checks Docker Desktop is running
  *   2. Creates .env from .env.example (if not already present)
- *   3. Prompts for Gemini + Firecrawl (required) and YouTube + DeepSeek (optional) API keys and writes them to .env
+ *   3. Prompts for Firecrawl (required) plus Gemini and/or DeepSeek (at least one
+ *      compile provider required) and YouTube (optional); writes them to .env
  *   4. Installs and globally links the kompl CLI (npm link)
  *   5. Writes ~/.kompl/config.json so `kompl` commands work immediately
  *   6. Runs `docker compose up --build -d` to start the full stack
@@ -75,29 +76,49 @@ async function main() {
   const alreadyHasFirecrawl  = /^FIRECRAWL_API_KEY=.+$/m.test(env)
   const alreadyHasYoutube    = /^YOUTUBE_API_KEY=.+$/m.test(env)
   const alreadyHasDeepSeek   = /^DEEPSEEK_API_KEY=.+$/m.test(env)
+  const hasCompileKey        = alreadyHasGemini || alreadyHasDeepSeek
 
-  if (alreadyHasGemini && alreadyHasFirecrawl && alreadyHasYoutube && alreadyHasDeepSeek) {
-    console.log('  API keys already set in .env — skipping prompts')
+  if (alreadyHasFirecrawl && hasCompileKey) {
+    console.log('  Required API keys already set in .env — skipping prompts')
   } else {
-    console.log('\n  Two required keys (both have free tiers):')
-    console.log(dim('    Gemini:    https://aistudio.google.com/apikey   (free works for the demo; paid Tier 1 strongly recommended for real use)'))
+    console.log('\n  Required:')
     console.log(dim('    Firecrawl: https://firecrawl.dev                (500 scrapes/month free)'))
-    console.log('\n  Two optional keys (press Enter to skip):')
-    console.log(dim('    YouTube:   https://console.cloud.google.com/apis/library/youtube.googleapis.com  (10K units/day free; required for YouTube URL ingestion)'))
-    console.log(dim('    DeepSeek:  https://api-docs.deepseek.com        (pay-as-you-go; alternative compile backend for long/dense sources)\n'))
+    console.log('\n  Wiki compilation — at least one (Enter to skip if using the other):')
+    console.log(dim('    Gemini:    https://aistudio.google.com/apikey   (free works for the demo; paid Tier 1 strongly recommended for real use)'))
+    console.log(dim('    DeepSeek:  https://api-docs.deepseek.com        (pay-as-you-go; pick a DeepSeek compile model in Settings)'))
+    console.log('\n  Optional (press Enter to skip):')
+    console.log(dim('    YouTube:   https://console.cloud.google.com/apis/library/youtube.googleapis.com  (10K units/day free; required for YouTube URL ingestion)\n'))
 
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
-
-    if (!alreadyHasGemini) {
-      const key = (await ask(rl, '  Gemini API key: ')).trim()
-      if (!key) { console.error('  Error: Gemini API key is required.'); rl.close(); process.exit(1) }
-      env = env.replace(/^GEMINI_API_KEY=.*$/m, `GEMINI_API_KEY=${key}`)
-    }
 
     if (!alreadyHasFirecrawl) {
       const key = (await ask(rl, '  Firecrawl API key: ')).trim()
       if (!key) { console.error('  Error: Firecrawl API key is required.'); rl.close(); process.exit(1) }
       env = env.replace(/^FIRECRAWL_API_KEY=.*$/m, `FIRECRAWL_API_KEY=${key}`)
+    }
+
+    if (!alreadyHasGemini) {
+      const key = (await ask(rl, '  Gemini API key (Enter to skip if using DeepSeek only): ')).trim()
+      if (key) {
+        env = env.replace(/^GEMINI_API_KEY=.*$/m, `GEMINI_API_KEY=${key}`)
+      } else {
+        console.log(dim('    Skipped — set a DeepSeek compile model in Settings if DeepSeek is your only provider'))
+      }
+    }
+
+    if (!alreadyHasDeepSeek) {
+      const key = (await ask(rl, '  DeepSeek API key (Enter to skip if using Gemini only): ')).trim()
+      if (key) {
+        env = env.replace(/^DEEPSEEK_API_KEY=.*$/m, `DEEPSEEK_API_KEY=${key}`)
+      } else {
+        console.log(dim('    Skipped — Gemini remains the default compile backend when its key is set'))
+      }
+    }
+
+    if (!/^GEMINI_API_KEY=.+$/m.test(env) && !/^DEEPSEEK_API_KEY=.+$/m.test(env)) {
+      console.error('  Error: at least one compile provider key is required (Gemini or DeepSeek).')
+      rl.close()
+      process.exit(1)
     }
 
     if (!alreadyHasYoutube) {
@@ -106,15 +127,6 @@ async function main() {
         env = env.replace(/^YOUTUBE_API_KEY=.*$/m, `YOUTUBE_API_KEY=${key}`)
       } else {
         console.log(dim('    Skipped — YouTube URLs will route to Saved Links until you add a key to .env'))
-      }
-    }
-
-    if (!alreadyHasDeepSeek) {
-      const key = (await ask(rl, '  DeepSeek API key (optional, Enter to skip): ')).trim()
-      if (key) {
-        env = env.replace(/^DEEPSEEK_API_KEY=.*$/m, `DEEPSEEK_API_KEY=${key}`)
-      } else {
-        console.log(dim('    Skipped — only Gemini will be selectable as the compile backend'))
       }
     }
 


### PR DESCRIPTION
﻿## Summary
- README / setup / `.env.example` / install scripts: compile LLM is **Gemini and/or DeepSeek** (at least one), not Gemini-required + DeepSeek-optional
- Matches runtime: nlp-service and compile health-check already require only the selected provider key
- Firecrawl remains required; YouTube remains optional
- Integration test: n8n ready before stage 11 + compile-gate release helpers so full-key local runs do not 409 across Gemini stages

## Test plan
- [ ] Fresh setup with only DeepSeek + Firecrawl succeeds
- [ ] Fresh setup with only Gemini + Firecrawl succeeds
- [ ] Skipping both compile keys fails with a clear error
- [ ] README table matches the prompts in setup.js
